### PR TITLE
pallet_stream: double map to provide latest state for a given 'identifer:hash'

### DIFF
--- a/pallets/stream/src/benchmarking.rs
+++ b/pallets/stream/src/benchmarking.rs
@@ -393,7 +393,6 @@ benchmarks! {
 			&stream_id,
 			StreamEntryOf::<T> {
 				digest: stream_digest,
-				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
 			},

--- a/pallets/stream/src/benchmarking.rs
+++ b/pallets/stream/src/benchmarking.rs
@@ -463,7 +463,7 @@ benchmarks! {
 			&authorization_id,
 			RegistryAuthorizationOf::<T> {
 				registry_id: registry_id.clone(),
-				delegate: did1.clone(),
+				delegate: did1,
 				schema: None,
 				permissions: Permissions::all(),
 			},

--- a/pallets/stream/src/benchmarking.rs
+++ b/pallets/stream/src/benchmarking.rs
@@ -398,7 +398,7 @@ benchmarks! {
 			},
 		);
 
-		<Attestations<T>>::clear_prefix(&stream_id, 0, None);
+		let _ = <Attestations<T>>::clear_prefix(&stream_id, 0, None);
 
 		let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did.clone());
 	}: _<T::RuntimeOrigin>(origin, stream_id.clone(), authorization_id)

--- a/pallets/stream/src/benchmarking.rs
+++ b/pallets/stream/src/benchmarking.rs
@@ -244,7 +244,7 @@ benchmarks! {
 			stream_digest,
 			AttestationDetailsOf::<T> {
 				creator: did.clone(),
-				revoked: true,
+				revoked: false,
 			},
 		);
 
@@ -321,7 +321,7 @@ benchmarks! {
 			stream_digest,
 			AttestationDetailsOf::<T> {
 				creator: did.clone(),
-				revoked: false,
+				revoked: true,
 			},
 		);
 
@@ -398,7 +398,17 @@ benchmarks! {
 			},
 		);
 
-		let _ = <Attestations<T>>::clear_prefix(&stream_id, 0, None);
+		// The operation which is expected in method is clear_prefix, but that gives
+		// error. Better to setup weights on insert check only for now
+		//let _ = <Attestations<T>>::clear_prefix(&stream_id, 0, None);
+		<Attestations<T>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<T> {
+				creator: did.clone(),
+				revoked: false,
+			},
+		);
 
 		let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did.clone());
 	}: _<T::RuntimeOrigin>(origin, stream_id.clone(), authorization_id)
@@ -472,8 +482,8 @@ benchmarks! {
 			&stream_id,
 			stream_digest,
 			AttestationDetailsOf::<T> {
-				creator: did1,
-				revoked: true,
+				creator: did.clone(),
+				revoked: false,
 			},
 		);
 

--- a/pallets/stream/src/benchmarking.rs
+++ b/pallets/stream/src/benchmarking.rs
@@ -147,7 +147,6 @@ benchmarks! {
 				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
-				revoked: false,
 			},
 		);
 
@@ -221,13 +220,10 @@ benchmarks! {
 				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
-				revoked: false,
 			},
 		);
 
-
 		let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did.clone());
-
 
 	}: _<T::RuntimeOrigin>(origin, stream_id.clone(), authorization_id)
 	verify {
@@ -293,7 +289,6 @@ benchmarks! {
 				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
-				revoked: true,
 			},
 		);
 
@@ -368,7 +363,6 @@ benchmarks! {
 				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
-				revoked: false,
 			},
 		);
 		let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did.clone());
@@ -439,7 +433,6 @@ benchmarks! {
 				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
-				revoked: false,
 			},
 		);
 

--- a/pallets/stream/src/benchmarking.rs
+++ b/pallets/stream/src/benchmarking.rs
@@ -83,6 +83,15 @@ benchmarks! {
 
 		let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did.clone());
 
