### PR TITLE
Speed up CI build time by using 4-core machine

### DIFF
--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   develop-pr-submit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-4-cores
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release-docker-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-4-cores
 
     env:
       IMAGE_REPOSITORY: ${{ github.event.repository.name }}


### PR DESCRIPTION
Current Github Action takes on average takes 1 hour. Trying to reduce the CI time by providing a better machine.
I'm hope it'll reduce build time and save us Action minutes.