### PR TITLE
pallet/asset: Dependency update to generate weights to Asset

### DIFF
--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-asset"
-description = "Experimentatl pallet for benchmarks"
+description = "Manage Asset"
 version = "0.9.1-dev"
 authors.workspace = true
 edition.workspace = true
@@ -69,7 +69,7 @@ std = [
 	"identifier/std",
 	"frame-support/std",
 	"frame-system/std",
-	"frame-benchmarking?/std",
+	"frame-benchmarking/std",
 	"cord-primitives/std",
 	"cord-utilities/std",
 	"pallet-balances/std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -244,6 +244,7 @@ runtime-benchmarks = [
 	"pallet-sudo/runtime-benchmarks",
 	"frame-system-benchmarking/runtime-benchmarks",
 	"pallet-network-score/runtime-benchmarks",
+	"pallet-asset/runtime-benchmarks",
 ]
 
 try-runtime = [

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -869,7 +869,7 @@ construct_runtime! (
 		Statement: pallet_statement = 105,
 		DidName: pallet_did_name = 106,
 		NetworkScore: pallet_network_score = 108,
-		Asset: pallet_asset =109,
+		Asset: pallet_asset = 109,
 		Sudo: pallet_sudo = 255,
 	}
 );
@@ -1036,6 +1036,7 @@ mod benches {
 		[pallet_network_membership, NetworkMembership]
 		[pallet_network_score, NetworkScore]
 		[pallet_sudo, Sudo]
+		[pallet_asset, Asset]
 	);
 }
 

--- a/scripts/run_benches_for_pallets.sh
+++ b/scripts/run_benches_for_pallets.sh
@@ -69,6 +69,7 @@ PALLETS=(
   "pallet_network_score"
   "pallet_schema"
   "pallet_statement"
+  "pallet_asset"
 )
 
 echo "[+] Benchmarking ${#PALLETS[@]} pallets."
@@ -118,6 +119,9 @@ for PALLET in "${PALLETS[@]}"; do
     ;;
   pallet_statement)
     FOLDER="statement"
+    ;;
+  pallet_asset)
+    FOLDER="asset"
     ;;
 
   *)


### PR DESCRIPTION
With these changes, it is now possible to generate weights to `asset` and integrate them to the pallet.

To generate weights for asset,
```
./target/production/cord benchmark pallet --chain=dev --steps=50 --repeat=20 \
--pallet=pallet_asset --extrinsic='*' --wasm-execution=compiled --heap-pages=4096 \
--output=./pallets/asset/src/weights.rs --header=./HEADER-GPL3 --template=./.maintain/frame-weight-template.hbs;
```

Signed-off-by: Shreevatsa N <vatsa@dhiway.com>