### PR TITLE
pallet/schema: add owner check before delegation. 

### DIFF
--- a/pallets/schema/src/schemas.rs
+++ b/pallets/schema/src/schemas.rs
@@ -52,7 +52,7 @@ impl<T: Config> SchemaDetails<T> {
 	pub fn schema_status(tx_schema: &IdOf<T>, requestor: CordAccountOf<T>) -> Result<(), Error<T>> {
 		let schema_details = <Schemas<T>>::get(tx_schema).ok_or(Error::<T>::SchemaNotFound)?;
 		ensure!(!schema_details.revoked, Error::<T>::SchemaRevoked);
-		if schema_details.permissioned {
+		if schema_details.creator != requestor && schema_details.permissioned {
 			let delegates = <Delegations<T>>::get(tx_schema);
 			ensure!(
 				(delegates.iter().find(|&delegate| *delegate == requestor) == Some(&requestor)),


### PR DESCRIPTION
With this, one DB query is saved if creator of schema and requester for check are same.

Signed-off-by: Amar Tumballi <amar@dhiway.com>