### PR TITLE
Statement: Add tests for StatementAlreadyAnchored

### DIFF
--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -878,3 +878,72 @@ fn trying_to_restore_a_revoked_statement_by_a_non_delegate_should_fail() {
 		);
 	});
 }
+
+#[test]
+fn registering_a_statement_again_should_fail() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let delegate = DID_01;
+	let capacity = 5u64;
+	let statement = [77u8; 32];
+	let statement_digest = <Test as frame_system::Config>::Hashing::hash(&statement[..]);
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id.clone(), capacity));
+
+		assert_ok!(Schema::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			schema.clone(),
+			authorization_id.clone()
+		));
+
+		assert_ok!(Space::add_delegate(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_id,
+			delegate.clone(),
+			authorization_id.clone(),
+		));
+
+		assert_ok!(Statement::register(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			statement_digest,
+			authorization_id.clone(),
+			Some(schema_id.clone())
+		));
+
+		assert_err!(
+			Statement::register(
+				DoubleOrigin(author, creator).into(),
+				statement_digest,
+				authorization_id,
+				Some(schema_id)
+			),
+			Error::<Test>::StatementAlreadyAnchored
+		);
+	});
+}


### PR DESCRIPTION
Fixes: #313 

Description:
This test checks functioning of the `StatementAlreadyAnchored` error-code by calling the `register` function on the same statement digest, space identifier, and creator identifier (which is used to create a unique identifier that if found used before throws `StatementAlreadyAnchored` error).