### PR TITLE
Fix release and telemetry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: release
 
 on:
   push:
-    branches: [develop]
+    branches: 
+      - develop
+      - 'release*'
 
 jobs:
   release-docker-image:
@@ -69,16 +71,20 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
     
       - name: Build binary (x86_64)
-        run: cargo build --release --target x86_64-unknown-linux-gnu
-
-      - name: Find compiled binary
-        run: |
-          find ${{ github.workspace }} -type f -executable -name "cord" | head -n 1 > binary_path.txt
-          BINARY_PATH=$(cat binary_path.txt)
-          echo "Binary path: $BINARY_PATH"
+        run: cargo build --locked --profile production --target x86_64-unknown-linux-gnu
       
-      - name: Rename Binary
-        run: mv "$BINARY_PATH" "cord-${GITHUB_REF#refs/heads/}-$(uname -m)-ubuntu-22.04"
+      - name: Find and move binary
+        run: |
+          BINARY_PATH=$(find ${{ github.workspace }} -type f -executable -name "cord" | head -n 1)
+          echo "Binary path: $BINARY_PATH"
+
+          if [ -n "$BINARY_PATH" ]; then
+            NEW_PATH="cord-${{ github.ref#refs/heads/ }}-$(uname -m)-ubuntu-22.04"
+            mv "$BINARY_PATH" "$NEW_PATH"
+            echo "Moved binary to: $NEW_PATH"
+            else
+              echo "No binary found."
+            fi
       
       - name: Create Release
         id: create_release
@@ -91,12 +97,12 @@ jobs:
           draft: false
           prerelease: false
       
-      - name: Upload binary as Rlease Asset
+      - name: Upload binary as Release Asset
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: cord-${GITHUB_REF#refs/heads/}-$(uname -m)-ubuntu-22.04
-          asset_name: cord-${GITHUB_REF#refs/heads/}-$(uname -m)-ubuntu-22.04
+          asset_path: cord-${{ github.ref#refs/heads/ }}-$(uname -m)-ubuntu-22.04
+          asset_name: cord-${{ github.ref#refs/heads/ }}-$(uname -m)-ubuntu-22.04
           asset_content_type: application/octet-stream
 
       - name: Get Download URL

--- a/node/chain-specs/spark.json
+++ b/node/chain-specs/spark.json
@@ -5,7 +5,7 @@
   "bootNodes": [],
   "telemetryEndpoints": [
     [
-      "/dns/telemetry.dway.io/tcp/443/x-parity-wss/%2Fsubmit",
+      "/dns/telemetry.cord.network/tcp/443/x-parity-wss/%2Fsubmit",
       0
     ]
   ],

--- a/node/chain-specs/sprint.json
+++ b/node/chain-specs/sprint.json
@@ -5,7 +5,7 @@
   "bootNodes": [],
   "telemetryEndpoints": [
     [
-      "/dns/telemetry.dway.io/tcp/443/x-parity-wss/%2Fsubmit",
+      "/dns/telemetry.cord.network/tcp/443/x-parity-wss/%2Fsubmit",
       0
     ]
   ],


### PR DESCRIPTION
Release Action will now run on `develop` branch and any branch that begins with `release`.
The CORD binary is now compiled with production profile, as previously it was only release profile.
The docker image and binary will be tagged based on the branch name.
Telemetry is pointed to `telemetry.cord.network` in both spark & sprint chain spec.