### PR TITLE
Docker: change the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This is the build stage for CORD. Here we create the binary in a temporary image.
-FROM docker.io/paritytech/ci-linux:production as builder
+FROM docker.io/paritytech/ci-unified:latest as builder
 
 LABEL maintainer="engineering@dhiway.com"
 ARG PROFILE=production

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 # This is the build stage for CORD. Here we create the binary in a temporary image.
-FROM docker.io/paritytech/ci-linux:production as builder
+FROM docker.io/paritytech/ci-unified:latest as builder
 
 LABEL maintainer="engineering@dhiway.com"
 ARG PROFILE=production
@@ -8,6 +8,3 @@ WORKDIR /build
 COPY . /build
 
 RUN cargo build --locked --profile ${PROFILE}
-
-# test
-# RUN cargo test --release --all


### PR DESCRIPTION
Update the base image as the old base is marked deprecated by upstream.

Fixes: #188 