### PR TITLE
Add Prometheus and Grafana Monitoring in `docker-compose`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,10 +76,23 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_USER=cord
-      - GF_SECURITY_ADMIN_PASSWORD=cord
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
     depends_on:
       - prometheus
+  
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:latest
+    container_name: node_exporter
+    command:
+      - '--path.rootfs=/host'
+    networks:
+      - cord_network
+    ports:
+      - "9100:9100"
+    restart: unless-stopped
+    volumes:
+      - /tmp/cord-data:/host:ro,rslave
 
 networks:
   cord_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,15 @@ services:
     networks:
       - cord_network
     ports:
-      - "127.0.0.1:30333:30333"
-      - "127.0.0.1:9933:9933"
-      - "127.0.0.1:9944:9944"
-      - "127.0.0.1:9615:9615"
+      - "30333:30333"
+      - "9933:9933"
+      - "9615:9615"
     volumes:
       - /tmp/cord-data:/data
-    command: --base-path /data/alice --validator --chain local --alice --port 30333 --rpc-port 9944 --prometheus-port 9615 --node-key abe47f4e1065d4aa6fb0c1dd69a9a6b63c4551da63aad5f688976f77bd21622f --rpc-methods=Safe --rpc-cors all --no-hardware-benchmarks --state-pruning 100 --blocks-pruning 100 --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0"
+    command: --base-path /data/alice --validator --chain local --alice --port 30333 --rpc-port 9944 --prometheus-port 9615 --prometheus-external --node-key abe47f4e1065d4aa6fb0c1dd69a9a6b63c4551da63aad5f688976f77bd21622f --rpc-methods=Safe --rpc-cors all --telemetry-url "wss://telemetry.cord.network/submit/ 0"
     restart: unless-stopped
 
-  node2:
+  bob_node:
     image: dhiway/cord
     container_name: bob
     networks:
@@ -23,13 +22,13 @@ services:
     ports:
       - "30334:30334"
       - "9934:9934"
-      - "9945:9944"
+      - "9616:9616"
     volumes:
       - /tmp/cord-data:/data
-    command: --base-path /data/bob --validator --chain local --bob --port 30334 --rpc-port 9934 --node-key 7609333b3e2e2e0c1b4064f074a7396b53d213e08d356d1be2d48fab3a6cd25a --rpc-methods=Safe --rpc-cors all --no-hardware-benchmarks --state-pruning 100 --blocks-pruning 100 --prometheus-external --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /dns4/bootnode/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
+    command: --base-path /data/bob --validator --chain local --bob --port 30334 --rpc-port 9934 --prometheus-port 9616 --prometheus-external --node-key 7609333b3e2e2e0c1b4064f074a7396b53d213e08d356d1be2d48fab3a6cd25a --rpc-methods=Safe --rpc-cors all --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /dns4/bootnode/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
     restart: unless-stopped
 
-  node3:
+  charlie_node:
     image: dhiway/cord
     container_name: charlie
     networks:
@@ -37,13 +36,13 @@ services:
     ports:
       - "30335:30335"
       - "9935:9935"
-      - "9946:9944"
+      - "9617:9617"
     volumes:
       - /tmp/cord-data:/data
-    command: --base-path /data/charlie --validator --chain local --charlie --port 30335 --rpc-port 9935 --node-key e18d2c105ad8188830979b7bf4e7779361beb9010b6574e1b35a0a354ce02e96 --rpc-methods=Safe --rpc-cors all --no-hardware-benchmarks --state-pruning 100 --blocks-pruning 100 --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /dns4/bootnode/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
+    command: --base-path /data/charlie --validator --chain local --charlie --port 30335 --rpc-port 9935 --prometheus-port 9617 --prometheus-external --node-key e18d2c105ad8188830979b7bf4e7779361beb9010b6574e1b35a0a354ce02e96 --rpc-methods=Safe --rpc-cors all --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /dns4/bootnode/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
     restart: unless-stopped
 
-  node4:
+  dave_node:
     image: dhiway/cord
     container_name: dave
     networks:
@@ -51,11 +50,36 @@ services:
     ports:
       - "30336:30336"
       - "9936:9936"
-      - "9947:9944"
+      - "9618:9618"
     volumes:
       - /tmp/cord-data:/data
-    command: --base-path /data/dave --chain local --dave --port 30336 --rpc-port 9936 --node-key f21d3114273b5d6184f9e595dba1850eb64b1e4965cfd2c6130354c67f632f5d --rpc-methods=Safe --rpc-cors all --no-hardware-benchmarks --state-pruning 100 --blocks-pruning 100 --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /dns4/bootnode/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
+    command: --base-path /data/dave --chain local --dave --port 30336 --rpc-port 9936 --prometheus-port 9618 --prometheus-external --node-key f21d3114273b5d6184f9e595dba1850eb64b1e4965cfd2c6130354c67f632f5d --rpc-methods=Safe --rpc-cors all --telemetry-url "wss://telemetry.cord.network/submit/ 0" --bootnodes /dns4/bootnode/tcp/30333/p2p/12D3KooWSNT7EqipGHpsAYptQfPNrMXdJcgjMd25hnQWwyvHxYnz
     restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    networks:
+      - cord_network
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring:/etc/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    networks:
+      - cord_network
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=cord
+      - GF_SECURITY_ADMIN_PASSWORD=cord
+    depends_on:
+      - prometheus
 
 networks:
   cord_network:
@@ -63,5 +87,6 @@ networks:
 
 x-lifecycle-hooks:
   before-up:
-    - mkdir /tmp/cord-data && chmod 777 /tmp/cord-data && chown $USER /tmp/cord-data 
-
+    - if [ -d /tmp/cord-data ]; then rm -rf /tmp/cord-data; fi
+    - mkdir /tmp/cord-data && chmod 777 /tmp/cord-data && chown $USER /tmp/cord-data
+ 

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "cord_node"
+    static_configs:
+      - targets: ["localhost:9615"]

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -9,3 +9,7 @@ scrape_configs:
   - job_name: "cord_node"
     static_configs:
       - targets: ["localhost:9615"]
+
+  - job_name: "node_exporter"
+    static_configs:
+      - targets: ["localhost:9100"]


### PR DESCRIPTION
- Running `docker-compose up -d` starts 4 CORD nodes and prometheus & grafana.
- Add monitoring so user can test monitoring if they want.