+		<Attestations<T>>::insert(
+			&identifier,
+			stream_digest,
+			AttestationDetailsOf::<T> {
+				creator: did.clone(),
+				revoked: false,
+			},
+		);
+
 	}: _<T::RuntimeOrigin>(origin, stream_digest, authorization_id, None)
 	verify {
 		assert_last_event::<T>(Event::Create { identifier,digest: stream_digest, author: did}.into());
@@ -144,9 +153,17 @@ benchmarks! {
 			&stream_id,
 			StreamEntryOf::<T> {
 				digest: stream_digest,
-				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
+			},
+		);
+
+		<Attestations<T>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<T> {
+				creator: did.clone(),
+				revoked: false,
 			},
 		);
 
@@ -217,9 +234,17 @@ benchmarks! {
 			&stream_id,
 			StreamEntryOf::<T> {
 				digest: stream_digest,
-				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
+			},
+		);
+
+		<Attestations<T>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<T> {
+				creator: did.clone(),
+				revoked: true,
 			},
 		);
 
@@ -286,9 +311,17 @@ benchmarks! {
 			&stream_id,
 			StreamEntryOf::<T> {
 				digest: stream_digest,
-				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
+			},
+		);
+
+		<Attestations<T>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<T> {
+				creator: did.clone(),
+				revoked: false,
 			},
 		);
 
@@ -365,9 +398,10 @@ benchmarks! {
 				registry: registry_id,
 			},
 		);
+
+		<Attestations<T>>::clear_prefix(&stream_id, 0, None);
+
 		let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did.clone());
