### PR TITLE
pallet/asset: New asset extrinsic methods for VC

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -65,10 +65,7 @@ pub mod pallet {
 	pub type AssetCreatorOf<T> = pallet_chain_space::SpaceCreatorOf<T>;
 	/// Type of the identitiy.
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
-
-	/// Hash of the Rating.
-	//pub type EntryHashOf<T> = <T as frame_system::Config>::Hash;
-
+	/// Type of Asset quantity.
 	pub type AssetQtyOf = u64;
 
 	pub type AssetDescriptionOf<T> = BoundedVec<u8, <T as Config>::MaxEncodedValueLength>;
@@ -77,8 +74,6 @@ pub mod pallet {
 
 	pub type AssetInputEntryOf<T> =
 		AssetInputEntry<AssetDescriptionOf<T>, AssetTypeOf, AssetTagOf<T>, AssetMetadataOf<T>>;
-
-	pub type VCAssetInputEntryOf = VCAssetInputEntry;
 
 	pub type AssetEntryOf<T> = AssetEntry<
 		AssetDescriptionOf<T>,
@@ -138,17 +133,18 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
-	/// asset entry identifiers with  details stored on chain.
+	/// asset entry identifiers with details stored on chain.
 	#[pallet::storage]
 	#[pallet::getter(fn assets)]
 	pub type Assets<T> = StorageMap<_, Blake2_128Concat, AssetIdOf, AssetEntryOf<T>, OptionQuery>;
 
+	/// asset vc entry idenitfiers with details stored on chain.
 	#[pallet::storage]
 	#[pallet::getter(fn vc_assets)]
 	pub type VCAssets<T> =
 		StorageMap<_, Blake2_128Concat, AssetIdOf, VCAssetEntryOf<T>, OptionQuery>;
 
-	/// asset entry identifiers with  details stored on chain.
+	/// asset entry identifiers with details stored on chain.
 	#[pallet::storage]
 	#[pallet::getter(fn distribution)]
 	pub type Distribution<T: Config> = StorageMap<
@@ -172,6 +168,7 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
+	/// asset vc entry identifiers with details stored on chain.
 	#[pallet::storage]
 	#[pallet::getter(fn vc_issued)]
 	pub type VCIssuance<T> = StorageDoubleMap<
@@ -487,8 +484,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		#[pallet::call_index(4)]
 		// TODO: Set actual weights
+		#[pallet::call_index(4)]
 		#[pallet::weight({0})]
 		pub fn vc_create(
 			origin: OriginFor<T>,

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -24,7 +24,14 @@ pub fn generate_asset_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetIdOf {
 	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Asset).unwrap()
 }
 
+/// Generates a asset instance ID from a digest
+pub fn generate_asset_instance_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetInstanceIdOf {
+	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::AssetInstance)
+		.unwrap()
+}
+
 pub(crate) const DID_00: SubjectId = SubjectId(AccountId32::new([1u8; 32]));
+pub(crate) const DID_01: SubjectId = SubjectId(AccountId32::new([1u8; 32]));
 pub(crate) const ACCOUNT_00: AccountId = AccountId::new([1u8; 32]);
 
 #[test]
@@ -281,6 +288,210 @@ fn asset_vc_issue_should_succeed() {
 			issue_entry.clone(),
 			issue_entry_digest,
 			authorization_id
+		));
+	});
+}
+
+#[test]
+fn asset_vc_transfer_should_succeed() {
+	let creator = DID_00;
+	let new_owner = DID_01;
+
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+	let issue_entry = AssetIssuanceEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_owner: creator.clone(),
+		asset_issuance_qty: Some(10),
+	};
+
+	let issue_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&issue_entry.encode()[..]].concat()[..]);
+
+	let instance_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&asset_id.encode()[..],
+			&creator.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+			&issue_entry_digest.encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let instance_id = generate_asset_instance_id::<Test>(&instance_id_digest);
+
+	let transfer_entry = AssetTransferEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_instance_id: instance_id.clone(),
+		asset_owner: creator.clone(),
+		new_asset_owner: new_owner.clone(),
+	};
+
+	let transfer_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&transfer_entry.encode()[..]].concat()[..]);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_ok!(Asset::vc_issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			authorization_id
+		));
+
+		assert_ok!(Asset::vc_transfer(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			transfer_entry.clone(),
+			transfer_entry_digest.clone(),
+		));
+	});
+}
+
+#[test]
+fn asset_vc_status_change_should_succeed() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+	let issue_entry = AssetIssuanceEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_owner: creator.clone(),
+		asset_issuance_qty: Some(10),
+	};
+
+	let issue_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&issue_entry.encode()[..]].concat()[..]);
+
+	let instance_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&asset_id.encode()[..],
+			&creator.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+			&issue_entry_digest.encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let instance_id = generate_asset_instance_id::<Test>(&instance_id_digest);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_ok!(Asset::vc_issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			authorization_id
+		));
+
+		assert_ok!(Asset::vc_status_change(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_id.clone(),
+			Some(instance_id.clone()),
+			AssetStatusOf::INACTIVE
 		));
 	});
 }

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -394,7 +394,7 @@ fn asset_vc_transfer_should_succeed() {
 		assert_ok!(Asset::vc_transfer(
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			transfer_entry.clone(),
-			transfer_entry_digest.clone(),
+			transfer_entry_digest,
 		));
 	});
 }

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -88,59 +88,6 @@ fn asset_create_should_succeed() {
 }
 
 #[test]
