### PR TITLE
Build docker image for mult-platforms using `buildx`.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,11 +7,8 @@ on:
       - "release*"
 
 jobs:
-  release-image:
+  release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        architecture: [arm64, x86_64]
 
     env:
       IMAGE_REPOSITORY: ${{ github.event.repository.name }}
@@ -22,34 +19,32 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Authenticate with DockerHub
-        run: |
-          # Authenticate with Dockerhub using a Docker password secret
-          docker login \
-            ${{ env.DOCKER_SERVER }} \
-            -u ${{ env.DOCKER_USER }} \
-            -p "${{ secrets.DOCKER_PASSWORD }}"
 
-      - name: Build and push Docker Image
+        # Setup hardware emulator using QEMU
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+        # Setup Docker Buildx for multi-arch images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Authenticate with Dockerhub using a Docker password secret
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.DOCKER_SERVER }}
+          username: ${{ env.DOCKER_USER }}
+          password: "${{ secrets.DOCKER_PASSWORD }}"
+
+      - name: Build and Push
         run: |
           # Get the branch name
-          DOCKER_BRANCH=${{ github.ref }}
+          DOCKER_BRANCH=${{ github.head_ref }}
           DOCKER_BRANCH=${DOCKER_BRANCH/refs\/heads\//}
 
-          # Build the Docker image
-          docker build \
-            --no-cache \
+          docker buildx build \
+            --push \
             --file Dockerfile \
-            --tag ${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH} \
+            --tag ${{ env.IMAGE_REPOSITORY }}:${DOCKER_BRANCH} \
+            --platform linux/amd64,linux/arm64,linux/arm64/v8 \
             .
-
-          # Tag the Docker image with the repository name, architecture, and the commit hash
-          docker tag \
-            ${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH} \
-            ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${{ env.IMAGE_TAG }} \
-            && docker tag \
-            ${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH} \
-            ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH}
-
-          # Push the Docker image to the registry
-          docker push ${{ env.DOCKER_SERVER }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_REPOSITORY }}-${{ matrix.architecture }}:${DOCKER_BRANCH}


### PR DESCRIPTION
- Using `buildx` to build multi-platform image.
- We should have docker image named as: `cord:branch_name`
