### PR TITLE
feat: chain-space: implement a subspace logic

### DIFF
--- a/pallets/chain-space/src/benchmarking.rs
+++ b/pallets/chain-space/src/benchmarking.rs
@@ -386,6 +386,40 @@ benchmarks! {
 			 assert_last_event::<T>(Event::ApprovalRestore { space: space_id }.into());
 		 }
 
+		subspace_create {
+			 let caller: T::AccountId = account("caller", 0, SEED);
+			 let did: T::SpaceCreatorId = account("did", 0, SEED);
+			 let space = [2u8; 256].to_vec();
+			 let subspace = [5u8; 256].to_vec();
+			 let capacity = 50u64;
+
+			 let space_digest = <T as frame_system::Config>::Hashing::hash(&space.encode()[..]);
+			 let subspace_digest = <T as frame_system::Config>::Hashing::hash(&subspace.encode()[..]);
+			 let id_digest = <T as frame_system::Config>::Hashing::hash(
+				 &[&space_digest.encode()[..], &did.encode()[..]].concat()[..],
+			 );
+			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
+
+			 let sub_id_digest = <T as frame_system::Config>::Hashing::hash(
+				 &[&subspace_digest.encode()[..], &did.encode()[..]].concat()[..],
+			 );
+			 let subspace_id: SpaceIdOf = generate_space_id::<T>(&sub_id_digest);
+
+			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				 &[&subspace_id.encode()[..], &did.encode()[..]].concat()[..],
+			 );
+			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			 let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did);
+
+			 Pallet::<T>::create(origin.clone(), space_digest )?;
+			 Pallet::<T>::approve(RawOrigin::Root.into(), space_id.clone(), capacity )?;
+
+		 }: _<T::RuntimeOrigin>(origin.clone(), subspace_digest, 10u64, space_id.clone())
+		 verify {
+			 assert_last_event::<T>(Event::Create { space: subspace_id, creator: origin, authorization: authorization_id }.into());
+		 }
+
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 
 }

--- a/pallets/chain-space/src/benchmarking.rs
+++ b/pallets/chain-space/src/benchmarking.rs
@@ -410,14 +410,14 @@ benchmarks! {
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
-			 let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did);
+			 let origin =  <T as Config>::EnsureOrigin::generate_origin(caller, did.clone());
 
 			 Pallet::<T>::create(origin.clone(), space_digest )?;
 			 Pallet::<T>::approve(RawOrigin::Root.into(), space_id.clone(), capacity )?;
 
