### PR TITLE
Issue318 add test presentation digest already anchored

### DIFF
--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -1062,42 +1062,42 @@ fn adding_duplicate_presentation_should_fail() {
 
 	let statement_id: StatementIdOf = generate_statement_id::<Test>(&statement_id_digest);
 
-    let presentation = [88u8; 32];
-    let presentation_digest = <Test as frame_system::Config>::Hashing::hash(&presentation[..]);
-    let presentation_type = PresentationTypeOf::Other; // Adjust this to the correct variant
+	let presentation = [88u8; 32];
+	let presentation_digest = <Test as frame_system::Config>::Hashing::hash(&presentation[..]);
+	let presentation_type = PresentationTypeOf::Other; // Adjust this to the correct variant
 
-    new_test_ext().execute_with(|| {
-        assert_ok!(Space::create(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            space_digest,
-        ));
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
 
 		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id.clone(), capacity));
 
-        assert_ok!(Statement::register(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            statement_digest,
-            authorization_id.clone(),
-            None,
-        ));
+		assert_ok!(Statement::register(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			statement_digest,
+			authorization_id.clone(),
+			None,
+		));
 
-        assert_ok!(Statement::add_presentation(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            statement_id.clone(), // Use the generated statement_id
-            presentation_digest,
-            presentation_type,
-            authorization_id.clone(),
-        ));
+		assert_ok!(Statement::add_presentation(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			statement_id.clone(), // Use the generated statement_id
+			presentation_digest,
+			presentation_type,
+			authorization_id.clone(),
+		));
 
-        assert_err!(
-            Statement::add_presentation(
-                DoubleOrigin(author, creator).into(),
-                statement_id, // Use the generated statement_id
-                presentation_digest,
+		assert_err!(
+			Statement::add_presentation(
+				DoubleOrigin(author, creator).into(),
+				statement_id, // Use the generated statement_id
+				presentation_digest,
 				presentation_type,
-                authorization_id,
-            ),
+				authorization_id,
+			),
 			Error::<Test>::PresentationDigestAlreadyAnchored
-        );
-    });
+		);
+	});
 }

--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -1024,3 +1024,80 @@ fn updating_a_registered_statement_again_should_fail() {
 		);
 	});
 }
+
+#[test]
+fn adding_duplicate_presentation_should_fail() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+	let statement = [77u8; 32];
+	let statement_digest: StatementDigestOf<Test> =
+		<Test as frame_system::Config>::Hashing::hash(&statement[..]);
+	let new_statement = [88u8; 32];
+	let new_statement_digest = <Test as frame_system::Config>::Hashing::hash(&new_statement[..]);
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let statement_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&statement_digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let statement_id: StatementIdOf = generate_statement_id::<Test>(&statement_id_digest);
+
+    let presentation = [88u8; 32];
+    let presentation_digest = <Test as frame_system::Config>::Hashing::hash(&presentation[..]);
+    let presentation_type = PresentationTypeOf::Other; // Adjust this to the correct variant
+
+    new_test_ext().execute_with(|| {
+        assert_ok!(Space::create(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            space_digest,
+        ));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id.clone(), capacity));
+
+        assert_ok!(Statement::register(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            statement_digest,
+            authorization_id.clone(),
+            None,
+        ));
+
+        assert_ok!(Statement::add_presentation(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            statement_id.clone(), // Use the generated statement_id
+            presentation_digest,
+            presentation_type,
+            authorization_id.clone(),
+        ));
+
+        assert_err!(
+            Statement::add_presentation(
+                DoubleOrigin(author, creator).into(),
+                statement_id, // Use the generated statement_id
+                presentation_digest,
+				presentation_type,
+                authorization_id,
+            ),
+			Error::<Test>::PresentationDigestAlreadyAnchored
+        );
+    });
+}


### PR DESCRIPTION
Fixes #318 

Add test to validate ```PresentationDigestAlreadyAnchored``` error in ```add_presentation``` call