### PR TITLE
Add `Makefile` to quickly run commands on CORD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,107 @@
+# Makefile for CORD Project
+
+# Flags for common Cargo commands
+CARGO_FLAGS := --locked --all-targets --color always
+
+# Define the binary name
+BINARY := cord
+
+# Define the output for production builds
+PROD_DIR := target/production
+
+TEST_CHECK_PALLETS := check \
+    check-did \
+    check-authorship \
+    check-did-name \
+    check-registry \
+    check-schema \
+    check-stream \
+    test \
+    test-did \
+    test-authorship \
+    test-did-name \
+    test-registry \
+    test-schema \
+    test-stream
+
+
+# Rule to build the production version of the project
+build:
+	cargo build $(CARGO_FLAGS) --profile production
+
+# Default rule, runs the production build
+all: build
+
+# Rule to build the project (debug profile)
+build-debug:
+	cargo build $(CARGO_FLAGS)
+
+# Rule to check the project with all targets
+check:
+	cargo check --all $(CARGO_FLAGS)
+
+# Rule to check the DID pallet with all targets
+check-did:
+	cargo check --package pallet-did $(CARGO_FLAGS)
+
+# Rule to check the Athorship pallet with all targets
+check-authorship:
+	cargo check --package pallet-extrinsic-authorship $(CARGO_FLAGS)
+
+# Rule to check the DID NAME pallet with all targets
+check-did-name:
+	cargo check --package pallet-did-names $(CARGO_FLAGS)
+
+# Rule to check the REGISTRY pallet with all targets
+check-registry:
+	cargo check --package pallet-registry $(CARGO_FLAGS)
+
+# Rule to check the SCHEMA pallet with all targets
+check-schema:
+	cargo check --package pallet-schema $(CARGO_FLAGS)
+
+# Rule to check the STREAM pallet with all targets
+check-stream:
+	cargo check --package pallet-stream $(CARGO_FLAGS)
+
+# Rule to run tests with runtime benchmarks and without fail-fast
+test:
+	cargo test --all --features=runtime-benchmarks --no-fail-fast $(CARGO_FLAGS)
+
+# Rule to test the DID pallet with all targets
+test-did:
+	cargo test --package pallet-did $(CARGO_FLAGS) 
+
+# Rule to test the Athorship pallet with all targets
+test-authorship:
+	cargo test --package pallet-extrinsic-authorship $(CARGO_FLAGS)
+
+# Rule to test the DID NAME pallet with all targets
+test-did-name:
+	cargo test --package pallet-did-names $(CARGO_FLAGS)
+
+# Rule to test the REGISTRY pallet with all targets
+test-registry:
+	cargo test --package pallet-registry $(CARGO_FLAGS)
+
+# Rule to test the SCHEMA pallet with all targets
+test-schema:
+	cargo test --package pallet-schema $(CARGO_FLAGS)
+
+# Rule to test the STREAM pallet with all targets
+test-stream:
+	cargo test --package pallet-stream $(CARGO_FLAGS)
+
+# Rule to run the production binary with --dev flag
+run-local: build
+	$(PROD_DIR)/$(BINARY) --dev
+
+# Rule to display the help message of the production binary
+help: build
+	$(PROD_DIR)/$(BINARY) --help
+
+# Rule to clean build artifacts
+clean:
+	cargo clean
+
+.PHONY: build build-debug run-local help clean all $(TEST_CHECK_PALLETS)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for CORD Project
 
 # Flags for common Cargo commands
-CARGO_FLAGS := --locked --all-targets --color always
+CARGO_FLAGS := --locked --all-targets --features=runtime-benchmarks --color always
 
 # Define the binary name
 BINARY := cord
@@ -66,7 +66,7 @@ check-stream:
 
 # Rule to run tests with runtime benchmarks and without fail-fast
 test:
-	cargo test --all --features=runtime-benchmarks --no-fail-fast $(CARGO_FLAGS)
+	cargo test --all --no-fail-fast $(CARGO_FLAGS)
 
 # Rule to test the DID pallet with all targets
 test-did:

