### PR TITLE
Chain-Space: Add tests for SpaceDelegatesLimitExceeded

### DIFF
--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -1105,16 +1105,13 @@ fn add_delegate_should_fail_if_space_delegates_limit_exceeded() {
 
 		// Add the maximum number of delegates to the space
 		let mut delegate_count: u8 = 0;
-		loop {
-			match Space::space_delegate_addition(
-				space_id.clone(),
-				SubjectId(AccountId32::new([delegate_count; 32])),
-				creator.clone(),
-				Permissions::all(),
-			) {
-				Ok(_) => delegate_count += 1,
-				Err(_) => break,
-			}
+		while let Ok(_) = Space::space_delegate_addition(
+			space_id.clone(),
+			SubjectId(AccountId32::new([delegate_count; 32])),
+			creator.clone(),
+			Permissions::all(),
+		) {
+			delegate_count += 1;
 		}
 
 		// Attempt to add one more delegate, which should exceed the limit and result in the

--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -1104,14 +1104,13 @@ fn add_delegate_should_fail_if_space_delegates_limit_exceeded() {
 		));
 
 		// Add the maximum number of delegates to the space
-		let mut delegate_count: u8 = 0;
-		while let Ok(_) = Space::space_delegate_addition(
-			space_id.clone(),
-			SubjectId(AccountId32::new([delegate_count; 32])),
-			creator.clone(),
-			Permissions::all(),
-		) {
-			delegate_count += 1;
+		for delegate_count in 0..4 {
+			assert_ok!(Space::space_delegate_addition(
+				space_id.clone(),
+				SubjectId(AccountId32::new([delegate_count; 32])),
+				creator.clone(),
+				Permissions::all(),
+			));
 		}
 
 		// Attempt to add one more delegate, which should exceed the limit and result in the
@@ -1119,7 +1118,7 @@ fn add_delegate_should_fail_if_space_delegates_limit_exceeded() {
 		assert_err!(
 			Space::space_delegate_addition(
 				space_id.clone(),
-				SubjectId(AccountId32::new([delegate_count; 32])),
+				SubjectId(AccountId32::new([4u8; 32])),
 				creator.clone(),
 				Permissions::all(),
 			),

--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -1117,7 +1117,8 @@ fn add_delegate_should_fail_if_space_delegates_limit_exceeded() {
 			}
 		}
 
-		// Attempt to add one more delegate, which should exceed the limit and result in the expected error
+		// Attempt to add one more delegate, which should exceed the limit and result in the
+		// expected error
 		assert_err!(
 			Space::space_delegate_addition(
 				space_id.clone(),


### PR DESCRIPTION
Fixes #281 

Details:
Two functions return this error code, namely `Space::create` and `Space::space_delegate_addition`. Used these two for this test. 