### PR TITLE
Statement: Add test for StatementDigestAlreadyAnchored

### DIFF
--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -947,3 +947,85 @@ fn registering_a_statement_again_should_fail() {
 		);
 	});
 }
+
+#[test]
+fn updating_a_registered_statement_again_should_fail() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let delegate = DID_01;
+	let capacity = 10u64;
+	let statement = [77u8; 32];
+	let statement_digest = <Test as frame_system::Config>::Hashing::hash(&statement[..]);
+	let new_statement = [88u8; 32];
+	let new_statement_digest = <Test as frame_system::Config>::Hashing::hash(&new_statement[..]);
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let statement_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&statement_digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let statement_id: StatementIdOf = generate_statement_id::<Test>(&statement_id_digest);
+
+	let delegate_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &delegate.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let delegate_authorization_id = generate_authorization_id::<Test>(&delegate_id_digest);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id.clone(), capacity));
+
+		assert_ok!(Schema::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			schema.clone(),
+			authorization_id.clone()
+		));
+
+		assert_ok!(Statement::register(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			statement_digest,
+			authorization_id.clone(),
+			Some(schema_id)
+		));
+
+		assert_ok!(Statement::update(
+			DoubleOrigin(author.clone(), delegate.clone()).into(),
+			statement_id.clone(),
+			new_statement_digest,
+			delegate_authorization_id.clone(),
+		));
+
+		assert_err!(
+			Statement::update(
+				DoubleOrigin(author, delegate).into(),
+				statement_id,
+				new_statement_digest,
+				delegate_authorization_id,
+			),
+			Error::<Test>::StatementDigestAlreadyAnchored
+		);
+	});
+}


### PR DESCRIPTION
Fixes #320 

Description:
This test checks functioning of the `StatementDigestAlreadyAnchored` error-code by calling the `update` function on a statement with the same digest.