### PR TITLE
transaction base fee

### DIFF
--- a/pallets/schema/src/lib.rs
+++ b/pallets/schema/src/lib.rs
@@ -157,7 +157,7 @@ pub mod pallet {
 		/// * origin: the identity of the schema controller.
 		/// * schema: unique identifier of the schema.
 		/// * delegates: schema delegates to add.
-		#[pallet::weight(182_886_000 + T::DbWeight::get().reads_writes(2, 2))]
+		#[pallet::weight(126_475_000 + T::DbWeight::get().reads_writes(2, 2))]
 		pub fn add_delegates(
 			origin: OriginFor<T>,
 			schema: IdOf<T>,
@@ -200,7 +200,7 @@ pub mod pallet {
 		/// * origin: the identity of the schema controller.
 		/// * schema: unique identifier of the schema.
 		/// * delegate: schema delegate to be removed.
-		#[pallet::weight(182_886_000 + T::DbWeight::get().reads_writes(2, 2))]
+		#[pallet::weight(126_475_000 + T::DbWeight::get().reads_writes(2, 2))]
 		pub fn remove_delegates(
 			origin: OriginFor<T>,
 			schema: IdOf<T>,
@@ -238,7 +238,7 @@ pub mod pallet {
 		/// * hash: hash of the incoming schema stream.
 		/// * cid: CID of the incoming schema stream.
 		/// * permissioned: schema type - permissioned or not.
-		#[pallet::weight(682_886_000 + T::DbWeight::get().reads_writes(1, 2))]
+		#[pallet::weight(570_952_000 + T::DbWeight::get().reads_writes(1, 2))]
 		pub fn create(
 			origin: OriginFor<T>,
 			identifier: IdOf<T>,
@@ -289,7 +289,7 @@ pub mod pallet {
 		/// * identifier: unique identifier of the incoming schema stream.
 		/// * hash: hash of the incoming schema stream.
 		/// * cid: CID of the incoming schema stream.
-		#[pallet::weight(471_532_000 + T::DbWeight::get().reads_writes(1, 2))]
+		#[pallet::weight(191_780_000 + T::DbWeight::get().reads_writes(1, 2))]
 		pub fn update(
 			origin: OriginFor<T>,
 			identifier: IdOf<T>,
@@ -348,7 +348,7 @@ pub mod pallet {
 		/// * origin: the identity of the schema controller.
 		/// * identifier: unique identifier of the incoming stream.
 		/// * status: status to be updated
-		#[pallet::weight(121_825_000 + T::DbWeight::get().reads_writes(1, 2))]
+		#[pallet::weight(124_410_000 + T::DbWeight::get().reads_writes(1, 2))]
 		pub fn set_status(
 			origin: OriginFor<T>,
 			identifier: IdOf<T>,
@@ -385,7 +385,7 @@ pub mod pallet {
 		/// * origin: the identity of the schema controller.
 		/// * identifier: unique identifier of the incoming stream.
 		/// * status: status to be updated
-		#[pallet::weight(121_825_000 + T::DbWeight::get().reads_writes(1, 2))]
+		#[pallet::weight(124_410_000 + T::DbWeight::get().reads_writes(1, 2))]
 		pub fn set_permission(
 			origin: OriginFor<T>,
 			identifier: IdOf<T>,

--- a/pallets/stream/src/lib.rs
+++ b/pallets/stream/src/lib.rs
@@ -135,7 +135,7 @@ pub mod pallet {
 		/// * cid: CID of the incoming  stream.
 		/// * schema: stream schema.
 		/// * link: stream link.
-		#[pallet::weight(682_886_000 + T::DbWeight::get().reads_writes(3, 4))]
+		#[pallet::weight(470_952_000 + T::DbWeight::get().reads_writes(3, 4))]
 		pub fn create(
 			origin: OriginFor<T>,
 			identifier: IdOf<T>,
@@ -201,7 +201,7 @@ pub mod pallet {
 		/// * identifier: unique identifier of the incoming stream.
 		/// * hash: hash of the incoming stream.
 		/// * cid: storage Id of the incoming stream.
-		#[pallet::weight(471_532_000 + T::DbWeight::get().reads_writes(1, 3))]
+		#[pallet::weight(171_780_000 + T::DbWeight::get().reads_writes(1, 3))]
 		pub fn update(
 			origin: OriginFor<T>,
 			identifier: IdOf<T>,
@@ -255,7 +255,7 @@ pub mod pallet {
 		/// * origin: the identity of the stream controller.
 		/// * identifier: unique identifier of the stream.
 		/// * status: stream revocation status (bool).
-		#[pallet::weight(121_825_000 + T::DbWeight::get().reads_writes(1, 2))]
+		#[pallet::weight(124_410_000 + T::DbWeight::get().reads_writes(1, 2))]
 		pub fn set_status(
 			origin: OriginFor<T>,
 			identifier: IdOf<T>,

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -62,19 +62,19 @@ pub mod fee {
 	pub use sp_runtime::Perbill;
 
 	parameter_types! {
-		/// 180 ms is needed to process an empty extrinsic.
-		pub const ExtrinsicBaseWeight: Weight = 180 * WEIGHT_PER_MILLIS;
-		/// We want the no-op transaction to cost 0.05 WAY
-		pub const CordBaseFee: Balance = 50 * super::currency::MILLI_WAY;
+		/// 50 ms to process an empty extrinsic.
+		pub const ExtrinsicBaseWeight: Weight = 50 * WEIGHT_PER_MILLIS;
+		/// We want the no-op transaction to cost 0.04 WAY
+		pub const CordBaseFee: Balance = 40 * super::currency::MILLI_WAY;
 	}
 	/// Converts Weight to Fee
 	pub struct WeightToFee;
 	impl WeightToFeePolynomial for WeightToFee {
 		type Balance = Balance;
-		/// We want a 0.05 WAY fee per ExtrinsicBaseWeight.
-		/// 180_000_000_000 weight = 50_000_000_000 fee => 3.6 weight = 1 fee.
-		/// Hence, 1 fee = 0 + 1/3.6 weight.
-		/// This implies, coeff_integer = 0 and coeff_frac = 1/3.6.
+		/// We want a 0.04 WAY fee per ExtrinsicBaseWeight.
+		/// 50_000_000_000 weight = 40_000_000_000 fee => 1.25 weight = 1 fee.
+		/// Hence, 1 fee = 0 + 1/1.25 weight.
+		/// This implies, coeff_integer = 0 and coeff_frac = 1/1.25.
 		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
 			smallvec![WeightToFeeCoefficient {
 				degree: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -160,8 +160,8 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 900;
 	/// 20 ms is needed to create a block.
     pub const BlockExecutionWeight: Weight = 20 * WEIGHT_PER_MILLIS;
-    /// 180 ms is needed to process an empty extrinsic.
-	pub const ExtrinsicBaseWeight: Weight = 180 * WEIGHT_PER_MILLIS;
+    /// 50 ms to process an empty extrinsic.
+	pub const ExtrinsicBaseWeight: Weight = 50 * WEIGHT_PER_MILLIS;
 	/// When the read/writes are cached/buffered, they take 25/100 microseconds on NVMe disks.
     /// When they are uncached, they take 250/450 microseconds on NVMe disks.
     /// Most read will be cached and writes will be buffered in production.
@@ -180,9 +180,9 @@ parameter_types! {
 	/// that combined with `AdjustmentVariable`, we can recover from the minimum.
 	/// See `multiplier_can_grow_from_zero`.
 	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
-	/// Maximum length of block. Up to 5MB.
+	/// Maximum length of block. Up to 4MB.
 	pub RuntimeBlockLength: limits::BlockLength =
-		limits::BlockLength::max_with_normal_ratio(10 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+		limits::BlockLength::max_with_normal_ratio(4 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	pub RuntimeBlockWeights: limits::BlockWeights = limits::BlockWeights::builder()
 		.base_block(BlockExecutionWeight::get())
 		.for_class(DispatchClass::all(), |weights| {


### PR DESCRIPTION
- tx base fee set to 0.05 WAY
- blocksize increased to 10MB to test the transaction limits using batch calls. Our transaction sizes are in the range of 750 - 820 bytes (large ones, schemas, streams and links)