### PR TITLE
Revert "did: remove the did counter check for did_submit_call() (#355)"

### DIFF
--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -1182,7 +1182,6 @@ pub mod pallet {
 				.ok_or(StorageError::NotFound(errors::NotFoundKind::Did))?;
 
 			Self::validate_counter_value(operation.tx_counter, &did_details)?;
-
 			// Increase the tx counter as soon as it is considered valid, no matter if the
 			// signature is valid or not.
 			did_details.increase_tx_counter();
@@ -1253,22 +1252,17 @@ pub mod pallet {
 		/// we do not have yet any mechanism in place to wrap the counter value
 		/// around when the limit is reached.
 		fn validate_counter_value(
-			_counter: u64,
-			_did_details: &DidDetails<T>,
+			counter: u64,
+			did_details: &DidDetails<T>,
 		) -> Result<(), DidError> {
 			// Verify that the operation counter is equal to the stored one + 1,
 			// possibly wrapping around when u64::MAX is reached.
-
-			// TODO: With agency model this nonce check would cause a problem when we get
-			// to utility batch etc. Re-enable this once we have better control of nonce
-			// check in utility methods.
-			/*
 			let expected_nonce_value = did_details.last_tx_counter.wrapping_add(1);
 			ensure!(
 				counter == expected_nonce_value,
 				DidError::Signature(SignatureError::InvalidNonce)
 			);
-			*/
+
 			Ok(())
 		}
 

--- a/pallets/did/src/tests.rs
+++ b/pallets/did/src/tests.rs
@@ -2044,7 +2044,6 @@ fn check_did_not_found_call_error() {
 	});
 }
 
-/*
 #[test]
 fn check_too_small_tx_counter_after_wrap_call_error() {
 	let auth_key = get_sr25519_authentication_key(&AUTH_SEED_0);
@@ -2075,9 +2074,7 @@ fn check_too_small_tx_counter_after_wrap_call_error() {
 		);
 	});
 }
-*/
 
-/*
 #[test]
 fn check_too_small_tx_counter_call_error() {
 	let auth_key = get_sr25519_authentication_key(&AUTH_SEED_0);
@@ -2107,9 +2104,7 @@ fn check_too_small_tx_counter_call_error() {
 		);
 	});
 }
-*/
 
-/*
 #[test]
 fn check_equal_tx_counter_call_error() {
 	let auth_key = get_sr25519_authentication_key(&AUTH_SEED_0);
@@ -2137,9 +2132,7 @@ fn check_equal_tx_counter_call_error() {
 		);
 	});
 }
-*/
 
-/*
 #[test]
 fn check_too_large_tx_counter_call_error() {
 	let auth_key = get_sr25519_authentication_key(&AUTH_SEED_0);
@@ -2167,7 +2160,6 @@ fn check_too_large_tx_counter_call_error() {
 		);
 	});
 }
-*/
 /* TODO: fix it - BadOrigin for submit_did_call
 #[test]
 fn check_tx_block_number_too_low_error() {
@@ -2712,7 +2704,6 @@ fn check_tx_counter_wrap_operation_verification() {
 	});
 }
 
-/*
 #[test]
 fn check_smaller_counter_operation_verification() {
 	let auth_key = get_ed25519_authentication_key(&AUTH_SEED_0);
@@ -2741,9 +2732,7 @@ fn check_smaller_counter_operation_verification() {
 		);
 	});
 }
-*/
 
-/*
 #[test]
 fn check_equal_counter_operation_verification() {
 	let auth_key = get_ed25519_authentication_key(&AUTH_SEED_0);
@@ -2770,9 +2759,7 @@ fn check_equal_counter_operation_verification() {
 		);
 	});
 }
-*/
 
-/*
 #[test]
 fn check_too_large_counter_operation_verification() {
 	let auth_key = get_ed25519_authentication_key(&AUTH_SEED_0);
@@ -2799,7 +2786,6 @@ fn check_too_large_counter_operation_verification() {
 		);
 	});
 }
-*/
 
 #[test]
 fn check_verification_key_not_present_operation_verification() {


### PR DESCRIPTION
This reverts commit 2a8c5259e762c6452b1171fb522458b4e3836dcc.

Without this logic, it is much easier to do the replay attacks on the chain. More info on #355.