--- a/README.md
+++ b/README.md
@@ -8,15 +8,119 @@ It is designed to simplify the management of information, making it easier for o
 
 CORD builds on the modular approach of the Substrate framework. It defines a rich set of primitives to help design exceptional levels of innovations for existing and emerging industries. Such innovative approaches cover conducting transactions and maintaining records across several sectors such as finance, trade, health, energy, water resources, agriculture and many more.
 
-### Getting Started
+## Quick Start Guide
 
-This section will guide you through the **following steps** needed to prepare a computer for **CORD** development. Since CORD is built with [the Rust programming language](https://www.rust-lang.org/), the first thing you will need to do is prepare the computer for Rust development - these steps will vary based on the computer's operating system.
+### Prerequisites
 
-Once Rust is configured, you will use its toolchains to interact with Rust projects; the commands for Rust's toolchains will be the same for all supported, Unix-based operating systems.
+Before you begin, ensure you have the following prerequisites installed on your system:
 
-Also, join and discover the various [discord] channels where you can engage, participate and keep up with the latest developments.
+- [Rust](http://rustup.rs/)
+- `Make`
+- [Build packages](#install-dependencies)
 
-## 1. Install dependencies
+### Build CORD in production mode
+
+To build the production version of the project, optimized for performance, execute the following command:
+
+```bash
+make
+
+# or
+
+make build
+```
+
+This will create the production binary in the `target/production` directory.
+
+
+### Build the CORD in debug mode:
+
+To build the project in the `debug` profile, run the following command:
+
+```bash
+make build-debug
+```
+
+This will compile the project without optimization and generate the executable in the `target/debug` directory.
+
+### Checking the CORD
+
+To perform a static analysis of the entire project, use the following command:
+
+```bash
+make check
+```
+
+This will check the code and dependencies for errors without producing an executable.
+
+### Running Tests
+
+To run all tests in the project, including runtime benchmarks and without fail-fast, run the following command:
+
+```bash
+make test
+```
+
+### Run Single Node Local CORD Network
+
+To run the production binary locally with the `--dev` flag, use the following command:
+
+```bash
+make run-local
+```
+
+### Displaying Help Message
+
+To see the help message of the production binary, run the following command:
+
+```bash
+make help
+```
+
+### Clean Build Artifacts
+
+To remove all build artifacts, use the following command:
+
+```bash
+make clean
+```
+
+This will clean up any compiled files and reset the project to a clean state.
+
+## Specific Pallet Checks and Tests
+
+The `Makefile` also provides specific rules to `check` and `test` individual `pallets`. 
+You can use these commands to `check` and `test` specific parts of the project.
+
+### Pallet Checks
+
+To check specific pallets, use the following commands:
+
+```bash
+make check-did
+make check-authorship
+make check-did-name
+make check-registry
+make check-schema
+make check-stream
+```
+
+### Pallet Tests
+
+To run tests for specific pallets, use the following commands:
+
+```bash
+make test-did
+make test-authorship
+make test-did-name
+make test-registry
+make test-schema
+make test-stream
+```
+
+---
+
+## Install Dependencies
 
 ### Ubuntu/Debian
 
@@ -66,8 +170,22 @@ brew update
 brew install openssl
 brew install protobuf
 ```
+---
 
-## 2. Rust developer environment
+## Getting Started
+
+This section will guide you through the **following steps** needed to prepare a computer for **CORD** development. Since CORD is built with [the Rust programming language](https://www.rust-lang.org/), the first thing you will need to do is prepare the computer for Rust development - these steps will vary based on the computer's operating system.
+
+Once Rust is configured, you will use its toolchains to interact with Rust projects; the commands for Rust's toolchains will be the same for all supported, Unix-based operating systems.
+
+Also, join and discover the various [discord] channels where you can engage, participate and keep up with the latest developments.
+
+<details>
+   <summary>
+      <b>
+         1. Rust developer environment
+      </b>
+   </summary>
 
 This guide uses <https://rustup.rs> installer and the `rustup` tool to manage the Rust toolchain.
 First, install and configure `rustup`:
@@ -87,95 +205,116 @@ rustup update
 rustup update nightly
 rustup target add wasm32-unknown-unknown --toolchain nightly
 ```
+</details>
 
-## 3. Build the node
+<details>
+   <summary>
+      <b>
+         2. Build the node
+      </b>
+   </summary>
 
 You can use rustup to install a specific version of rust, including its custom compilation targets. Using rustup, it should set a proper toolchain automatically while you call rustup show within project's root directory. Naturally, we can try to use different versions of these dependencies, i.e. delivered by system's default package manager. To compile the CORD node:
 
 1. Clone this repository by running the following command:
 
-   ```bash
-   git clone https://github.com/dhiway/cord
-   ```
+```bash
+git clone https://github.com/dhiway/cord
+```
 
-1. Change to the root of the node template directory by running the following command:
+2. Change to the root of the node template directory by running the following command:
 
-   ```bash
-   cd cord
-   git checkout develop
-   ```
+```bash
+cd cord
+git checkout develop
+```
 
-1. Compile by running the following command:
+3. Compile by running the following command:
 
-   ```bash
-   cargo build --release
-   ```
+```bash
+make
+```
 
-   You should always use the `--release` flag to build optimized artifacts.
+</details>
 
-## 4. Run the node
+<details>
+   <summary>
+      <b>
+         3. Run the node
+      </b>
+   </summary>
 
 1. Start the single-node development chain, by running:
 
-   ```
-   ./target/release/cord --dev
-   ```
+```bash
+make run-local
+```
 
-1. Detailed logs may be shown by running the chain with the following environment variables set:
+2. Detailed logs may be shown by running the chain with the following environment variables set:
 
-   ```bash
-   RUST_LOG=debug RUST_BACKTRACE=1 ./target/release/cord --dev
-   ```
+```bash
+RUST_LOG=debug RUST_BACKTRACE=1 make run-local
+```
 
-1. Additional CLI usage options
+3. Additional CLI usage options
 
-   ```
-   ./target/release/cord --help
-   ```
+```bash
+make help
+```
 
-## 5. Using Docker
+</details>
 
-The easiest/faster option to run CORD in Docker is to use the latest release images. These are small images that use the latest official release of the CORD binary, pulled from our package repository.
+<details>
+   <summary>
+      <b>
+         4. Using Docker
+      </b>
+   </summary>
+
+The easiest/faster option to run CORD in Docker is to use the latest release images. 
+These are small images that use the latest official release of the CORD binary, pulled from our package repository.
 
 1. Let's first check the version we have. The first time you run this command, the CORD docker image will be downloaded. This takes a bit of time and bandwidth, be patient:
 
-   ```bash
-    docker run --rm -it dhiway/cord:develop --version
-   ```
+```bash
+docker run --rm -it dhiway/cord:develop --version
+```
 
-   You can also pass any argument/flag that CORD supports:
+You can also pass any argument/flag that CORD supports:
 
-   ```bash
-    docker run --rm -it dhiway/cord:develop --dev --name "CordDocker"
-   ```
+```bash
+docker run --rm -it dhiway/cord:develop --dev --name "CordDocker"
+```
 
-   Once you are done experimenting and picking the best node name :) you can start CORD as daemon, exposes the CORD ports and mount a volume that will keep your blockchain data locally. Make sure that you set the ownership of your local directory to the CORD user that is used by the container. Set user id 1000 and group id 1000, by running `chown 1000.1000 /my/local/folder -R` if you use a bind mount.
+Once you are done experimenting and picking the best node name :) you can start CORD as daemon, exposes the CORD ports and mount a volume that will keep your blockchain data locally. 
+Make sure that you set the ownership of your local directory to the CORD user that is used by the container. Set user id 1000 and group id 1000, by running `chown 1000.1000 /my/local/folder -R` if you use a bind mount.
 
-1. To start a CORD node on default rpc port 9933 and default p2p port 30333 use the following command. If you want to connect to rpc port 9933, then must add CORD startup parameter: `--rpc-external`.
+2. To start a CORD node on default rpc port 9933 and default p2p port 30333 use the following command. If you want to connect to rpc port 9933, then must add CORD startup parameter: `--rpc-external`.
 
-   ```bash
-   docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/cord dhiway/cord:develop --dev --rpc-external --rpc-cors all
-   ```
+```bash
+docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/cord dhiway/cord:develop --dev --rpc-external --rpc-cors all
+```
 
-1. Additionally if you want to have custom node name you can add the `--name "YourName"` at the end
+3. Additionally if you want to have custom node name you can add the `--name "YourName"` at the end
 
-   ```bash
-   docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/cord dhiway/cord:develop --dev --rpc-external --rpc-cors all --name "CordDocker"
-   ```
+```bash
+docker run -d -p 30333:30333 -p 9933:9933 -v /my/local/folder:/cord dhiway/cord:develop --dev --rpc-external --rpc-cors all --name "CordDocker"
+```
 
-1. If you also want to expose the webservice port 9944 use the following command:
+4. If you also want to expose the webservice port 9944 use the following command:
 
-   ```bash
-   docker run -d -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /my/local/folder:/cord dhiway/cord:develop --dev --ws-external --rpc-external --rpc-cors all --name "CordDocker"
-   ```
+```bash
+docker run -d -p 30333:30333 -p 9933:9933 -p 9944:9944 -v /my/local/folder:/cord dhiway/cord:develop --dev --ws-external --rpc-external --rpc-cors all --name "CordDocker"
+```
 
-1. To get up and running with the smallest footprint on your system, you may use the CORD Docker image.
-   You can build it yourself (it takes a while...).
+5. To get up and running with the smallest footprint on your system, you may use the CORD Docker image.
+You can build it yourself (it takes a while...).
 
-   ```
-    docker build -t local/cord:develop .
-   ```
+```bash
+docker build -t local/cord:develop .
+```
 
+</details>
 
 ## Other projects of interest
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,8 @@ CORD builds on the modular approach of the Substrate framework. It defines a ric
 
 ### Prerequisites
 
-Before you begin, ensure you have the following prerequisites installed on your system:
+Before you begin, ensure you have the [necessary packages](/docs/installation.md) to locally run CORD.
 
-- [Rust](http://rustup.rs/)
-- `Make`
-- [Build packages](#install-dependencies)
 
 ### Build CORD in production mode
 
@@ -24,10 +21,6 @@ To build the production version of the project, optimized for performance, execu
 
 ```bash
 make
-
-# or
-
-make build
 ```
 
 This will create the production binary in the `target/production` directory.
@@ -69,6 +62,12 @@ To run the production binary locally with the `--dev` flag, use the following co
 make run-local
 ```
 
+Detailed logs may be shown by running the chain with the following environment variables set:
+
+```bash
+RUST_LOG=debug RUST_BACKTRACE=1 make run-local
+```
+
 ### Displaying Help Message
 
 To see the help message of the production binary, run the following command:
@@ -92,7 +91,7 @@ This will clean up any compiled files and reset the project to a clean state.
 The `Makefile` also provides specific rules to `check` and `test` individual `pallets`. 
 You can use these commands to `check` and `test` specific parts of the project.
 
-### Pallet Checks
+### Check Pallets
 
 To check specific pallets, use the following commands:
 
@@ -105,7 +104,7 @@ make check-schema
 make check-stream
 ```
 
-### Pallet Tests
+### Test Pallets
 
 To run tests for specific pallets, use the following commands:
 
@@ -120,159 +119,7 @@ make test-stream
 
 ---
 
-## Install Dependencies
-
-### Ubuntu/Debian
-
-Use a terminal shell to execute the following commands:
-
-```bash
-sudo apt update
-# May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev pkg-config
-```
-
-### Arch Linux
-
-Run these commands from a terminal:
-
-```bash
-pacman -Syu --needed --noconfirm curl git clang
-```
-
-### Fedora
-
-Run these commands from a terminal:
-
-```bash
-sudo dnf update
-sudo dnf install clang curl git openssl-devel
-```
-
-### OpenSUSE
-
-Run these commands from a terminal:
-
-```bash
-sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel
-```
-
-### macOS
-
-Open the Terminal application and execute the following commands:
-
-```bash
-# Install Homebrew if necessary https://brew.sh/
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-
-# Make sure Homebrew is up-to-date, install openssl and protobuf
-brew update
-brew install openssl
-brew install protobuf
-```
----
-
-## Getting Started
-
-This section will guide you through the **following steps** needed to prepare a computer for **CORD** development. Since CORD is built with [the Rust programming language](https://www.rust-lang.org/), the first thing you will need to do is prepare the computer for Rust development - these steps will vary based on the computer's operating system.
-
-Once Rust is configured, you will use its toolchains to interact with Rust projects; the commands for Rust's toolchains will be the same for all supported, Unix-based operating systems.
-
-Also, join and discover the various [discord] channels where you can engage, participate and keep up with the latest developments.
-
-<details>
-   <summary>
-      <b>
-         1. Rust developer environment
-      </b>
-   </summary>
-
-This guide uses <https://rustup.rs> installer and the `rustup` tool to manage the Rust toolchain.
-First, install and configure `rustup`:
-
-```bash
-# Install
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-# Configure
-source ~/.cargo/env
-```
-
-Configure the Rust toolchain to default to the latest stable version, add nightly and the nightly wasm target:
-
-```bash
-rustup default stable
-rustup update
-rustup update nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly
-```
-</details>
-
-<details>
-   <summary>
-      <b>
-         2. Build the node
-      </b>
-   </summary>
-
-You can use rustup to install a specific version of rust, including its custom compilation targets. Using rustup, it should set a proper toolchain automatically while you call rustup show within project's root directory. Naturally, we can try to use different versions of these dependencies, i.e. delivered by system's default package manager. To compile the CORD node:
-
-1. Clone this repository by running the following command:
-
-```bash
-git clone https://github.com/dhiway/cord
-```
-
-2. Change to the root of the node template directory by running the following command:
-
-```bash
-cd cord
-git checkout develop
-```
-
-3. Compile by running the following command:
-
-```bash
-make
-```
-
-</details>
-
-<details>
-   <summary>
-      <b>
-         3. Run the node
-      </b>
-   </summary>
-
-1. Start the single-node development chain, by running:
-
-```bash
-make run-local
-```
-
-2. Detailed logs may be shown by running the chain with the following environment variables set:
-
-```bash
-RUST_LOG=debug RUST_BACKTRACE=1 make run-local
-```
-
-3. Additional CLI usage options
-
-```bash
-make help
-```
-
-</details>
-
-<details>
-   <summary>
-      <b>
-         4. Using Docker
-      </b>
-   </summary>
-
-The easiest/faster option to run CORD in Docker is to use the latest release images. 
-These are small images that use the latest official release of the CORD binary, pulled from our package repository.
+### Using Docker
 
 1. Let's first check the version we have. The first time you run this command, the CORD docker image will be downloaded. This takes a bit of time and bandwidth, be patient:
 
@@ -313,8 +160,6 @@ You can build it yourself (it takes a while...).
 ```bash
 docker build -t local/cord:develop .
 ```
-
-</details>
 
 ## Other projects of interest
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,75 @@
+# CORD Installation Guide
+
+## Setup Rust
+
+This guide uses [rustup](https://rustup.rs) to install and manage the Rust toolchains.
+
+First, install and configure `rustup`:
+
+```bash
+# Install
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Configure
+source ~/.cargo/env
+```
+
+Configure the Rust toolchain to default to the latest stable version, add nightly and the nightly wasm target:
+
+```bash
+rustup default stable
+rustup update
+rustup update nightly
+rustup target add wasm32-unknown-unknown --toolchain nightly
+```
+
+## Install OS Specific Dependencies
+
+### Ubuntu/Debian
+
+Use a terminal shell to execute the following commands:
+
+```bash
+sudo apt update
+# May prompt for location information
+sudo apt install -y git clang curl libssl-dev llvm libudev-dev pkg-config
+```
+
+### Arch Linux
+
+Run these commands from a terminal:
+
+```bash
+pacman -Syu --needed --noconfirm curl git clang
+```
+
+### Fedora
+
+Run these commands from a terminal:
+
+```bash
+sudo dnf update
+sudo dnf install clang curl git openssl-devel
+```
+
+### OpenSUSE
+
+Run these commands from a terminal:
+
+```bash
+sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel
+```
+
+### macOS
+
+Open the Terminal application and execute the following commands:
+
+```bash
+# Install Homebrew if necessary https://brew.sh/
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+# Make sure Homebrew is up-to-date, install openssl and protobuf
+brew update
+brew install openssl
+brew install protobuf
+```


### PR DESCRIPTION
- Remembering all the long commands with all required flags are prone to error.
- Any new developer wants to contribute to `CORD` can progress more ergonomically.