### PR TITLE
fix: bootstrap.sh: allow re-use-of-nodekeys

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -88,8 +88,9 @@ generate_address() {
 }
 
 generate_node_key() {
-  $cord key generate-node-key >"$OUTPUT_DIR/node$i.key" 2>/dev/null
-
+    if [ ! -e $OUTPUT_DIR/node$i.key ]; then
+	$cord key generate-node-key >"$OUTPUT_DIR/node$i.key" 2>/dev/null
+    fi
   NODE_KEY=$($cord key inspect-node-key --file "$OUTPUT_DIR/node$i.key")
   echo "\"${NODE_KEY}\"," >>$CONFIG_FILE
 }


### PR DESCRIPTION
assuming an admin/script would re-use the directory for same type of network (`sprint/` for sprintnet, `spark/` for sparknet etc), this minor change allows 're-use' of node key, which helps in automating the bootnode option encoding in scripts if someone is automating.