### PR TITLE
Refactor release workflow and build ARM & x86_64 docker image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - develop
+      - "release*"
+
+jobs:
+  release-image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [arm64, x86_64]
+
+    env:
+      IMAGE_REPOSITORY: ${{ github.event.repository.name }}
+      IMAGE_TAG: ${{ github.sha }}
+      DOCKER_SERVER: docker.io
+      DOCKER_USER: dhiway
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Authenticate with DockerHub
+        run: |
+          # Authenticate with Dockerhub using a Docker password secret
+          docker login \
+            ${{ env.DOCKER_SERVER }} \
+            -u ${{ env.DOCKER_USER }} \
+            -p "${{ secrets.DOCKER_PASSWORD }}"
+
+      - name: Build and push Docker Image
+        run: |
+          # Get the branch name
+          DOCKER_BRANCH=${{ github.ref }}
+          DOCKER_BRANCH=${DOCKER_BRANCH/refs\/heads\//}
+
+          # Build the Docker image
+          docker build \
+            --no-cache \
+            --file Dockerfile \
+            --tag ${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH} \
+            .
+
+          # Tag the Docker image with the repository name, architecture, and the commit hash
+          docker tag \
+            ${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH} \
+            ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${{ env.IMAGE_TAG }} \
+            && docker tag \
+            ${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH} \
+            ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH}
+
+          # Push the Docker image to the registry
+          docker push ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,65 +3,20 @@ name: release
 on:
   push:
     branches:
-      - develop
       - "release*"
 
 jobs:
-  release-docker-image:
-    runs-on: ubuntu-22.04
-
-    env:
-      IMAGE_REPOSITORY: ${{ github.event.repository.name }}
-      IMAGE_TAG: ${{ github.sha }}
-      DOCKER_SERVER: docker.io
-      DOCKER_USER: dhiway
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Authenticate with DockerHub
-        run: |
-          # Authenticate with Dockerhub using a Docker password secret
-          docker login \
-            ${{ env.DOCKER_SERVER }} \
-            -u ${{ env.DOCKER_USER }} \
-            -p "${{ secrets.DOCKER_PASSWORD }}"
-
-      - name: Build and push Docker Image
-        run: |
-          # Get the branch name
-          DOCKER_BRANCH=${{ github.ref }}
-          DOCKER_BRANCH=${DOCKER_BRANCH/refs\/heads\//}
-
-          # Build the Docker image
-          docker build \
-            --no-cache \
-            --file Dockerfile \
-            --tag ${{ env.IMAGE_REPOSITORY }}:${DOCKER_BRANCH} \
-            .
-
-          # Tag the Docker image with the repository name and the commit hash
-          docker tag \
-            ${{ env.IMAGE_REPOSITORY }}:${DOCKER_BRANCH} \
-            ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} \
-            && docker tag \
-            ${{ env.IMAGE_REPOSITORY }}:${DOCKER_BRANCH} \
-            ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}:${DOCKER_BRANCH}
-
-          # Push the Docker image to the registry
-          docker push ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}:${DOCKER_BRANCH}
-
-  x86_64-binary:
+  x86_64:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Install dependencies
         run: sudo apt-get update -y && sudo apt-get install -y protobuf-compiler libssl-dev
 
       - name: Setup Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         continue-on-error: false
         with:
           path: |


### PR DESCRIPTION
Now we should have 2 docker images based on architecture: x86_64 and ARM. It will simplify our Graviton deployments.
From now one binary will be released on any `release` branch (assuming that the release branches will have `release` as a prefix in the name).