### PR TITLE
GH-Workflow: Update 'checkout' & 'cache' actions to `node 20` version.

### DIFF
--- a/.github/workflows/ci-on-pr-rustfmt-test-clippy-build.yml
+++ b/.github/workflows/ci-on-pr-rustfmt-test-clippy-build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libssl-dev
@@ -36,7 +36,7 @@ jobs:
         run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
 
       - name: cache rust toolchain and dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/
@@ -52,13 +52,13 @@ jobs:
     needs: rustfmt
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libssl-dev
 
       - name: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/
@@ -74,13 +74,13 @@ jobs:
     needs: rustfmt
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libssl-dev
 
       - name: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/
@@ -96,20 +96,18 @@ jobs:
   #   needs: rustfmt
   #   steps:
   #     - name: checkout repository
-  #       uses: actions/checkout@v3
-
+  #       uses: actions/checkout@v4.1.1
   #     - name: install dependencies
   #       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libssl-dev
 
   #     - name: cache
-  #       uses: actions/cache@v3
+  #       uses: actions/cache@v4
   #       with:
   #         path: |
   #           ~/.cargo/
   #           target/
   #         key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
   #         restore-keys: ${{ runner.os }}-rust-
-
   #     - name: cargo build
   #       run: rustup component add rust-src && cargo build --locked
 

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
 
       - name: Install dependencies
         run: sudo apt-get update -y && sudo apt-get install -y protobuf-compiler libssl-dev
 
       - name: Setup Cargo cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Runner info
         run: |


### PR DESCRIPTION
CORD's CI was using `node 16` version, hence we were having warnings in workflows.
- Change `checkout` from v3 to v4.1.1 .
- Change `cache` from v3 to v4 .

Signed-off-by: Shreeevatsa N <vatsa@dhiway.com>