### PR TITLE
Dockerfile: don't provide options to cord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,5 @@ RUN ["/cord","--version"]
 
 USER 1000:1000
 EXPOSE 30333 9933 9944 9615
-VOLUME ["/data"]
 
-ENTRYPOINT ["/cord","-d","/data"]
+ENTRYPOINT ["/cord"]


### PR DESCRIPTION
we should expect a <COMMAND> after `cord`. If we provide `-d /data` option in Dockerfile itself, it fails to run the command