### PR TITLE
Makefile: Add persistent logging to all nodes and remove a few options from validator startup commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,13 +109,13 @@ clean:
 # Start a 4 node CORD network using local chain spec
 .PHONY: spinup spindown
 
-NODE_1_CMD := ./target/production/cord --base-path /tmp/cord-data/alice --validator --chain local --alice --port 30333 --rpc-port 9933 --prometheus-port 9615 --node-key abe47f4e1065d4aa6fb0c1dd69a9a6b63c4551da63aad5f688976f77bd21622f --rpc-methods=Safe --rpc-cors all --no-hardware-benchmarks --state-pruning 100 --blocks-pruning 100 --offchain-worker never --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0"
+NODE_1_CMD := ./target/production/cord --base-path /tmp/cord-data/alice --validator --chain local --alice --port 30333 --rpc-port 9933 --prometheus-port 9615 --node-key abe47f4e1065d4aa6fb0c1dd69a9a6b63c4551da63aad5f688976f77bd21622f --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0"
 
-NODE_2_CMD := ./target/production/cord --base-path /tmp/cord-data/bob --validator --chain local --bob --port 30334 --rpc-port 9934 --node-key 7609333b3e2e2e0c1b4064f074a7396b53d213e08d356d1be2d48fab3a6cd25a --rpc-methods=Safe --rpc-cors all --no-hardware-benchmarks --state-pruning 100 --blocks-pruning 100 --offchain-worker never --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
+NODE_2_CMD := ./target/production/cord --base-path /tmp/cord-data/bob --validator --chain local --bob --port 30334 --rpc-port 9934 --node-key 7609333b3e2e2e0c1b4064f074a7396b53d213e08d356d1be2d48fab3a6cd25a --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
 
-NODE_3_CMD := ./target/production/cord --base-path /tmp/cord-data/charlie --validator --chain local --charlie --port 30335 --rpc-port 9935 --node-key e18d2c105ad8188830979b7bf4e7779361beb9010b6574e1b35a0a354ce02e96 --rpc-methods=Safe --rpc-cors all --no-hardware-benchmarks --state-pruning 100 --blocks-pruning 100 --offchain-worker never --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
+NODE_3_CMD := ./target/production/cord --base-path /tmp/cord-data/charlie --validator --chain local --charlie --port 30335 --rpc-port 9935 --node-key e18d2c105ad8188830979b7bf4e7779361beb9010b6574e1b35a0a354ce02e96 --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
 
-NODE_4_CMD := ./target/production/cord --base-path /tmp/cord-data/dave --chain local --dave --port 30336 --rpc-port 9936 --node-key f21d3114273b5d6184f9e595dba1850eb64b1e4965cfd2c6130354c67f632f5d --rpc-methods=Safe --rpc-cors all --no-hardware-benchmarks --state-pruning 100 --blocks-pruning 100 --offchain-worker never --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
+NODE_4_CMD := ./target/production/cord --base-path /tmp/cord-data/dave --chain local --dave --port 30336 --rpc-port 9936 --node-key f21d3114273b5d6184f9e595dba1850eb64b1e4965cfd2c6130354c67f632f5d --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
 
 
 spinup: build
@@ -136,5 +136,5 @@ spindown:
 	@rm -rf /tmp/cord-data/
 	@echo "/tmp/cord-data/ directory deleted."
 	@echo ""
-	@echo "Commercial Support Services on CORD are offered by Dhiway (sales@dhiway.com)"
-	@echo "CORD team recommends having a separate chain in production, because 'local' chain uses the default keys, which are common."
+	@echo "Commercial Support Services on CORD are offered by Dhiway \033[0;34m(sales@dhiway.com)\033[0m "
+	@echo "CORD team recommends having a separate chain in production, because \033[0;34mlocal\033[0m chain uses the default keys, which are common."

--- a/Makefile
+++ b/Makefile
@@ -109,14 +109,13 @@ clean:
 # Start a 4 node CORD network using local chain spec
 .PHONY: spinup spindown
 
-NODE_1_CMD := ./target/production/cord --base-path /tmp/cord-data/alice --validator --chain local --alice --port 30333 --rpc-port 9933 --prometheus-port 9615 --node-key abe47f4e1065d4aa6fb0c1dd69a9a6b63c4551da63aad5f688976f77bd21622f --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0"
+NODE_1_CMD := ./target/production/cord --base-path /tmp/cord-data/alice --validator --chain local --alice --port 30333 --rpc-port 9933 --prometheus-port 9615 --node-key 0000000000000000000000000000000000000000000000000000000000000001 --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0"
 
-NODE_2_CMD := ./target/production/cord --base-path /tmp/cord-data/bob --validator --chain local --bob --port 30334 --rpc-port 9934 --node-key 7609333b3e2e2e0c1b4064f074a7396b53d213e08d356d1be2d48fab3a6cd25a --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
+NODE_2_CMD := ./target/production/cord --base-path /tmp/cord-data/bob --validator --chain local --bob --port 30334 --rpc-port 9934 --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp
 
-NODE_3_CMD := ./target/production/cord --base-path /tmp/cord-data/charlie --validator --chain local --charlie --port 30335 --rpc-port 9935 --node-key e18d2c105ad8188830979b7bf4e7779361beb9010b6574e1b35a0a354ce02e96 --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
+NODE_3_CMD := ./target/production/cord --base-path /tmp/cord-data/charlie --validator --chain local --charlie --port 30335 --rpc-port 9935 --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp
 
-NODE_4_CMD := ./target/production/cord --base-path /tmp/cord-data/dave --chain local --dave --port 30336 --rpc-port 9936 --node-key f21d3114273b5d6184f9e595dba1850eb64b1e4965cfd2c6130354c67f632f5d --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
-
+NODE_4_CMD := ./target/production/cord --base-path /tmp/cord-data/dave --chain local --dave --port 30336 --rpc-port 9936 --rpc-methods=Safe --rpc-cors all --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp
 
 spinup: build
 	@echo "Starting nodes in the background..."


### PR DESCRIPTION
Removed the flowing options:
  - `--no-hardware-benchmarks`
  - `--state-pruning 100`
  - `--blocks-pruning 100`
  - `--offchain-worker never`
 
Update `node-key` for all nodes.
Persist logs from all CORD nodes and print instructions to view the logs.