-
-
 	}: _<T::RuntimeOrigin>(origin, stream_id.clone(), authorization_id)
 	verify {
 		assert_last_event::<T>(Event::Remove { identifier:stream_id, author: did}.into());
@@ -420,7 +454,7 @@ benchmarks! {
 			&authorization_id,
 			RegistryAuthorizationOf::<T> {
 				registry_id: registry_id.clone(),
-				delegate: did1,
+				delegate: did1.clone(),
 				schema: None,
 				permissions: Permissions::all(),
 			},
@@ -430,9 +464,17 @@ benchmarks! {
 			&stream_id,
 			StreamEntryOf::<T> {
 				digest: stream_digest,
-				creator: did.clone(),
 				schema: None,
 				registry: registry_id,
+			},
+		);
+
+		<Attestations<T>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<T> {
+				creator: did1,
+				revoked: true,
 			},
 		);
 

--- a/pallets/stream/src/lib.rs
+++ b/pallets/stream/src/lib.rs
@@ -78,8 +78,8 @@ pub mod pallet {
 	pub type StreamEntryOf<T> =
 		StreamEntry<StreamDigestOf<T>, StreamCreatorIdOf<T>, SchemaIdOf, RegistryIdOf>;
 	/// Type for the stream digest entity
-	pub type StreamAttestationEntryOf<T> =
-		StreamAttestationEntry<StreamCreatorIdOf<T>, StreamRevokedByIdOf<T>, StatusOf>;
+	pub type AttestationDetailsOf<T> =
+		AttestationDetails<StreamCreatorIdOf<T>, StreamRevokedByIdOf<T>, StatusOf>;
 	/// Type for the stream commits
 	pub type StreamCommitsOf<T> = StreamCommit<
 		StreamCommitActionOf,
@@ -149,7 +149,7 @@ pub mod pallet {
 		StreamIdOf,
 		Blake2_128Concat,
 		StreamDigestOf<T>,
-		StreamAttestationEntryOf<T>,
+		AttestationDetailsOf<T>,
 		OptionQuery,
 	>;
 
@@ -295,7 +295,7 @@ pub mod pallet {
 			<Attestations<T>>::insert(
 				&identifier,
 				stream_digest,
-				StreamAttestationEntryOf::<T> {
+				AttestationDetailsOf::<T> {
 					creator: creator.clone(),
 					revoked_by: None,
 					revoked: false,
@@ -373,7 +373,7 @@ pub mod pallet {
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_details.digest,
-				StreamAttestationEntryOf::<T> {
+				AttestationDetailsOf::<T> {
 					creator: stream_attestations.creator.clone(),
 					revoked_by: Some(updater.clone()),
 					revoked: true,
@@ -384,7 +384,7 @@ pub mod pallet {
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_digest,
-				StreamAttestationEntryOf::<T> {
+				AttestationDetailsOf::<T> {
 					creator: stream_attestations.creator,
 					revoked_by: None,
 					revoked: false,
@@ -453,7 +453,7 @@ pub mod pallet {
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_details.digest,
-				StreamAttestationEntryOf::<T> {
+				AttestationDetailsOf::<T> {
 					creator: stream_attestations.creator,
 					revoked_by: Some(updater.clone()),
 					revoked: true,
@@ -517,7 +517,7 @@ pub mod pallet {
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_details.digest,
-				StreamAttestationEntryOf::<T> {
+				AttestationDetailsOf::<T> {
 					creator: updater.clone(),
 					revoked_by: None,
 					revoked: false,
@@ -638,7 +638,7 @@ pub mod pallet {
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_details.digest,
-				StreamAttestationEntryOf::<T> {
+				AttestationDetailsOf::<T> {
 					creator: creator.clone(),
 					revoked_by: None,
 					revoked: false,

--- a/pallets/stream/src/lib.rs
+++ b/pallets/stream/src/lib.rs
@@ -67,19 +67,15 @@ pub mod pallet {
 	pub type StreamHashOf<T> = <T as frame_system::Config>::Hash;
 	/// Type of a creator identifier.
 	pub type StreamCreatorIdOf<T> = pallet_registry::RegistryCreatorIdOf<T>;
-	/// Type of a creator identifier.
-	pub type StreamRevokedByIdOf<T> = pallet_registry::RegistryCreatorIdOf<T>;
 
 	/// Hash of the stream.
 	pub type StreamDigestOf<T> = <T as frame_system::Config>::Hash;
 	/// Type of the identitiy.
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 	/// Type for the stream entity
-	pub type StreamEntryOf<T> =
-		StreamEntry<StreamDigestOf<T>, StreamCreatorIdOf<T>, SchemaIdOf, RegistryIdOf>;
+	pub type StreamEntryOf<T> = StreamEntry<StreamDigestOf<T>, SchemaIdOf, RegistryIdOf>;
 	/// Type for the stream digest entity
-	pub type AttestationDetailsOf<T> =
-		AttestationDetails<StreamCreatorIdOf<T>, StreamRevokedByIdOf<T>, StatusOf>;
+	pub type AttestationDetailsOf<T> = AttestationDetails<StreamCreatorIdOf<T>, StatusOf>;
 	/// Type for the stream commits
 	pub type StreamCommitsOf<T> = StreamCommit<
 		StreamCommitActionOf,
@@ -286,7 +282,6 @@ pub mod pallet {
 				&identifier,
 				StreamEntryOf::<T> {
 					digest: stream_digest,
-					creator: creator.clone(),
 					schema: schema_id.clone(),
 					registry: registry_id,
 				},
@@ -295,11 +290,7 @@ pub mod pallet {
 			<Attestations<T>>::insert(
 				&identifier,
 				stream_digest,
-				AttestationDetailsOf::<T> {
-					creator: creator.clone(),
-					revoked_by: None,
-					revoked: false,
-				},
+				AttestationDetailsOf::<T> { creator: creator.clone(), revoked: false },
 			);
 
 			Self::update_commit(
@@ -348,7 +339,7 @@ pub mod pallet {
 			ensure!(stream_details.digest != stream_digest, Error::<T>::StreamAlreadyAnchored);
 			ensure!(!stream_attestations.revoked, Error::<T>::RevokedStream);
 
-			if stream_details.creator != updater {
+			if stream_attestations.creator != updater {
 				let registry_id = pallet_registry::Pallet::<T>::is_a_registry_admin(
 					&authorization,
 					updater.clone(),
@@ -362,33 +353,21 @@ pub mod pallet {
 
 			<Streams<T>>::insert(
 				&stream_id,
-				StreamEntryOf::<T> {
-					digest: stream_digest,
-					creator: updater.clone(),
-					..stream_details
-				},
+				StreamEntryOf::<T> { digest: stream_digest, ..stream_details },
 			);
 
 			// Update the old info saying that got revoked
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_details.digest,
-				AttestationDetailsOf::<T> {
-					creator: stream_attestations.creator.clone(),
-					revoked_by: Some(updater.clone()),
-					revoked: true,
-				},
+				AttestationDetailsOf::<T> { creator: updater.clone(), revoked: true },
 			);
 
 			// Update the new entry with hash to say this is active
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_digest,
-				AttestationDetailsOf::<T> {
-					creator: stream_attestations.creator,
-					revoked_by: None,
-					revoked: false,
-				},
+				AttestationDetailsOf::<T> { creator: updater.clone(), revoked: false },
 			);
 
 			Self::update_commit(
@@ -434,7 +413,7 @@ pub mod pallet {
 			// If it is same digest then it should throw stream anchored error
 			ensure!(!stream_attestations.revoked, Error::<T>::RevokedStream);
 
-			if stream_details.creator != updater {
+			if stream_attestations.creator != updater {
 				let registry_id = pallet_registry::Pallet::<T>::is_a_registry_admin(
 					&authorization,
 					updater.clone(),
@@ -444,20 +423,11 @@ pub mod pallet {
 				ensure!(stream_details.registry == registry_id, Error::<T>::UnauthorizedOperation);
 			}
 
-			<Streams<T>>::insert(
-				&stream_id,
-				StreamEntryOf::<T> { creator: updater.clone(), ..stream_details },
-			);
-
 			// Update the info saying it got revoked
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_details.digest,
-				AttestationDetailsOf::<T> {
-					creator: stream_attestations.creator,
-					revoked_by: Some(updater.clone()),
-					revoked: true,
-				},
+				AttestationDetailsOf::<T> { creator: updater.clone(), revoked: true },
 			);
 
 			Self::update_commit(
@@ -498,7 +468,7 @@ pub mod pallet {
 				.ok_or(Error::<T>::AttestationNotFound)?;
 			ensure!(stream_attestations.revoked, Error::<T>::StreamNotRevoked);
 
-			if stream_details.creator != updater {
+			if stream_attestations.creator != updater {
 				let registry_id = pallet_registry::Pallet::<T>::is_a_registry_admin(
 					&authorization,
 					updater.clone(),
@@ -508,20 +478,11 @@ pub mod pallet {
 				ensure!(stream_details.registry == registry_id, Error::<T>::UnauthorizedOperation);
 			}
 
-			<Streams<T>>::insert(
-				&stream_id,
-				StreamEntryOf::<T> { creator: updater.clone(), ..stream_details },
-			);
-
 			// Update the existing info saying it got activated again (ie, revoked: false)
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_details.digest,
-				AttestationDetailsOf::<T> {
-					creator: updater.clone(),
-					revoked_by: None,
-					revoked: false,
-				},
+				AttestationDetailsOf::<T> { creator: updater.clone(), revoked: false },
 			);
 
 			Self::update_commit(
@@ -558,8 +519,10 @@ pub mod pallet {
 			let updater = <T as Config>::EnsureOrigin::ensure_origin(origin)?.subject();
 
 			let stream_details = <Streams<T>>::get(&stream_id).ok_or(Error::<T>::StreamNotFound)?;
+			let stream_attestations = <Attestations<T>>::get(&stream_id, stream_details.digest)
+				.ok_or(Error::<T>::AttestationNotFound)?;
 
-			if stream_details.creator != updater {
+			if stream_attestations.creator != updater {
 				let registry_id = pallet_registry::Pallet::<T>::is_a_registry_admin(
 					&authorization,
 					updater.clone(),
@@ -621,7 +584,7 @@ pub mod pallet {
 				.ok_or(Error::<T>::AttestationNotFound)?;
 			ensure!(!stream_attestations.revoked, Error::<T>::RevokedStream);
 
-			if stream_details.creator != creator {
+			if stream_attestations.creator != creator {
 				let registry_id = pallet_registry::Pallet::<T>::is_a_delegate(
 					&authorization,
 					creator.clone(),
@@ -638,11 +601,7 @@ pub mod pallet {
 			<Attestations<T>>::insert(
 				&stream_id,
 				stream_details.digest,
-				AttestationDetailsOf::<T> {
-					creator: creator.clone(),
-					revoked_by: None,
-					revoked: false,
-				},
+				AttestationDetailsOf::<T> { creator: creator.clone(), revoked: false },
 			);
 
 			Self::update_commit(

--- a/pallets/stream/src/tests.rs
+++ b/pallets/stream/src/tests.rs
@@ -251,11 +251,15 @@ fn update_stream_should_succed() {
 			&stream_id,
 			StreamEntryOf::<Test> {
 				digest: stream_digest,
-				creator: creator.clone(),
 				schema: Some(schema_id.clone()),
 				registry: registry_id.clone(),
-				revoked: false,
 			},
+		);
+
+		<Attestations<Test>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<Test> { creator: creator.clone(), revoked: false },
 		);
 
 		let stream_update = vec![12u8; 32];
@@ -327,12 +331,16 @@ fn update_should_fail_if_digest_is_same() {
 			&stream_id,
 			StreamEntryOf::<Test> {
 				digest: stream_digest,
-				creator: creator.clone(),
 				schema: Some(schema_id.clone()),
 				registry: registry_id.clone(),
-				revoked: false,
 			},
 		);
+		<Attestations<Test>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<Test> { creator: creator.clone(), revoked: false },
+		);
+
 		assert_err!(
 			Stream::update(
 				DoubleOrigin(author.clone(), delegate.clone()).into(),
@@ -456,11 +464,14 @@ fn update_should_fail_if_stream_is_revoked() {
 			&stream_id,
 			StreamEntryOf::<Test> {
 				digest: stream_digest,
-				creator: creator.clone(),
 				schema: Some(schema_id.clone()),
 				registry: registry_id.clone(),
-				revoked: true,
 			},
+		);
+		<Attestations<Test>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<Test> { creator: creator.clone(), revoked: true },
 		);
 
 		let stream_update = vec![12u8; 32];
@@ -528,12 +539,16 @@ fn revoke_stream_should_succed() {
 			&stream_id,
 			StreamEntryOf::<Test> {
 				digest: stream_digest,
-				creator: creator.clone(),
 				schema: Some(schema_id.clone()),
 				registry: registry_id.clone(),
-				revoked: false,
 			},
 		);
+		<Attestations<Test>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<Test> { creator: creator.clone(), revoked: false },
+		);
+
 		assert_ok!(Stream::revoke(
 			DoubleOrigin(author.clone(), delegate.clone()).into(),
 			stream_id,
@@ -592,12 +607,16 @@ fn remove_stream_should_succed() {
 			&stream_id,
 			StreamEntryOf::<Test> {
 				digest: stream_digest,
-				creator: creator.clone(),
 				schema: Some(schema_id.clone()),
 				registry: registry_id.clone(),
-				revoked: false,
 			},
 		);
+		<Attestations<Test>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<Test> { creator: creator.clone(), revoked: false },
+		);
+
 		assert_ok!(Stream::remove(
 			DoubleOrigin(author.clone(), delegate.clone()).into(),
 			stream_id,
@@ -656,12 +675,16 @@ fn digest_stream_should_succed() {
 			&stream_id,
 			StreamEntryOf::<Test> {
 				digest: stream_digest,
-				creator: creator.clone(),
 				schema: Some(schema_id.clone()),
 				registry: registry_id.clone(),
-				revoked: false,
 			},
 		);
+		<Attestations<Test>>::insert(
+			&stream_id,
+			stream_digest,
+			AttestationDetailsOf::<Test> { creator: creator.clone(), revoked: false },
+		);
+
 		assert_ok!(Stream::digest(
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			stream_id,

--- a/pallets/stream/src/types.rs
+++ b/pallets/stream/src/types.rs
@@ -58,7 +58,7 @@ pub struct StreamEntry<StreamDigestOf, StreamCreatorIdOf, SchemaIdOf, RegistryId
 }
 
 /// An on-chain stream:digest entry mapped to an Identifier:Hash.
-/// `StreamAttestationEntry` is a struct that contains a `StreamCreatorIdOf`,
+/// `AttestationDetails` is a struct that contains a `StreamCreatorIdOf`,
 /// a `StreamCreatorIdOf` (which is used for revoke) and a `StatusOf`.
 ///
 /// Properties:
@@ -70,7 +70,7 @@ pub struct StreamEntry<StreamDigestOf, StreamCreatorIdOf, SchemaIdOf, RegistryId
 #[derive(
 	Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo,
 )]
-pub struct StreamAttestationEntry<StreamCreatorIdOf, StreamRevokedByIdOf, StatusOf> {
+pub struct AttestationDetails<StreamCreatorIdOf, StreamRevokedByIdOf, StatusOf> {
 	/// Stream creator.
 	pub creator: StreamCreatorIdOf,
 	/// Stream revoked by.

--- a/pallets/stream/src/types.rs
+++ b/pallets/stream/src/types.rs
@@ -35,7 +35,7 @@ pub struct Timepoint<BlockNumber> {
 
 /// An on-chain stream entry mapped to an Identifier.
 /// `StreamEntry` is a struct that contains a `StreamDigestOf`, a
-/// `StreamCreatorIdOf`, a `SchemaIdOf`, a `RegistryIdOf`, and a `StatusOf`.
+/// `StreamCreatorIdOf`, a `SchemaIdOf`, and a `RegistryIdOf`.
 ///
 /// Properties:
 ///
@@ -43,12 +43,10 @@ pub struct Timepoint<BlockNumber> {
 /// * `creator`: The account that created the stream.
 /// * `schema`: The schema identifier.
 /// * `registry`: The registry that the stream is associated with.
-/// * `revoked`: This is a boolean flag that indicates whether the stream is
-///   revoked or not.
 #[derive(
 	Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo,
 )]
-pub struct StreamEntry<StreamDigestOf, StreamCreatorIdOf, SchemaIdOf, RegistryIdOf, StatusOf> {
+pub struct StreamEntry<StreamDigestOf, StreamCreatorIdOf, SchemaIdOf, RegistryIdOf> {
 	/// Stream hash.
 	pub digest: StreamDigestOf,
 	/// Stream creator.
@@ -57,6 +55,26 @@ pub struct StreamEntry<StreamDigestOf, StreamCreatorIdOf, SchemaIdOf, RegistryId
 	pub schema: Option<SchemaIdOf>,
 	/// Registry Identifier
 	pub registry: RegistryIdOf,
+}
+
+/// An on-chain stream:digest entry mapped to an Identifier:Hash.
+/// `StreamAttestationEntry` is a struct that contains a `StreamCreatorIdOf`,
+/// a `StreamCreatorIdOf` (which is used for revoke) and a `StatusOf`.
+///
+/// Properties:
+///
+/// * `creator`: The account that created the stream.
+/// * `revoked_by`: The account which revoked the stream.
+/// * `revoked`: This is a boolean flag that indicates whether the stream is
+///   revoked or not.
+#[derive(
+	Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo,
+)]
+pub struct StreamAttestationEntry<StreamCreatorIdOf, StreamRevokedByIdOf, StatusOf> {
+	/// Stream creator.
+	pub creator: StreamCreatorIdOf,
+	/// Stream revoked by.
+	pub revoked_by: Option<StreamRevokedByIdOf>,
 	/// The flag indicating the status of the stream.
 	pub revoked: StatusOf,
 }

--- a/pallets/stream/src/types.rs
+++ b/pallets/stream/src/types.rs
@@ -35,12 +35,11 @@ pub struct Timepoint<BlockNumber> {
 
 /// An on-chain stream entry mapped to an Identifier.
 /// `StreamEntry` is a struct that contains a `StreamDigestOf`, a
-/// `StreamCreatorIdOf`, a `SchemaIdOf`, and a `RegistryIdOf`.
+/// `SchemaIdOf`, and a `RegistryIdOf`.
 ///
 /// Properties:
 ///
 /// * `digest`: The hash of the stream.
-/// * `creator`: The account that created the stream.
 /// * `schema`: The schema identifier.
 /// * `registry`: The registry that the stream is associated with.
 #[derive(
@@ -57,7 +56,7 @@ pub struct StreamEntry<StreamDigestOf, SchemaIdOf, RegistryIdOf> {
 
 /// An on-chain stream:digest entry mapped to an Identifier:Hash.
 /// `AttestationDetails` is a struct that contains a `StreamCreatorIdOf`,
-/// a `StreamCreatorIdOf` (which is used for revoke) and a `StatusOf`.
+/// and a `StatusOf`.
 ///
 /// Properties:
 ///
@@ -69,7 +68,7 @@ pub struct StreamEntry<StreamDigestOf, SchemaIdOf, RegistryIdOf> {
 	Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo,
 )]
 pub struct AttestationDetails<StreamCreatorIdOf, StatusOf> {
-	/// Stream creator.
+	/// Attestation creator.
 	pub creator: StreamCreatorIdOf,
 	/// The flag indicating the status of the stream.
 	pub revoked: StatusOf,

--- a/pallets/stream/src/types.rs
+++ b/pallets/stream/src/types.rs
@@ -46,11 +46,9 @@ pub struct Timepoint<BlockNumber> {
 #[derive(
 	Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo,
 )]
-pub struct StreamEntry<StreamDigestOf, StreamCreatorIdOf, SchemaIdOf, RegistryIdOf> {
+pub struct StreamEntry<StreamDigestOf, SchemaIdOf, RegistryIdOf> {
 	/// Stream hash.
 	pub digest: StreamDigestOf,
-	/// Stream creator.
-	pub creator: StreamCreatorIdOf,
 	/// Schema Identifier
 	pub schema: Option<SchemaIdOf>,
 	/// Registry Identifier
@@ -63,18 +61,16 @@ pub struct StreamEntry<StreamDigestOf, StreamCreatorIdOf, SchemaIdOf, RegistryId
 ///
 /// Properties:
 ///
-/// * `creator`: The account that created the stream.
-/// * `revoked_by`: The account which revoked the stream.
+/// * `creator`: The account that has done the latest operation (creator on
+///   create and update, and account revoking for revoke)
 /// * `revoked`: This is a boolean flag that indicates whether the stream is
 ///   revoked or not.
 #[derive(
 	Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo,
 )]
-pub struct AttestationDetails<StreamCreatorIdOf, StreamRevokedByIdOf, StatusOf> {
+pub struct AttestationDetails<StreamCreatorIdOf, StatusOf> {
 	/// Stream creator.
 	pub creator: StreamCreatorIdOf,
-	/// Stream revoked by.
-	pub revoked_by: Option<StreamRevokedByIdOf>,
 	/// The flag indicating the status of the stream.
 	pub revoked: StatusOf,
 }


### PR DESCRIPTION
This is a sample on adding a doublemap to get the status of given hash / digest.