### PR TITLE
primitives/identifier: Optimize encoding to base58 and decoding to binary

### DIFF
--- a/.github/workflows/ci-on-pr-rustfmt-test-clippy-build.yml
+++ b/.github/workflows/ci-on-pr-rustfmt-test-clippy-build.yml
@@ -67,7 +67,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rust-
 
       - name: cargo test
-        run: rustup component add rust-src && cargo test --release --all --all-targets --locked --features=runtime-benchmarks --no-fail-fast --verbose --color always
+        run: rustup component add rust-src && cargo test --release --all --all-targets --features=runtime-benchmarks --no-fail-fast --verbose --color always
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,12 +753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base58"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,8 +1503,8 @@ dependencies = [
 name = "cord-identifier"
 version = "0.9.1"
 dependencies = [
- "base58",
  "blake2-rfc",
+ "bs58 0.5.0",
  "cord-primitives",
  "cord-utilities",
  "frame-benchmarking",

--- a/primitives/identifier/Cargo.toml
+++ b/primitives/identifier/Cargo.toml
@@ -36,7 +36,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 scale-info = { version = "2.10.0", default-features = false, features = [
 	"derive",
 ] }
-bs58 = "0.5.0"
+bs58 = { version = "0.5.0", default-features = false }
 blake2-rfc = { version = "0.2.18", default-features = false }
 cord-primitives = { package = "cord-primitives", path = "../cord", default-features = false }
 cord-utilities = { package = "cord-utilities", path = "../../utilities", default-features = false }
@@ -73,6 +73,7 @@ std = [
 	"sp-io/std",
 	"sp-std/std",
 	"sp-keystore/std",
+	"bs58/std",
 ]
 
 try-runtime = [

--- a/primitives/identifier/Cargo.toml
+++ b/primitives/identifier/Cargo.toml
@@ -36,7 +36,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 scale-info = { version = "2.10.0", default-features = false, features = [
 	"derive",
 ] }
-base58 = "0.2.0"
+bs58 = "0.5.0"
 blake2-rfc = { version = "0.2.18", default-features = false }
 cord-primitives = { package = "cord-primitives", path = "../cord", default-features = false }
 cord-utilities = { package = "cord-utilities", path = "../../utilities", default-features = false }

--- a/primitives/identifier/src/curi.rs
+++ b/primitives/identifier/src/curi.rs
@@ -20,7 +20,6 @@
 
 use crate::*;
 use blake2_rfc::blake2b::{Blake2b, Blake2bResult};
-use bs58::{decode, encode};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{ensure, sp_runtime::RuntimeDebug, traits::ConstU32, BoundedVec};
 use scale_info::TypeInfo;
@@ -188,7 +187,7 @@ impl Ss58Identifier {
 		v.extend(&r.as_bytes()[0..2]);
 
 		Ok(Self(
-			Vec::<u8>::from(encode(v).into_string())
+			Vec::<u8>::from(bs58::encode(v).into_string())
 				.try_into()
 				.map_err(|_| IdentifierError::InvalidIdentifier)?,
 		))
@@ -201,9 +200,10 @@ impl Ss58Identifier {
 	pub fn get_identifier_type(&self) -> Result<u16, IdentifierError> {
 		let identifier =
 			str::from_utf8(self.inner()).map_err(|_| IdentifierError::InvalidFormat)?;
-		// let data = identifier.from_base58().map_err(|_| IdentifierError::InvalidIdentifier)?;
 
-		let data = decode(identifier).into_vec().map_err(|_| IdentifierError::InvalidIdentifier)?;
+		let data = bs58::decode(identifier)
+			.into_vec()
+			.map_err(|_| IdentifierError::InvalidIdentifier)?;
 
 		if data.len() < 2 {
 			return Err(IdentifierError::InvalidIdentifierLength);
@@ -228,7 +228,7 @@ impl Ss58Identifier {
 	}
 
 	pub fn default_error() -> Self {
-		let error_value_base58 = encode([0]).into_string();
+		let error_value_base58 = bs58::encode([0]).into_string();
 
 		// Convert the Base58 encoded string to a byte vector.
 		let error_value_bytes = error_value_base58.into_bytes();

--- a/primitives/identifier/src/curi.rs
+++ b/primitives/identifier/src/curi.rs
@@ -19,8 +19,8 @@
 #![allow(clippy::unused_unit)]
 
 use crate::*;
-use base58::{FromBase58, ToBase58};
 use blake2_rfc::blake2b::{Blake2b, Blake2bResult};
+use bs58::{decode, encode};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{ensure, sp_runtime::RuntimeDebug, traits::ConstU32, BoundedVec};
 use scale_info::TypeInfo;
@@ -188,7 +188,7 @@ impl Ss58Identifier {
 		v.extend(&r.as_bytes()[0..2]);
 
 		Ok(Self(
-			Vec::<u8>::from(v.to_base58())
+			Vec::<u8>::from(encode(v).into_string())
 				.try_into()
 				.map_err(|_| IdentifierError::InvalidIdentifier)?,
 		))
@@ -201,7 +201,9 @@ impl Ss58Identifier {
 	pub fn get_identifier_type(&self) -> Result<u16, IdentifierError> {
 		let identifier =
 			str::from_utf8(self.inner()).map_err(|_| IdentifierError::InvalidFormat)?;
-		let data = identifier.from_base58().map_err(|_| IdentifierError::InvalidIdentifier)?;
+		// let data = identifier.from_base58().map_err(|_| IdentifierError::InvalidIdentifier)?;
+
+		let data = decode(identifier).into_vec().map_err(|_| IdentifierError::InvalidIdentifier)?;
 
 		if data.len() < 2 {
 			return Err(IdentifierError::InvalidIdentifierLength);
@@ -226,7 +228,7 @@ impl Ss58Identifier {
 	}
 
 	pub fn default_error() -> Self {
-		let error_value_base58 = [0].to_base58();
+		let error_value_base58 = encode([0]).into_string();
 
 		// Convert the Base58 encoded string to a byte vector.
 		let error_value_bytes = error_value_base58.into_bytes();


### PR DESCRIPTION
This PR retires usage of `base58` crate, which has been archived since 2021.
Newer maintained crate `bs58` is replaced against it instead.

Claims from [`bs58`](https://crates.io/crates/bs58) crate.

```
Compared to base58 this is significantly faster at decoding (about 2.4x as fast when decoding 32 bytes),
almost the same speed for encoding (about 3% slower when encoding 32 bytes),
doesn't have the 128 byte limitation and supports a configurable alphabet.
```


Tested with `CORD` pre-pr checks and `yarn demo-*` of `CORD.JS`