### PR TITLE
CI: fix the CI failure in after merge workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,6 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /cord cord && \
 
 USER cord
 
-# checks
-RUN /usr/local/bin/cord --version
-
 EXPOSE 30333 9933 9944 9615 
 VOLUME ["/data"]
 


### PR DESCRIPTION
```
Step 12/16 : USER cord
 ---> Running in f96ecc0671f9
Removing intermediate container f96ecc0671f9
 ---> 586b03a8c44b
Step 13/16 : RUN /usr/local/bin/cord --version
 ---> Running in af928b09ec97
failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown
Error: Process completed with exit code 1.
```

Looks like the issue is because of different user not having permission to use it.

Signed-off-by: Amar Tumballi <amar@dhiway.com>