-fn asset_vc_create_should_succeed() {
-	let creator = DID_00;
-	let author = ACCOUNT_00;
-	let capacity = 5u64;
-
-	let raw_space = [2u8; 256].to_vec();
-	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
-	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
-	);
-	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
-
-	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
-	);
-	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
-
-	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
-	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
-	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
-	let asset_qty = 10;
-	let asset_value = 10;
-	let asset_type = AssetTypeOf::MF;
-
-	let entry = AssetInputEntryOf::<Test> {
-		asset_desc,
-		asset_qty,
-		asset_type,
-		asset_value,
-		asset_tag,
-		asset_meta,
-	};
-
-	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
-
-	new_test_ext().execute_with(|| {
-		assert_ok!(Space::create(
-			DoubleOrigin(author.clone(), creator.clone()).into(),
-			space_digest,
-		));
-
-		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
-
-		assert_ok!(Asset::vc_create(
-			DoubleOrigin(author.clone(), creator.clone()).into(),
-			asset_qty,
-			digest,
-			authorization_id
-		));
-	});
-}
-
-#[test]
 fn asset_issue_should_succeed() {
 	let creator = DID_00;
 	let author = ACCOUNT_00;
@@ -211,6 +158,59 @@ fn asset_issue_should_succeed() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			issue_entry.clone(),
 			issue_entry_digest,
+			authorization_id
+		));
+	});
+}
+
+#[test]
+fn asset_vc_create_should_succeed() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
 			authorization_id
 		));
 	});

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -81,6 +81,59 @@ fn asset_create_should_succeed() {
 }
 
 #[test]
