### PR TITLE
Release CORD Arch x86 compiled binary from github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,56 @@ jobs:
 
           # Push the Docker image to the registry
           docker push ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}:${DOCKER_BRANCH}
+
+  x86_64-binary:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+    
+      - name: Install dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y protobuf-compiler libssl-dev
+
+      - name: Setup Cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+    
+      - name: Build binary (x86_64)
+        run: cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Rename Binary
+        run: mv target/release/cord cord-${GITHUB_REF#refs/heads/}-$(uname -m)-ubuntu-22.04
+      
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      
+      - name: Upload binary as Rlease Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: cord-${GITHUB_REF#refs/heads/}-$(uname -m)-ubuntu-22.04
+          asset_name: cord-${GITHUB_REF#refs/heads/}-$(uname -m)-ubuntu-22.04
+          asset_content_type: application/octet-stream
+
+      - name: Get Download URL
+        id: get_download_url
+        run: |
+          echo "::set-output name=download_url::$(curl -s -X GET -H 'Accept: application/vnd.github.v3+json' -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.assets[] | select(.name == "cord-${GITHUB_REF#refs/heads/}-$(uname -m)-ubuntu-22.04") | .browser_download_url')"
+
+      - name: Print Download URL
+        run: |
+          echo "Download URL: ${{ steps.get_download_url.outputs.download_url }}"


### PR DESCRIPTION
    - Upload the binary as a release asset
    - User should be able to `wget` or `curl` the pre-compiled binary