### PR TITLE
tests: Add test for `InvalidIdentifierLength`

### DIFF
--- a/primitives/identifier/src/curi.rs
+++ b/primitives/identifier/src/curi.rs
@@ -190,7 +190,7 @@ impl Ss58Identifier {
 		Ok(Self(
 			Vec::<u8>::from(v.to_base58())
 				.try_into()
-				.map_err(|_| IdentifierError::InvalidIdentifierLength)?,
+				.map_err(|_| IdentifierError::InvalidIdentifier)?,
 		))
 	}
 

--- a/primitives/identifier/src/lib.rs
+++ b/primitives/identifier/src/lib.rs
@@ -36,6 +36,12 @@ use frame_system::pallet_prelude::BlockNumberFor;
 pub use crate::pallet::*;
 use sp_std::vec;
 
+#[cfg(any(feature = "mock", test))]
+pub mod mock;
+
+#[cfg(test)]
+mod tests;
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;

--- a/primitives/identifier/src/mock.rs
+++ b/primitives/identifier/src/mock.rs
@@ -1,0 +1,82 @@
+// This file is part of CORD – https://cord.network
+
+// Copyright (C) Dhiway Networks Pvt. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// CORD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CORD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CORD. If not, see <https://www.gnu.org/licenses/>.
+
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{ConstU32, ConstU64},
+};
+
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
+	BuildStorage, MultiSignature,
+};
+
+type Hash = sp_core::H256;
+type Signature = MultiSignature;
+type AccountPublic = <Signature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+pub(crate) type Block = frame_system::mocking::MockBlock<Test>;
+
+construct_runtime!(
+	pub enum Test {
+		System: frame_system
+	}
+);
+
+parameter_types! {
+	pub const SS58Prefix: u8 = 29;
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Nonce = u64;
+	type Block = Block;
+	type Hash = Hash;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<2>;
+}
+
+#[allow(dead_code)]
+pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
+	let t: sp_runtime::Storage =
+		frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	#[cfg(feature = "runtime-benchmarks")]
+	let keystore = sp_keystore::testing::MemoryKeystore::new();
+	#[cfg(feature = "runtime-benchmarks")]
+	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/primitives/identifier/src/tests.rs
+++ b/primitives/identifier/src/tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+use crate::mock::*;
+use codec::Encode;
+use frame_support::{assert_err, assert_ok};
+
+#[test]
+fn creating_a_invalid_identifier_length_should_fail() {
+	let space1 = [2u8; 1].to_vec();
+	let space2 = [2u8; 50].to_vec();
+	let space3 = [2u8; 30].to_vec();
+
+	new_test_ext().execute_with(|| {
+		assert_err!(
+			Ss58Identifier::create_identifier(&(space1).encode()[..], IdentifierType::Space),
+			IdentifierError::InvalidIdentifierLength
+		);
+		assert_err!(
+			Ss58Identifier::create_identifier(&(space2).encode()[..], IdentifierType::Space),
+			IdentifierError::InvalidIdentifierLength
+		);
+		assert_ok!(Ss58Identifier::create_identifier(
+			&(space3).encode()[..],
+			IdentifierType::Space
+		));
+	});
+}


### PR DESCRIPTION
This PR implements test-case for error-code InvalidIdentifierLength for chain-space pallet.
When Identifier Length < 2 or Identifier Length > 49.

Fixes: https://github.com/dhiway/cord/issues/280
Signed-off-by: Shree Vatsa N [vatsa@dhiway.com](mailto:vatsa@dhiway.com)

[TODO: For this to pass (currently fails even length is below 49) have to change error codes emitted in `primitives/identifier`]