+fn asset_vc_create_should_succeed() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
+			authorization_id
+		));
+	});
+}
+
+#[test]
 fn asset_issue_should_succeed() {
 	let creator = DID_00;
 	let author = ACCOUNT_00;
@@ -148,6 +201,82 @@ fn asset_issue_should_succeed() {
 		));
 
 		assert_ok!(Asset::issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			authorization_id
+		));
+	});
+}
+
+#[test]
+fn asset_vc_issue_should_succeed() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+	let issue_entry = AssetIssuanceEntryOf::<Test> {
+		asset_id,
+		asset_owner: creator.clone(),
+		asset_issuance_qty: Some(10),
+	};
+
+	let issue_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&issue_entry.encode()[..]].concat()[..]);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_ok!(Asset::vc_issue(
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			issue_entry.clone(),
 			issue_entry_digest,

--- a/pallets/asset/src/types.rs
+++ b/pallets/asset/src/types.rs
@@ -41,15 +41,6 @@ pub struct AssetInputEntry<AssetDescription, AssetTypeOf, AssetTag, AssetMeta> {
 	/// open structure - 1024 bytes max
 	pub asset_meta: AssetMeta,
 }
-
-#[derive(
-	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
-)]
-pub struct VCAssetInputEntry {
-	/// asset quantity
-	pub asset_qty: u64,
-}
-
 #[derive(Encode, Decode, MaxEncodedLen, Clone, RuntimeDebug, PartialEq, Eq, TypeInfo)]
 pub enum AssetTypeOf {
 	ART,
@@ -103,12 +94,8 @@ pub struct AssetEntry<
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
 )]
 pub struct VCAssetEntry<AssetStatusOf, AssetCreatorOf, BlockNumber, EntryHashOf> {
-	/// asset_detail consists of asset_qty (TODO: Keep any one asset_qty/this)
-	//pub asset_detail: VCAssetInputEntry,
-
 	/// digest of the input entry
 	pub digest: EntryHashOf,
-
 	/// asset issuance count
 	pub asset_issuance: u64,
 	/// status of the asset
@@ -116,7 +103,7 @@ pub struct VCAssetEntry<AssetStatusOf, AssetCreatorOf, BlockNumber, EntryHashOf>
 	/// asset issuer
 	pub asset_issuer: AssetCreatorOf,
 	/// asset quantity
-	pub asset_qty: u64,
+	pub asset_qty: AssetQtyOf,
 	/// asset inlclusion block
 	pub created_at: BlockNumber,
 }
@@ -151,7 +138,6 @@ pub struct AssetDistributionEntry<
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
 )]
 pub struct VCAssetDistributionEntry<AssetStatusOf, AssetCreatorOf, BlockNumber, AssetId> {
-	//pub asset_instance_detail: VCAssetInputEntry,
 	pub asset_qty: AssetQtyOf,
 	/// asset parent reference
 	pub asset_instance_parent: AssetId,

--- a/pallets/asset/src/types.rs
+++ b/pallets/asset/src/types.rs
@@ -38,6 +38,14 @@ pub struct AssetInputEntry<AssetDescription, AssetTypeOf, AssetTag, AssetMeta> {
 	pub asset_meta: AssetMeta,
 }
 
+#[derive(
+	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
+)]
+pub struct VCAssetInputEntry {
+	/// asset quantity
+	pub asset_qty: u32,
+}
+
 #[derive(Encode, Decode, MaxEncodedLen, Clone, RuntimeDebug, PartialEq, Eq, TypeInfo)]
 pub enum AssetTypeOf {
 	ART,
@@ -90,6 +98,21 @@ pub struct AssetEntry<
 #[derive(
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
 )]
+pub struct VCAssetEntry<AssetStatusOf, AssetCreatorOf, BlockNumber> {
+	pub asset_detail: VCAssetInputEntry,
+	/// asset issuance count
+	pub asset_issuance: u32,
+	/// status of the asset
+	pub asset_status: AssetStatusOf,
+	/// asset issuer
+	pub asset_issuer: AssetCreatorOf,
+	/// asset inlclusion block
+	pub created_at: BlockNumber,
+}
+
+#[derive(
+	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
+)]
 pub struct AssetDistributionEntry<
 	AssetDescription,
 	AssetTypeOf,
@@ -101,6 +124,23 @@ pub struct AssetDistributionEntry<
 	AssetId,
 > {
 	pub asset_instance_detail: AssetInputEntry<AssetDescription, AssetTypeOf, AssetTag, AssetMeta>,
+	/// asset parent reference
+	pub asset_instance_parent: AssetId,
+	/// status of the asset
+	pub asset_instance_status: AssetStatusOf,
+	/// asset issuer
+	pub asset_instance_issuer: AssetCreatorOf,
+	/// asset owner
+	pub asset_instance_owner: AssetCreatorOf,
+	/// asset inlclusion block
+	pub created_at: BlockNumber,
+}
+
+#[derive(
+	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
+)]
+pub struct VCAssetDistributionEntry<AssetStatusOf, AssetCreatorOf, BlockNumber, AssetId> {
+	pub asset_instance_detail: VCAssetInputEntry,
 	/// asset parent reference
 	pub asset_instance_parent: AssetId,
 	/// status of the asset

--- a/pallets/asset/src/types.rs
+++ b/pallets/asset/src/types.rs
@@ -20,6 +20,10 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 
+use crate::AssetQtyOf;
+
+pub type EntryHashOf<T> = <T as frame_system::Config>::Hash;
+
 #[derive(
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
 )]
