### PR TITLE
Switch to using distroless in Dockerfiles 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,20 @@ RUN cargo build --locked --profile ${PROFILE}
 # RUN cargo test --release --all
 
 # This is the 2nd stage: a very small image where we copy the Polkadot binary."
-FROM docker.io/library/ubuntu:20.04
+FROM gcr.io/distroless/cc
 LABEL maintainer="engineering@dhiway.com"
 
 ARG PROFILE=production
 
+# Install bash and dash shells
+RUN apt-get update && \
+    apt-get install -y bash dash && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the built binary from the builder stage
 COPY --from=builder /build/target/${PROFILE}/cord /usr/local/bin
 
+# Add a new user
 RUN useradd -m -u 1000 -U -s /bin/sh -d /cord cord && \
 	mkdir -p /data /cord/.local/share && \
 	chown -R cord:cord /data && \
@@ -35,3 +42,4 @@ EXPOSE 30333 9933 9944 9615
 VOLUME ["/data"]
 
 ENTRYPOINT ["/usr/local/bin/cord"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cargo build --locked --profile ${PROFILE}
 # RUN cargo test --release --all
 
 # This is the 2nd stage: a very small image where we copy the Polkadot binary."
-FROM docker.io/library/ubuntu:20.04
+FROM gcr.io/distroless/cc
 LABEL maintainer="engineering@dhiway.com"
 
 ARG PROFILE=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cargo build --locked --profile ${PROFILE}
 # RUN cargo test --release --all
 
 # This is the 2nd stage: a very small image where we copy the CORD binary."
-FROM gcr.io/distroless/cc-debian11@sha256:3516ad5504f54aeaea0444dfd5044cc5969653e49b594cecb47dc400ea6f6820
+FROM gcr.io/distroless/cc-debian11@sha256:9b8e0854865dcaf49470b4ec305df45957020fbcf17b71eeb50ffd3bc5bf885d
 LABEL maintainer="engineering@dhiway.com"
 
 ARG PROFILE=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,20 +13,13 @@ RUN cargo build --locked --profile ${PROFILE}
 # RUN cargo test --release --all
 
 # This is the 2nd stage: a very small image where we copy the Polkadot binary."
-FROM gcr.io/distroless/cc
+FROM docker.io/library/ubuntu:20.04
 LABEL maintainer="engineering@dhiway.com"
 
 ARG PROFILE=production
 
-# Install bash and dash shells
-RUN apt-get update && \
-    apt-get install -y bash dash && \
-    rm -rf /var/lib/apt/lists/*
-
-# Copy the built binary from the builder stage
 COPY --from=builder /build/target/${PROFILE}/cord /usr/local/bin
 
-# Add a new user
 RUN useradd -m -u 1000 -U -s /bin/sh -d /cord cord && \
 	mkdir -p /data /cord/.local/share && \
 	chown -R cord:cord /data && \
@@ -42,4 +35,3 @@ EXPOSE 30333 9933 9944 9615
 VOLUME ["/data"]
 
 ENTRYPOINT ["/usr/local/bin/cord"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,25 +13,17 @@ RUN cargo build --locked --profile ${PROFILE}
 # RUN cargo test --release --all
 
 # This is the 2nd stage: a very small image where we copy the Polkadot binary."
-FROM docker.io/library/ubuntu:20.04
+FROM gcr.io/distroless/cc-debian11@sha256:c2e1b5b0c64e3a44638e79246130d480ff09645d543d27e82ffd46a6e78a3ce3
 LABEL maintainer="engineering@dhiway.com"
 
 ARG PROFILE=production
 
-COPY --from=builder /build/target/${PROFILE}/cord /usr/local/bin
+COPY --from=builder /build/target/${PROFILE}/cord /cord
 
-RUN useradd -m -u 1000 -U -s /bin/sh -d /cord cord && \
-	mkdir -p /data /cord/.local/share && \
-	chown -R cord:cord /data && \
-	ln -s /data /cord/.local/share/cord && \
-	# unclutter and minimize the attack surface
-	rm -rf /usr/bin /usr/sbin && \
-	# check if executable works in this container
-	/usr/local/bin/cord --version
+RUN ["/cord","--version"]
 
-USER cord
-
-EXPOSE 30333 9933 9944 9615 
+USER 1000:1000
+EXPOSE 30333 9933 9944 9615
 VOLUME ["/data"]
 
-ENTRYPOINT ["/usr/local/bin/cord"]
+ENTRYPOINT ["/cord","-d","/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN cargo build --locked --profile ${PROFILE}
 # test
 # RUN cargo test --release --all
 
-# This is the 2nd stage: a very small image where we copy the Polkadot binary."
-FROM gcr.io/distroless/cc-debian11@sha256:c2e1b5b0c64e3a44638e79246130d480ff09645d543d27e82ffd46a6e78a3ce3
+# This is the 2nd stage: a very small image where we copy the CORD binary."
+FROM gcr.io/distroless/cc-debian11@sha256:3516ad5504f54aeaea0444dfd5044cc5969653e49b594cecb47dc400ea6f6820
 LABEL maintainer="engineering@dhiway.com"
 
 ARG PROFILE=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cargo build --locked --profile ${PROFILE}
 # RUN cargo test --release --all
 
 # This is the 2nd stage: a very small image where we copy the Polkadot binary."
-FROM gcr.io/distroless/cc
+FROM docker.io/library/ubuntu:20.04
 LABEL maintainer="engineering@dhiway.com"
 
 ARG PROFILE=production


### PR DESCRIPTION
switched to [Google's Distroless](https://github.com/GoogleContainerTools/distroless) for a resulting image in a multistage build. Distroless is a very minimal Docker image that tailored to only contain dependencies required for a particular programming language. For Rust it only contains glibc and its dependencies. See https://github.com/GoogleContainerTools/distroless/blob/main/cc/BUILD for how the base image is built. The resulting image does not contain a shell.

The resulting image is 40% smaller (128MB vs 76MB). 
fixes: #149 