-		 }: _<T::RuntimeOrigin>(origin.clone(), subspace_digest, 10u64, space_id.clone())
+		 }: _<T::RuntimeOrigin>(origin, subspace_digest, 10u64, space_id.clone())
 		 verify {
-			 assert_last_event::<T>(Event::Create { space: subspace_id, creator: origin, authorization: authorization_id }.into());
+			 assert_last_event::<T>(Event::Create { space: subspace_id, creator: did, authorization: authorization_id }.into());
 		 }
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -807,18 +807,18 @@ pub mod pallet {
 
 				// Ensure the new capacity is greater than the current usage
 				ensure!(
-					(parent_details.txn_capacity
-						>= (parent_details.txn_count
-							+ parent_details.txn_reserve + new_txn_capacity
-							- space_details.txn_capacity)),
+					(parent_details.txn_capacity >=
+						(parent_details.txn_count +
+							parent_details.txn_reserve + new_txn_capacity -
+							space_details.txn_capacity)),
 					Error::<T>::CapacityLessThanUsage
 				);
 
 				<Spaces<T>>::insert(
 					&space_details.parent.clone(),
 					SpaceDetailsOf::<T> {
-						txn_reserve: parent_details.txn_reserve - space_details.txn_capacity
-							+ new_txn_capacity,
+						txn_reserve: parent_details.txn_reserve - space_details.txn_capacity +
+							new_txn_capacity,
 						..parent_details.clone()
 					},
 				);
@@ -881,9 +881,8 @@ pub mod pallet {
 			} else {
 				T::ChainSpaceOrigin::ensure_origin(origin)?;
 			}
-			let txn_count: u64 = 0;
 
-			<Spaces<T>>::insert(&space_id, SpaceDetailsOf::<T> { txn_count, ..space_details });
+			<Spaces<T>>::insert(&space_id, SpaceDetailsOf::<T> { txn_count: 0, ..space_details });
 
 			Self::update_activity(&space_id, IdentifierTypeOf::ChainSpace, CallTypeOf::Usage)
 				.map_err(Error::<T>::from)?;
@@ -1016,9 +1015,9 @@ pub mod pallet {
 
 			// Ensure the new capacity is greater than the current usage
 			ensure!(
-				count
-					<= (space_details.txn_capacity
-						- (space_details.txn_count + space_details.txn_reserve)),
+				count <=
+					(space_details.txn_capacity -
+						(space_details.txn_count + space_details.txn_reserve)),
 				Error::<T>::CapacityLimitExceeded
 			);
 

--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -802,18 +802,18 @@ pub mod pallet {
 
 				// Ensure the new capacity is greater than the current usage
 				ensure!(
-					(parent_details.txn_capacity
-						>= (parent_details.txn_count
-							+ parent_details.txn_reserve + new_txn_capacity
-							- space_details.txn_capacity)),
+					(parent_details.txn_capacity >=
+						(parent_details.txn_count +
+							parent_details.txn_reserve + new_txn_capacity -
+							space_details.txn_capacity)),
 					Error::<T>::CapacityLessThanUsage
 				);
 
 				<Spaces<T>>::insert(
 					&space_details.parent.clone(),
 					SpaceDetailsOf::<T> {
-						txn_reserve: parent_details.txn_reserve - space_details.txn_capacity
-							+ new_txn_capacity,
+						txn_reserve: parent_details.txn_reserve - space_details.txn_capacity +
+							new_txn_capacity,
 						..parent_details.clone()
 					},
 				);
@@ -1008,9 +1008,9 @@ pub mod pallet {
 
 			// Ensure the new capacity is greater than the current usage
 			ensure!(
-				count
-					<= (space_details.txn_capacity
-						- (space_details.txn_count + space_details.txn_reserve)),
+				count <=
+					(space_details.txn_capacity -
+						(space_details.txn_count + space_details.txn_reserve)),
 				Error::<T>::CapacityLimitExceeded
 			);
 
@@ -1142,17 +1142,17 @@ pub mod pallet {
 
 			// Ensure the new capacity is greater than the current usage
 			ensure!(
-				(parent_details.txn_capacity
-					>= (parent_details.txn_count + parent_details.txn_reserve + new_txn_capacity
-						- space_details.txn_capacity)),
+				(parent_details.txn_capacity >=
+					(parent_details.txn_count + parent_details.txn_reserve + new_txn_capacity -
+						space_details.txn_capacity)),
 				Error::<T>::CapacityLessThanUsage
 			);
 
 			<Spaces<T>>::insert(
 				&space_details.parent.clone(),
 				SpaceDetailsOf::<T> {
-					txn_reserve: parent_details.txn_reserve - space_details.txn_capacity
-						+ new_txn_capacity,
+					txn_reserve: parent_details.txn_reserve - space_details.txn_capacity +
+						new_txn_capacity,
 					..parent_details.clone()
 				},
 			);

--- a/pallets/chain-space/src/types.rs
+++ b/pallets/chain-space/src/types.rs
@@ -78,13 +78,14 @@ impl Default for Permissions {
 /// - `approved`: Indicates whether the space has been approved by the appropriate governance body.
 /// - `archive`: Indicates whether the space is currently archived.
 #[derive(Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, TypeInfo)]
-pub struct SpaceDetails<SpaceCodeOf, SpaceCreatorOf, StatusOf> {
+pub struct SpaceDetails<SpaceCodeOf, SpaceCreatorOf, StatusOf, SpaceIdOf> {
 	pub code: SpaceCodeOf,
 	pub creator: SpaceCreatorOf,
 	pub txn_capacity: u64,
 	pub txn_count: u64,
 	pub approved: StatusOf,
 	pub archive: StatusOf,
+	pub parent: Option<SpaceIdOf>,
 }
 
 /// Authorization details for a space delegate.

--- a/pallets/chain-space/src/types.rs
+++ b/pallets/chain-space/src/types.rs
@@ -82,10 +82,11 @@ pub struct SpaceDetails<SpaceCodeOf, SpaceCreatorOf, StatusOf, SpaceIdOf> {
 	pub code: SpaceCodeOf,
 	pub creator: SpaceCreatorOf,
 	pub txn_capacity: u64,
+	pub txn_reserve: u64,
 	pub txn_count: u64,
 	pub approved: StatusOf,
 	pub archive: StatusOf,
-	pub parent: Option<SpaceIdOf>,
+	pub parent: SpaceIdOf,
 }
 
 /// Authorization details for a space delegate.

--- a/pallets/chain-space/src/weights.rs
+++ b/pallets/chain-space/src/weights.rs
@@ -61,6 +61,7 @@ pub trait WeightInfo {
 	fn reset_transaction_count() -> Weight;
 	fn approval_revoke() -> Weight;
 	fn approval_restore() -> Weight;
+	fn subspace_create() -> Weight;
 }
 
 /// Weights for `pallet_chain_space` using the CORD node and recommended hardware.
@@ -246,6 +247,20 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
+	/// Storage: `ChainSpace::Spaces` (r:1 w:1)
+	/// Proof: `ChainSpace::Spaces` (`max_values`: None, `max_size`: Some(148), added: 2623, mode: `MaxEncodedLen`)
+	/// Storage: `Identifier::Identifiers` (r:1 w:1)
+	/// Proof: `Identifier::Identifiers` (`max_values`: None, `max_size`: Some(4294967295), added: 2474, mode: `MaxEncodedLen`)
+	fn subspace_create() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `445`
+		//  Estimated: `3613`
+		// Minimum execution time: 21_510_000 picoseconds.
+		Weight::from_parts(28_140_000, 3613)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	
 }
 
 // For backwards compatibility and tests.
@@ -429,5 +444,22 @@ impl WeightInfo for () {
 		Weight::from_parts(21_830_000, 3613)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+	/// Storage: `ChainSpace::Spaces` (r:1 w:1)
+	/// Proof: `ChainSpace::Spaces` (`max_values`: None, `max_size`: Some(148), added: 2623, mode: `MaxEncodedLen`)
+	/// Storage: `Identifier::Identifiers` (r:1 w:1)
+	/// Proof: `Identifier::Identifiers` (`max_values`: None, `max_size`: Some(4294967295), added: 2474, mode: `MaxEncodedLen`)
+	/// Storage: `ChainSpace::Delegates` (r:0 w:1)
+	/// Proof: `ChainSpace::Delegates` (`max_values`: None, `max_size`: Some(320068), added: 322543, mode: `MaxEncodedLen`)
+	/// Storage: `ChainSpace::Authorizations` (r:0 w:1)
+	/// Proof: `ChainSpace::Authorizations` (`max_values`: None, `max_size`: Some(184), added: 2659, mode: `MaxEncodedLen`)
+	fn subspace_create() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `115`
+		//  Estimated: `3613`
+		// Minimum execution time: 27_360_000 picoseconds.
+		Weight::from_parts(28_140_000, 3613)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(4_u64))
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -127,7 +127,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("cord"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9012,
+	spec_version: 9014,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -916,6 +916,15 @@ impl pallet_did::DeriveDidCallAuthorizationVerificationKeyRelationship for Runti
 			RuntimeCall::ChainSpace(pallet_chain_space::Call::restore { .. }) => {
 				Ok(pallet_did::DidVerificationKeyRelationship::Authentication)
 			},
+			RuntimeCall::ChainSpace(pallet_chain_space::Call::subspace_create { .. }) => {
+				Ok(pallet_did::DidVerificationKeyRelationship::Authentication)
+			},
+			RuntimeCall::ChainSpace(pallet_chain_space::Call::update_transaction_capacity { .. }) => {
+				Ok(pallet_did::DidVerificationKeyRelationship::Authentication)
+			},
+			RuntimeCall::ChainSpace(pallet_chain_space::Call::update_transaction_capacity_sub { .. }) => {
+				Ok(pallet_did::DidVerificationKeyRelationship::Authentication)
+			},
 			RuntimeCall::Utility(pallet_utility::Call::batch { calls }) => {
 				single_key_relationship(&calls[..])
 			},

--- a/runtime/src/weights/pallet_chain_space.rs
+++ b/runtime/src/weights/pallet_chain_space.rs
@@ -241,4 +241,22 @@ impl<T: frame_system::Config> pallet_chain_space::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
+	/// Storage: `ChainSpace::Spaces` (r:1 w:1)
+	/// Proof: `ChainSpace::Spaces` (`max_values`: None, `max_size`: Some(148), added: 2623, mode: `MaxEncodedLen`)
+	/// Storage: `Identifier::Identifiers` (r:1 w:1)
+	/// Proof: `Identifier::Identifiers` (`max_values`: None, `max_size`: Some(4294967295), added: 2474, mode: `MaxEncodedLen`)
+	/// Storage: `ChainSpace::Delegates` (r:0 w:1)
+	/// Proof: `ChainSpace::Delegates` (`max_values`: None, `max_size`: Some(320068), added: 322543, mode: `MaxEncodedLen`)
+	/// Storage: `ChainSpace::Authorizations` (r:0 w:1)
+	/// Proof: `ChainSpace::Authorizations` (`max_values`: None, `max_size`: Some(184), added: 2659, mode: `MaxEncodedLen`)
+	fn subspace_create() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `115`
+		//  Estimated: `3613`
+		// Minimum execution time: 27_200_000 picoseconds.
+		Weight::from_parts(27_760_000, 0)
+			.saturating_add(Weight::from_parts(0, 3613))
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(4))
+	}
 }


### PR DESCRIPTION
chain-space pallet is designed to handle delegate management and also number of transactions (approved from the council). This way, we always endup with a proper authorization as the way to write to chain, and manage multiple usecases / projects with the same DID for an entity. 

This allows entities (legal-person (ie, humans, orgs, councils, etc)) to keep same Identity on chain and manage multiple usecases, thus solving ACL related issues on chain.

One of the limitation of having council approve all the chain-space count is, it becomes un-manageable. With this subspace concept, the governance council can only approve each nodes (or possible network-members) with a space, and give say N Million transaction capability on the chain, and later, each of the creator of these spaces can continue to carve out usecase specific spaces from the same.