@@ -29,7 +33,7 @@ pub struct AssetInputEntry<AssetDescription, AssetTypeOf, AssetTag, AssetMeta> {
 	/// asset description
 	pub asset_desc: AssetDescription,
 	/// asset quantity
-	pub asset_qty: u32,
+	pub asset_qty: u64,
 	/// asset value
 	pub asset_value: u32,
 	/// open structure - 1024 bytes max
@@ -43,7 +47,7 @@ pub struct AssetInputEntry<AssetDescription, AssetTypeOf, AssetTag, AssetMeta> {
 )]
 pub struct VCAssetInputEntry {
 	/// asset quantity
-	pub asset_qty: u32,
+	pub asset_qty: u64,
 }
 
 #[derive(Encode, Decode, MaxEncodedLen, Clone, RuntimeDebug, PartialEq, Eq, TypeInfo)]
@@ -86,7 +90,7 @@ pub struct AssetEntry<
 > {
 	pub asset_detail: AssetInputEntry<AssetDescription, AssetTypeOf, AssetTag, AssetMeta>,
 	/// asset issuance count
-	pub asset_issuance: u32,
+	pub asset_issuance: u64,
 	/// status of the asset
 	pub asset_status: AssetStatusOf,
 	/// asset issuer
@@ -98,14 +102,21 @@ pub struct AssetEntry<
 #[derive(
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
 )]
-pub struct VCAssetEntry<AssetStatusOf, AssetCreatorOf, BlockNumber> {
-	pub asset_detail: VCAssetInputEntry,
+pub struct VCAssetEntry<AssetStatusOf, AssetCreatorOf, BlockNumber, EntryHashOf> {
+	/// asset_detail consists of asset_qty (TODO: Keep any one asset_qty/this)
+	//pub asset_detail: VCAssetInputEntry,
+
+	/// digest of the input entry
+	pub digest: EntryHashOf,
+
 	/// asset issuance count
-	pub asset_issuance: u32,
+	pub asset_issuance: u64,
 	/// status of the asset
 	pub asset_status: AssetStatusOf,
 	/// asset issuer
 	pub asset_issuer: AssetCreatorOf,
+	/// asset quantity
+	pub asset_qty: u64,
 	/// asset inlclusion block
 	pub created_at: BlockNumber,
 }
@@ -140,7 +151,8 @@ pub struct AssetDistributionEntry<
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
 )]
 pub struct VCAssetDistributionEntry<AssetStatusOf, AssetCreatorOf, BlockNumber, AssetId> {
-	pub asset_instance_detail: VCAssetInputEntry,
+	//pub asset_instance_detail: VCAssetInputEntry,
+	pub asset_qty: AssetQtyOf,
 	/// asset parent reference
 	pub asset_instance_parent: AssetId,
 	/// status of the asset
@@ -162,7 +174,7 @@ pub struct AssetIssuanceEntry<AssetIdOf, AssetCreatorOf> {
 	/// asset owner
 	pub asset_owner: AssetCreatorOf,
 	/// issuance quantity
-	pub asset_issuance_qty: Option<u32>,
+	pub asset_issuance_qty: Option<u64>,
 }
 
 #[derive(


### PR DESCRIPTION
This PR,
- Creates 4 new extrinsic methods `vc_create`, `vc_issue`, `vc_transfer` & `vc_status_change`  for VC create & issue.
- Pallet storage changes.
- Asset type changes.
- Unit tests to demonstrate the same.

Signed-off-by: Shreevatsa N <vatsa@dhiway.com>