### PR TITLE
identifier: Network ID in create identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -132,6 +132,7 @@ fn cord_development_config_genesis() -> serde_json::Value {
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
 		)],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		29,
 	)
 }
 
@@ -161,6 +162,7 @@ fn cord_local_config_genesis() -> serde_json::Value {
 			),
 		],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		29,
 	)
 }
 
@@ -218,8 +220,12 @@ fn cord_local_genesis(
 	initial_authorities: Vec<(AccountId, BabeId, GrandpaId, ImOnlineId, AuthorityDiscoveryId)>,
 	initial_well_known_nodes: Vec<(NodeId, AccountId)>,
 	root_key: AccountId,
+	ss58_identifier_format: u16,
 ) -> serde_json::Value {
 	serde_json::json!( {
+		"identifier": {
+			"ss58IdentifierFormat": ss58_identifier_format,
+		},
 		"nodeAuthorization":  {
 			"nodes": initial_well_known_nodes.iter().map(|x| (x.0.clone(), x.1.clone())).collect::<Vec<_>>(),
 		},

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -20,7 +20,7 @@
 
 pub mod bootstrap;
 
-pub use cord_primitives::{AccountId, Balance, NodeId, Signature};
+pub use cord_primitives::{AccountId, Balance, NodeId, Signature, DEFAULT_SS58_IDENTIFIER_PREFIX};
 pub use cord_runtime::RuntimeGenesisConfig;
 use cord_runtime::{Block, SessionKeys};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
@@ -132,7 +132,7 @@ fn cord_development_config_genesis() -> serde_json::Value {
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
 		)],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
-		29,
+		DEFAULT_SS58_IDENTIFIER_PREFIX,
 	)
 }
 
@@ -162,7 +162,7 @@ fn cord_local_config_genesis() -> serde_json::Value {
 			),
 		],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
-		29,
+		DEFAULT_SS58_IDENTIFIER_PREFIX,
 	)
 }
 

--- a/node/cli/src/chain_spec/bootstrap.rs
+++ b/node/cli/src/chain_spec/bootstrap.rs
@@ -39,6 +39,7 @@ use crate::chain_spec::{get_properties, Extensions, CORD_TELEMETRY_URL, DEFAULT_
 pub struct ChainParams {
 	pub chain_name: String,
 	pub chain_type: ChainType,
+	pub ss58_identifier_format: u16,
 	pub authorities: Vec<Vec<String>>,
 	pub well_known_nodes: Vec<Vec<String>>,
 	pub network_members: Vec<String>,
@@ -54,6 +55,9 @@ impl ChainParams {
 
 	pub fn chain_name(&self) -> &str {
 		&self.chain_name
+	}
+	pub fn ss58_identifier_format(&self) -> u16 {
+		self.ss58_identifier_format
 	}
 }
 
@@ -71,6 +75,7 @@ fn session_keys(
 
 /// Custom config.
 fn cord_custom_config_genesis(config: ChainParams) -> serde_json::Value {
+	let ss58_identifier_format = config.ss58_identifier_format();
 	let initial_network_members: Vec<AccountId> =
 		config.network_members.iter().map(array_bytes::hex_n_into_unchecked).collect();
 
@@ -116,6 +121,7 @@ fn cord_custom_config_genesis(config: ChainParams) -> serde_json::Value {
 		initial_council_members,
 		initial_tech_committee_members,
 		initial_sudo_key,
+		ss58_identifier_format,
 	)
 }
 
@@ -147,8 +153,12 @@ fn cord_custom_genesis(
 	council_members: Vec<AccountId>,
 	tech_committee_members: Vec<AccountId>,
 	sudo_key: AccountId,
+	ss58_identifier_format: u16,
 ) -> serde_json::Value {
 	serde_json::json!( {
+		"identifier": {
+			"ss58IdentifierFormat": ss58_identifier_format,
+		},
 		"nodeAuthorization":  {
 			"nodes": well_known_nodes.iter().map(|x| (x.0.clone(), x.1.clone())).collect::<Vec<_>>(),
 		},

--- a/node/cli/src/chain_spec/bootstrap.rs
+++ b/node/cli/src/chain_spec/bootstrap.rs
@@ -56,6 +56,7 @@ impl ChainParams {
 	pub fn chain_name(&self) -> &str {
 		&self.chain_name
 	}
+
 	pub fn ss58_identifier_format(&self) -> u16 {
 		self.ss58_identifier_format
 	}

--- a/node/cli/src/command/chain_setup.rs
+++ b/node/cli/src/command/chain_setup.rs
@@ -82,7 +82,7 @@ impl BootstrapChainCmd {
 			)),
 		};
 
-		let ss58_identifier_format: u16 = if config.ss58_identifier_format != 0 { 
+		let ss58_identifier_format: u16 = if config.ss58_identifier_format != 0 {
 			config.ss58_identifier_format
 		} else {
 			DEFAULT_SS58_IDENTIFIER_PREFIX

--- a/node/cli/src/command/chain_setup.rs
+++ b/node/cli/src/command/chain_setup.rs
@@ -31,10 +31,13 @@ use crate::chain_spec::{
 
 // use chain_spec::bootstrap::{cord_custom_config, ChainParams, ChainType};
 
+const DEFAULT_SS58_IDENTIFIER_PREFIX: u16 = 10029;
+
 #[derive(Debug, Deserialize)]
 pub struct ChainConfigParams {
 	pub chain_name: String,
 	pub chain_type: String,
+	pub ss58_identifier_format: u16,
 	pub authorities: Vec<Vec<String>>,
 	pub well_known_nodes: Vec<Vec<String>>,
 	pub network_members: Vec<Vec<String>>,
@@ -79,8 +82,11 @@ impl BootstrapChainCmd {
 			)),
 		};
 
-		let chain_type = chain_type?;
-
+		let ss58_identifier_format: u16 = if config.ss58_identifier_format != 0 { 
+			config.ss58_identifier_format
+		} else {
+			DEFAULT_SS58_IDENTIFIER_PREFIX
+		};
 		let initial_members: Vec<String> =
 			config.network_members.iter().map(|net| net[1].clone()).collect();
 
@@ -118,9 +124,11 @@ impl BootstrapChainCmd {
 				.expect("No authorities provided; cannot set sudo_key")
 		});
 
+		let chain_type = chain_type?;
 		let chain_params = ChainParams {
 			chain_name,
 			chain_type,
+			ss58_identifier_format,
 			authorities: initial_authorities,
 			well_known_nodes: initial_well_known_nodes,
 			network_members: initial_members,

--- a/node/testing/src/genesis.rs
+++ b/node/testing/src/genesis.rs
@@ -92,5 +92,6 @@ pub fn config_endowed(extra_endowed: Vec<AccountId>) -> RuntimeGenesisConfig {
 		technical_committee: Default::default(),
 		technical_membership: Default::default(),
 		sudo: Default::default(),
+		identifier: Default::default(),
 	}
 }

--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -16,20 +16,20 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 }
 
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 
 pub fn generate_asset_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Asset).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub fn generate_asset_instance_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetInstanceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::AssetInstance)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 

--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -7,7 +7,6 @@ use frame_benchmarking::{account, benchmarks};
 use frame_support::sp_runtime::traits::Hash;
 use frame_system::RawOrigin;
 
-use identifier::{IdentifierType, Ss58Identifier};
 use pallet_chain_space::{SpaceCodeOf, SpaceIdOf};
 use sp_runtime::BoundedVec;
 

--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -20,8 +20,7 @@ pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
 }
 
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub fn generate_asset_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetIdOf {
@@ -29,8 +28,7 @@ pub fn generate_asset_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetIdOf {
 }
 
 pub fn generate_asset_instance_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetInstanceIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 const SEED: u32 = 0;

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -247,9 +247,8 @@ pub mod pallet {
 				&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
 			);
 
-			let identifier =
-				identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
-					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Assets<T>>::contains_key(&identifier), Error::<T>::AssetIdAlreadyExists);
 
@@ -317,7 +316,7 @@ pub mod pallet {
 			);
 
 			let instance_id = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
-			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			let block_number = frame_system::Pallet::<T>::block_number();
 

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -48,7 +48,7 @@ pub mod pallet {
 	use cord_utilities::traits::CallSources;
 	use frame_support::{pallet_prelude::*, Twox64Concat};
 	use frame_system::pallet_prelude::*;
-	pub use identifier::{IdentifierCreator, IdentifierTimeline, IdentifierType, Ss58Identifier};
+	pub use identifier::{IdentifierTimeline, IdentifierType, Ss58Identifier};
 	use sp_runtime::{
 		traits::{Hash, Zero},
 		BoundedVec,
@@ -248,7 +248,7 @@ pub mod pallet {
 			);
 
 			let identifier =
-				Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Asset)
+				identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
 					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Assets<T>>::contains_key(&identifier), Error::<T>::AssetIdAlreadyExists);
@@ -316,10 +316,7 @@ pub mod pallet {
 				.concat()[..],
 			);
 
-			let instance_id = Ss58Identifier::create_identifier(
-				&(id_digest).encode()[..],
-				IdentifierType::AssetInstance,
-			)
+			let instance_id = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			let block_number = frame_system::Pallet::<T>::block_number();

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -15,8 +15,7 @@ pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates a asset ID from a digest.

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -10,18 +10,18 @@ use sp_std::prelude::*;
 
 /// Generates a space ID from a digest.
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 
 /// Generates a asset ID from a digest.
 pub fn generate_asset_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Asset).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub(crate) const DID_00: SubjectId = SubjectId(AccountId32::new([1u8; 32]));

--- a/pallets/chain-space/src/benchmarking.rs
+++ b/pallets/chain-space/src/benchmarking.rs
@@ -6,7 +6,6 @@ use cord_utilities::traits::GenerateBenchmarkOrigin;
 use frame_benchmarking::{account, benchmarks};
 use frame_support::sp_runtime::traits::Hash;
 use frame_system::RawOrigin;
-use identifier::{IdentifierType, Ss58Identifier};
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());

--- a/pallets/chain-space/src/benchmarking.rs
+++ b/pallets/chain-space/src/benchmarking.rs
@@ -17,8 +17,7 @@ pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
 }
 
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 const SEED: u32 = 0;

--- a/pallets/chain-space/src/benchmarking.rs
+++ b/pallets/chain-space/src/benchmarking.rs
@@ -13,11 +13,11 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 }
 
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 

--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -799,18 +799,18 @@ pub mod pallet {
 
 				// Ensure the new capacity is greater than the current usage
 				ensure!(
-					(parent_details.txn_capacity
-						>= (parent_details.txn_count
-							+ parent_details.txn_reserve + new_txn_capacity
-							- space_details.txn_capacity)),
+					(parent_details.txn_capacity >=
+						(parent_details.txn_count +
+							parent_details.txn_reserve + new_txn_capacity -
+							space_details.txn_capacity)),
 					Error::<T>::CapacityLessThanUsage
 				);
 
 				<Spaces<T>>::insert(
 					&space_details.parent.clone(),
 					SpaceDetailsOf::<T> {
-						txn_reserve: parent_details.txn_reserve - space_details.txn_capacity
-							+ new_txn_capacity,
+						txn_reserve: parent_details.txn_reserve - space_details.txn_capacity +
+							new_txn_capacity,
 						..parent_details.clone()
 					},
 				);
@@ -1005,9 +1005,9 @@ pub mod pallet {
 
 			// Ensure the new capacity is greater than the current usage
 			ensure!(
-				count
-					<= (space_details.txn_capacity
-						- (space_details.txn_count + space_details.txn_reserve)),
+				count <=
+					(space_details.txn_capacity -
+						(space_details.txn_count + space_details.txn_reserve)),
 				Error::<T>::CapacityLimitExceeded
 			);
 
@@ -1136,17 +1136,17 @@ pub mod pallet {
 
 			// Ensure the new capacity is greater than the current usage
 			ensure!(
-				(parent_details.txn_capacity
-					>= (parent_details.txn_count + parent_details.txn_reserve + new_txn_capacity
-						- space_details.txn_capacity)),
+				(parent_details.txn_capacity >=
+					(parent_details.txn_count + parent_details.txn_reserve + new_txn_capacity -
+						space_details.txn_capacity)),
 				Error::<T>::CapacityLessThanUsage
 			);
 
 			<Spaces<T>>::insert(
 				&space_details.parent.clone(),
 				SpaceDetailsOf::<T> {
-					txn_reserve: parent_details.txn_reserve - space_details.txn_capacity
-						+ new_txn_capacity,
+					txn_reserve: parent_details.txn_reserve - space_details.txn_capacity +
+						new_txn_capacity,
 					..parent_details.clone()
 				},
 			);

--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -1021,7 +1021,7 @@ pub mod pallet {
 			);
 
 			let identifier =
-				Ss58Identifier::create_identifier(&id_digest.encode()[..], IdentifierType::Space)
+				Ss58Identifier::create_identifier(&id_digest.encode()[..])
 					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Spaces<T>>::contains_key(&identifier), Error::<T>::SpaceAlreadyAnchored);

--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -516,9 +516,8 @@ pub mod pallet {
 				&[&space_code.encode()[..], &creator.encode()[..]].concat()[..],
 			);
 
-			let identifier =
-				identifier::Pallet::<T>::create_identifier(&id_digest.encode()[..])
-					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+			let identifier = identifier::Pallet::<T>::create_identifier(&id_digest.encode()[..])
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Spaces<T>>::contains_key(&identifier), Error::<T>::SpaceAlreadyAnchored);
 
@@ -528,8 +527,9 @@ pub mod pallet {
 			let auth_id_digest =
 				T::Hashing::hash(&[&identifier.encode()[..], &creator.encode()[..]].concat()[..]);
 
-			let authorization_id = identifier::Pallet::<T>::create_identifier(&auth_id_digest.encode())
-			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+			let authorization_id =
+				identifier::Pallet::<T>::create_identifier(&auth_id_digest.encode())
+					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			let mut delegates: BoundedVec<SpaceCreatorOf<T>, T::MaxSpaceDelegates> =
 				BoundedVec::default();
@@ -799,18 +799,18 @@ pub mod pallet {
 
 				// Ensure the new capacity is greater than the current usage
 				ensure!(
-					(parent_details.txn_capacity >=
-						(parent_details.txn_count +
-							parent_details.txn_reserve + new_txn_capacity -
-							space_details.txn_capacity)),
+					(parent_details.txn_capacity
+						>= (parent_details.txn_count
+							+ parent_details.txn_reserve + new_txn_capacity
+							- space_details.txn_capacity)),
 					Error::<T>::CapacityLessThanUsage
 				);
 
 				<Spaces<T>>::insert(
 					&space_details.parent.clone(),
 					SpaceDetailsOf::<T> {
-						txn_reserve: parent_details.txn_reserve - space_details.txn_capacity +
-							new_txn_capacity,
+						txn_reserve: parent_details.txn_reserve - space_details.txn_capacity
+							+ new_txn_capacity,
 						..parent_details.clone()
 					},
 				);
@@ -1005,9 +1005,9 @@ pub mod pallet {
 
 			// Ensure the new capacity is greater than the current usage
 			ensure!(
-				count <=
-					(space_details.txn_capacity -
-						(space_details.txn_count + space_details.txn_reserve)),
+				count
+					<= (space_details.txn_capacity
+						- (space_details.txn_count + space_details.txn_reserve)),
 				Error::<T>::CapacityLimitExceeded
 			);
 
@@ -1017,9 +1017,8 @@ pub mod pallet {
 				&[&space_code.encode()[..], &creator.encode()[..]].concat()[..],
 			);
 
-			let identifier =
-			identifier::Pallet::<T>::create_identifier(&id_digest.encode()[..])
-					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+			let identifier = identifier::Pallet::<T>::create_identifier(&id_digest.encode()[..])
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Spaces<T>>::contains_key(&identifier), Error::<T>::SpaceAlreadyAnchored);
 
@@ -1029,10 +1028,9 @@ pub mod pallet {
 			let auth_id_digest =
 				T::Hashing::hash(&[&identifier.encode()[..], &creator.encode()[..]].concat()[..]);
 
-			let authorization_id = identifier::Pallet::<T>::create_identifier(
-				&auth_id_digest.encode()
-			)
-			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+			let authorization_id =
+				identifier::Pallet::<T>::create_identifier(&auth_id_digest.encode())
+					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			let mut delegates: BoundedVec<SpaceCreatorOf<T>, T::MaxSpaceDelegates> =
 				BoundedVec::default();
@@ -1138,17 +1136,17 @@ pub mod pallet {
 
 			// Ensure the new capacity is greater than the current usage
 			ensure!(
-				(parent_details.txn_capacity >=
-					(parent_details.txn_count + parent_details.txn_reserve + new_txn_capacity -
-						space_details.txn_capacity)),
+				(parent_details.txn_capacity
+					>= (parent_details.txn_count + parent_details.txn_reserve + new_txn_capacity
+						- space_details.txn_capacity)),
 				Error::<T>::CapacityLessThanUsage
 			);
 
 			<Spaces<T>>::insert(
 				&space_details.parent.clone(),
 				SpaceDetailsOf::<T> {
-					txn_reserve: parent_details.txn_reserve - space_details.txn_capacity +
-						new_txn_capacity,
+					txn_reserve: parent_details.txn_reserve - space_details.txn_capacity
+						+ new_txn_capacity,
 					..parent_details.clone()
 				},
 			);

--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -129,7 +129,7 @@ pub mod pallet {
 	use cord_utilities::traits::CallSources;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	pub use identifier::{IdentifierCreator, IdentifierTimeline, IdentifierType, Ss58Identifier};
+	pub use identifier::{IdentifierTimeline, IdentifierType, Ss58Identifier};
 
 	/// The current storage version.
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
@@ -517,7 +517,7 @@ pub mod pallet {
 			);
 
 			let identifier =
-				Ss58Identifier::create_identifier(&id_digest.encode()[..], IdentifierType::Space)
+				identifier::Pallet::<T>::create_identifier(&id_digest.encode()[..])
 					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Spaces<T>>::contains_key(&identifier), Error::<T>::SpaceAlreadyAnchored);
@@ -528,10 +528,7 @@ pub mod pallet {
 			let auth_id_digest =
 				T::Hashing::hash(&[&identifier.encode()[..], &creator.encode()[..]].concat()[..]);
 
-			let authorization_id = Ss58Identifier::create_identifier(
-				&auth_id_digest.encode(),
-				IdentifierType::Authorization,
-			)
+			let authorization_id = identifier::Pallet::<T>::create_identifier(&auth_id_digest.encode())
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			let mut delegates: BoundedVec<SpaceCreatorOf<T>, T::MaxSpaceDelegates> =
@@ -1021,7 +1018,7 @@ pub mod pallet {
 			);
 
 			let identifier =
-				Ss58Identifier::create_identifier(&id_digest.encode()[..])
+			identifier::Pallet::<T>::create_identifier(&id_digest.encode()[..])
 					.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Spaces<T>>::contains_key(&identifier), Error::<T>::SpaceAlreadyAnchored);
@@ -1032,9 +1029,8 @@ pub mod pallet {
 			let auth_id_digest =
 				T::Hashing::hash(&[&identifier.encode()[..], &creator.encode()[..]].concat()[..]);
 
-			let authorization_id = Ss58Identifier::create_identifier(
-				&auth_id_digest.encode(),
-				IdentifierType::Authorization,
+			let authorization_id = identifier::Pallet::<T>::create_identifier(
+				&auth_id_digest.encode()
 			)
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
@@ -1193,7 +1189,7 @@ impl<T: Config> Pallet<T> {
 		);
 
 		let delegate_authorization_id =
-			Ss58Identifier::create_identifier(&id_digest.encode(), IdentifierType::Authorization)
+			identifier::Pallet::<T>::create_identifier(&id_digest.encode())
 				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 		ensure!(

--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -8,11 +8,11 @@ use sp_runtime::{traits::Hash, AccountId32};
 use sp_std::prelude::*;
 
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 

--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -12,8 +12,7 @@ pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
 }
 
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub(crate) const DID_00: SubjectId = SubjectId(AccountId32::new([1u8; 32]));

--- a/pallets/network-score/src/benchmarking.rs
+++ b/pallets/network-score/src/benchmarking.rs
@@ -31,15 +31,15 @@ const SEED: u32 = 0;
 const MAX_PAYLOAD_BYTE_LENGTH: u32 = 15 * 1024;
 
 pub fn generate_space_id<T: Config>(other_digest: &SpaceCodeOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(other_digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(other_digest).encode()[..]).unwrap()
 }
 
 pub fn generate_rating_id<T: Config>(other_digest: &RatingEntryHashOf<T>) -> RatingEntryIdOf {
-	Ss58Identifier::create_identifier(&(other_digest).encode()[..], IdentifierType::Rating).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(other_digest).encode()[..]).unwrap()
 }
 
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 

--- a/pallets/network-score/src/benchmarking.rs
+++ b/pallets/network-score/src/benchmarking.rs
@@ -24,7 +24,6 @@ use cord_utilities::traits::GenerateBenchmarkOrigin;
 use frame_benchmarking::{account, benchmarks};
 use frame_support::{sp_runtime::traits::Hash, BoundedVec};
 use frame_system::RawOrigin;
-use identifier::{IdentifierType, Ss58Identifier};
 use pallet_chain_space::SpaceCodeOf;
 
 const SEED: u32 = 0;

--- a/pallets/network-score/src/benchmarking.rs
+++ b/pallets/network-score/src/benchmarking.rs
@@ -39,8 +39,7 @@ pub fn generate_rating_id<T: Config>(other_digest: &RatingEntryHashOf<T>) -> Rat
 }
 
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {

--- a/pallets/network-score/src/lib.rs
+++ b/pallets/network-score/src/lib.rs
@@ -370,16 +370,16 @@ pub mod pallet {
 			.map_err(<pallet_chain_space::Error<T>>::from)?;
 
 			ensure!(
-				entry.total_encoded_rating > 0
-					&& entry.count_of_txn > 0
-					&& entry.total_encoded_rating
-						<= entry.count_of_txn * T::MaxRatingValue::get() as u64,
+				entry.total_encoded_rating > 0 &&
+					entry.count_of_txn > 0 &&
+					entry.total_encoded_rating <=
+						entry.count_of_txn * T::MaxRatingValue::get() as u64,
 				Error::<T>::InvalidRatingValue
 			);
 
 			ensure!(
-				entry.entity_type.is_valid_entity_type()
-					&& entry.rating_type.is_valid_rating_type(),
+				entry.entity_type.is_valid_entity_type() &&
+					entry.rating_type.is_valid_rating_type(),
 				Error::<T>::InvalidEntryOrRatingType
 			);
 
@@ -635,16 +635,16 @@ pub mod pallet {
 			.map_err(<pallet_chain_space::Error<T>>::from)?;
 
 			ensure!(
-				entry.total_encoded_rating > 0
-					&& entry.count_of_txn > 0
-					&& entry.total_encoded_rating
-						<= entry.count_of_txn * T::MaxRatingValue::get() as u64,
+				entry.total_encoded_rating > 0 &&
+					entry.count_of_txn > 0 &&
+					entry.total_encoded_rating <=
+						entry.count_of_txn * T::MaxRatingValue::get() as u64,
 				Error::<T>::InvalidRatingValue
 			);
 
 			ensure!(
-				entry.entity_type.is_valid_entity_type()
-					&& entry.rating_type.is_valid_rating_type(),
+				entry.entity_type.is_valid_entity_type() &&
+					entry.rating_type.is_valid_rating_type(),
 				Error::<T>::InvalidEntryOrRatingType
 			);
 

--- a/pallets/network-score/src/lib.rs
+++ b/pallets/network-score/src/lib.rs
@@ -127,7 +127,7 @@ pub mod pallet {
 	use cord_utilities::traits::CallSources;
 	use frame_support::{pallet_prelude::*, Twox64Concat};
 	use frame_system::pallet_prelude::*;
-	pub use identifier::{IdentifierCreator, IdentifierTimeline, IdentifierType, Ss58Identifier};
+	pub use identifier::{IdentifierTimeline, IdentifierType, Ss58Identifier};
 	use sp_runtime::traits::Hash;
 	use sp_std::{prelude::Clone, str};
 
@@ -405,10 +405,7 @@ pub mod pallet {
 				.concat()[..],
 			);
 
-			let identifier = Ss58Identifier::create_identifier(
-				&(id_digest).encode()[..],
-				IdentifierType::Rating,
-			)
+			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(
@@ -532,10 +529,7 @@ pub mod pallet {
 				.concat()[..],
 			);
 
-			let identifier = Ss58Identifier::create_identifier(
-				&(id_digest).encode()[..],
-				IdentifierType::Rating,
-			)
+			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(
@@ -690,10 +684,7 @@ pub mod pallet {
 				.concat()[..],
 			);
 
-			let identifier = Ss58Identifier::create_identifier(
-				&(id_digest).encode()[..],
-				IdentifierType::Rating,
-			)
+			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(

--- a/pallets/network-score/src/lib.rs
+++ b/pallets/network-score/src/lib.rs
@@ -370,16 +370,16 @@ pub mod pallet {
 			.map_err(<pallet_chain_space::Error<T>>::from)?;
 
 			ensure!(
-				entry.total_encoded_rating > 0 &&
-					entry.count_of_txn > 0 &&
-					entry.total_encoded_rating <=
-						entry.count_of_txn * T::MaxRatingValue::get() as u64,
+				entry.total_encoded_rating > 0
+					&& entry.count_of_txn > 0
+					&& entry.total_encoded_rating
+						<= entry.count_of_txn * T::MaxRatingValue::get() as u64,
 				Error::<T>::InvalidRatingValue
 			);
 
 			ensure!(
-				entry.entity_type.is_valid_entity_type() &&
-					entry.rating_type.is_valid_rating_type(),
+				entry.entity_type.is_valid_entity_type()
+					&& entry.rating_type.is_valid_rating_type(),
 				Error::<T>::InvalidEntryOrRatingType
 			);
 
@@ -406,7 +406,7 @@ pub mod pallet {
 			);
 
 			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
-			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(
 				!<RatingEntries<T>>::contains_key(&identifier),
@@ -530,7 +530,7 @@ pub mod pallet {
 			);
 
 			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
-			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(
 				!<RatingEntries<T>>::contains_key(&identifier),
@@ -635,16 +635,16 @@ pub mod pallet {
 			.map_err(<pallet_chain_space::Error<T>>::from)?;
 
 			ensure!(
-				entry.total_encoded_rating > 0 &&
-					entry.count_of_txn > 0 &&
-					entry.total_encoded_rating <=
-						entry.count_of_txn * T::MaxRatingValue::get() as u64,
+				entry.total_encoded_rating > 0
+					&& entry.count_of_txn > 0
+					&& entry.total_encoded_rating
+						<= entry.count_of_txn * T::MaxRatingValue::get() as u64,
 				Error::<T>::InvalidRatingValue
 			);
 
 			ensure!(
-				entry.entity_type.is_valid_entity_type() &&
-					entry.rating_type.is_valid_rating_type(),
+				entry.entity_type.is_valid_entity_type()
+					&& entry.rating_type.is_valid_rating_type(),
 				Error::<T>::InvalidEntryOrRatingType
 			);
 
@@ -685,7 +685,7 @@ pub mod pallet {
 			);
 
 			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
-			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(
 				!<RatingEntries<T>>::contains_key(&identifier),

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -68,8 +68,7 @@ fn check_successful_rating_creation() {
 		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
-		identifier::Pallet::<T>::create_identifier(&auth_digest.encode()[..])
-			.unwrap();
+		identifier::Pallet::<T>::create_identifier(&auth_digest.encode()[..]).unwrap();
 
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
@@ -123,8 +122,7 @@ fn check_duplicate_message_id() {
 		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
-		identifier::Pallet::<T>::create_identifier(&auth_digest.encode()[..])
-			.unwrap();
+		identifier::Pallet::<T>::create_identifier(&auth_digest.encode()[..]).unwrap();
 
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -27,11 +27,11 @@ use sp_runtime::{traits::Hash, AccountId32};
 use sp_std::prelude::*;
 
 pub fn generate_rating_id<T: Config>(digest: &RatingEntryHashOf<T>) -> RatingEntryIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Rating).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub(crate) const DID_00: SubjectId = SubjectId(AccountId32::new([1u8; 32]));
@@ -68,7 +68,7 @@ fn check_successful_rating_creation() {
 		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
-		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
+		identifier::Pallet::<T>::create_identifier(&auth_digest.encode()[..])
 			.unwrap();
 
 	new_test_ext().execute_with(|| {
@@ -123,7 +123,7 @@ fn check_duplicate_message_id() {
 		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
-		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
+		identifier::Pallet::<T>::create_identifier(&auth_digest.encode()[..])
 			.unwrap();
 
 	new_test_ext().execute_with(|| {

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -68,7 +68,7 @@ fn check_successful_rating_creation() {
 		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
-		identifier::Pallet::<T>::create_identifier(&auth_digest.encode()[..]).unwrap();
+		identifier::Pallet::<Test>::create_identifier(&auth_digest.encode()[..]).unwrap();
 
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
@@ -122,7 +122,7 @@ fn check_duplicate_message_id() {
 		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
-		identifier::Pallet::<T>::create_identifier(&auth_digest.encode()[..]).unwrap();
+		identifier::Pallet::<Test>::create_identifier(&auth_digest.encode()[..]).unwrap();
 
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);

--- a/pallets/schema/src/benchmarking.rs
+++ b/pallets/schema/src/benchmarking.rs
@@ -46,8 +46,7 @@ pub fn generate_space_id<T: Config>(digest: &SchemaHashOf<T>) -> SpaceIdOf {
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SchemaHashOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 benchmarks! {

--- a/pallets/schema/src/benchmarking.rs
+++ b/pallets/schema/src/benchmarking.rs
@@ -36,17 +36,17 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 }
 
 pub fn generate_schema_id<T: Config>(digest: &SchemaHashOf<T>) -> SchemaIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Schema).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates a space ID from a digest.
 pub fn generate_space_id<T: Config>(digest: &SchemaHashOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SchemaHashOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 

--- a/pallets/schema/src/lib.rs
+++ b/pallets/schema/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
 			);
 
 			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
-			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Schemas<T>>::contains_key(&identifier), Error::<T>::SchemaAlreadyAnchored);
 

--- a/pallets/schema/src/lib.rs
+++ b/pallets/schema/src/lib.rs
@@ -70,7 +70,7 @@ pub mod pallet {
 	pub use cord_utilities::traits::CallSources;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	pub use identifier::{IdentifierCreator, IdentifierTimeline, IdentifierType, Ss58Identifier};
+	pub use identifier::{IdentifierTimeline, IdentifierType, Ss58Identifier};
 	use sp_runtime::{traits::Hash, SaturatedConversion};
 
 	/// The current storage version.
@@ -190,10 +190,7 @@ pub mod pallet {
 					[..],
 			);
 
-			let identifier = Ss58Identifier::create_identifier(
-				&(id_digest).encode()[..],
-				IdentifierType::Schema,
-			)
+			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(!<Schemas<T>>::contains_key(&identifier), Error::<T>::SchemaAlreadyAnchored);

--- a/pallets/schema/src/tests.rs
+++ b/pallets/schema/src/tests.rs
@@ -81,17 +81,17 @@ where
 ///
 /// This function will panic if the conversion from digest to schema ID fails.
 pub fn generate_schema_id<T: Config>(digest: &SchemaHashOf<T>) -> SchemaIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Schema).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates a space ID from a digest.
 pub fn generate_space_id<T: Config>(digest: &SchemaHashOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SchemaHashOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 

--- a/pallets/schema/src/tests.rs
+++ b/pallets/schema/src/tests.rs
@@ -81,17 +81,17 @@ where
 ///
 /// This function will panic if the conversion from digest to schema ID fails.
 pub fn generate_schema_id<T: Config>(digest: &SchemaHashOf<T>) -> SchemaIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
+	identifier::Pallet::<Test>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates a space ID from a digest.
 pub fn generate_space_id<T: Config>(digest: &SchemaHashOf<T>) -> SpaceIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
+	identifier::Pallet::<Test>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SchemaHashOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
+	identifier::Pallet::<Test>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 // submit_schema_creation_operation

--- a/pallets/schema/src/tests.rs
+++ b/pallets/schema/src/tests.rs
@@ -91,8 +91,7 @@ pub fn generate_space_id<T: Config>(digest: &SchemaHashOf<T>) -> SpaceIdOf {
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SchemaHashOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 // submit_schema_creation_operation

--- a/pallets/statement/src/benchmarking.rs
+++ b/pallets/statement/src/benchmarking.rs
@@ -14,17 +14,17 @@ const MAX_PAYLOAD_BYTE_LENGTH: u32 = 5 * 1024;
 
 /// Generates a statement ID from a statement digest.
 pub fn generate_statement_id<T: Config>(digest: &StatementDigestOf<T>) -> StatementIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Statement).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates a space ID from a digest.
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 

--- a/pallets/statement/src/benchmarking.rs
+++ b/pallets/statement/src/benchmarking.rs
@@ -24,8 +24,7 @@ pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {

--- a/pallets/statement/src/benchmarking.rs
+++ b/pallets/statement/src/benchmarking.rs
@@ -6,7 +6,6 @@ use cord_utilities::traits::GenerateBenchmarkOrigin;
 use frame_benchmarking::{account, benchmarks};
 use frame_support::sp_runtime::traits::Hash;
 use frame_system::RawOrigin;
-use identifier::{IdentifierType, Ss58Identifier};
 use pallet_chain_space::SpaceCodeOf;
 
 const SEED: u32 = 0;

--- a/pallets/statement/src/lib.rs
+++ b/pallets/statement/src/lib.rs
@@ -102,7 +102,7 @@ pub mod pallet {
 	use cord_utilities::traits::CallSources;
 	use frame_support::pallet_prelude::{OptionQuery, *};
 	use frame_system::pallet_prelude::*;
-	pub use identifier::{IdentifierCreator, IdentifierTimeline, IdentifierType, Ss58Identifier};
+	pub use identifier::{IdentifierTimeline, IdentifierType, Ss58Identifier};
 	use sp_runtime::traits::Hash;
 
 	/// The current storage version.
@@ -412,10 +412,7 @@ pub mod pallet {
 				&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
 			);
 
-			let identifier = Ss58Identifier::create_identifier(
-				&(id_digest).encode()[..],
-				IdentifierType::Statement,
-			)
+			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(
@@ -924,10 +921,7 @@ pub mod pallet {
 					.concat()[..],
 				);
 
-				let identifier_result = Ss58Identifier::create_identifier(
-					&(id_digest).encode()[..],
-					IdentifierType::Statement,
-				);
+				let identifier_result = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..]);
 
 				match identifier_result {
 					Ok(identifier) => {

--- a/pallets/statement/src/lib.rs
+++ b/pallets/statement/src/lib.rs
@@ -413,7 +413,7 @@ pub mod pallet {
 			);
 
 			let identifier = identifier::Pallet::<T>::create_identifier(&(id_digest).encode()[..])
-			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+				.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
 
 			ensure!(
 				!<Statements<T>>::contains_key(&identifier),

--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -10,22 +10,22 @@ use sp_runtime::{traits::Hash, AccountId32};
 
 /// Generates a statement ID from a statement digest.
 pub fn generate_statement_id<T: Config>(digest: &StatementDigestOf<T>) -> StatementIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Statement).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates a schema ID from a schema digest.
 pub fn generate_schema_id<T: Config>(digest: &SchemaHashOf<T>) -> SchemaIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Schema).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates a space ID from a digest.
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Authorization)
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
 		.unwrap()
 }
 

--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -25,8 +25,7 @@ pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
 
 /// Generates an authorization ID from a digest.
 pub fn generate_authorization_id<T: Config>(digest: &SpaceCodeOf<T>) -> AuthorizationIdOf {
-	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..])
-		.unwrap()
+	identifier::Pallet::<T>::create_identifier(&(digest).encode()[..]).unwrap()
 }
 
 pub(crate) const DID_00: SubjectId = SubjectId(AccountId32::new([1u8; 32]));

--- a/primitives/cord/src/lib.rs
+++ b/primitives/cord/src/lib.rs
@@ -100,6 +100,9 @@ pub type NodeId = Vec<u8>;
 // pub const AUTHORSHIP_PERIOD: u32 = 5256000;
 pub const AUTHORSHIP_PERIOD: u32 = 20;
 
+/// SS58 identifier format prefix
+pub const DEFAULT_SS58_IDENTIFIER_PREFIX: u16 = 10029;
+
 /// Macro to set a value (e.g. when using the `parameter_types` macro) to either
 /// a production value or to an environment variable or testing value (in case
 /// the `fast-runtime` feature is selected). Note that the environment variable

--- a/primitives/identifier/Cargo.toml
+++ b/primitives/identifier/Cargo.toml
@@ -40,6 +40,7 @@ bs58 = { version = "0.5.0", default-features = false }
 blake2-rfc = { version = "0.2.18", default-features = false }
 cord-primitives = { package = "cord-primitives", path = "../cord", default-features = false }
 cord-utilities = { package = "cord-utilities", path = "../../utilities", default-features = false }
+log = "0.4.17"
 
 
 # Substrate dependencies
@@ -74,6 +75,7 @@ std = [
 	"sp-std/std",
 	"sp-keystore/std",
 	"bs58/std",
+	"log/std",
 ]
 
 try-runtime = [

--- a/primitives/identifier/src/curi.rs
+++ b/primitives/identifier/src/curi.rs
@@ -45,45 +45,7 @@ pub enum IdentifierType {
 	Rating,
 }
 
-impl IdentifierType {
-	const IDENT_AUTH: u16 = 2092;
-	const IDENT_SPACE: u16 = 3390;
-	const IDENT_SCHEMA: u16 = 7366;
-	const IDENT_STATEMENT: u16 = 8902;
-	const IDENT_ENTITY: u16 = 6480;
-	const IDENT_TEMPLATE: u16 = 8911;
-	const IDENT_ASSET: u16 = 2348;
-	const IDENT_RATING: u16 = 6077;
-	const IDENT_ASSET_INSTANCE: u16 = 11380;
-
-	fn ident_value(&self) -> u16 {
-		match self {
-			IdentifierType::Authorization => Self::IDENT_AUTH,
-			IdentifierType::Space => Self::IDENT_SPACE,
-			IdentifierType::Schema => Self::IDENT_SCHEMA,
-			IdentifierType::Statement => Self::IDENT_STATEMENT,
-			IdentifierType::Entity => Self::IDENT_ENTITY,
-			IdentifierType::Template => Self::IDENT_TEMPLATE,
-			IdentifierType::Asset => Self::IDENT_ASSET,
-			IdentifierType::AssetInstance => Self::IDENT_ASSET_INSTANCE,
-			IdentifierType::Rating => Self::IDENT_RATING,
-		}
-	}
-	fn from_u16(value: u16) -> Option<Self> {
-		match value {
-			2092 => Some(IdentifierType::Authorization),
-			3390 => Some(IdentifierType::Space),
-			7366 => Some(IdentifierType::Schema),
-			8902 => Some(IdentifierType::Statement),
-			6480 => Some(IdentifierType::Entity),
-			8911 => Some(IdentifierType::Template),
-			2348 => Some(IdentifierType::Asset),
-			6077 => Some(IdentifierType::AssetInstance),
-			11380 => Some(IdentifierType::Rating),
-			_ => None,
-		}
-	}
-}
+const DEFAULT_SS58_IDENTIFIER_PREFIX: u16 = 10029;
 
 /// The minimum length of a valid identifier.
 pub const MINIMUM_IDENTIFIER_LENGTH: usize = 2;
@@ -121,29 +83,19 @@ pub enum IdentifierError {
 pub trait IdentifierCreator {
 	fn create_identifier(
 		data: &[u8],
-		id_type: IdentifierType,
 	) -> Result<Ss58Identifier, IdentifierError>;
 }
 
 impl IdentifierCreator for Ss58Identifier {
 	fn create_identifier(
 		data: &[u8],
-		id_type: IdentifierType,
 	) -> Result<Ss58Identifier, IdentifierError> {
-		let id_ident = id_type.ident_value();
-		Ss58Identifier::from_encoded(data, id_ident)
-	}
-}
-
-pub trait CordIdentifierType {
-	fn get_type(&self) -> Result<IdentifierType, IdentifierError>;
-}
-
-impl CordIdentifierType for Ss58Identifier {
-	fn get_type(&self) -> Result<IdentifierType, IdentifierError> {
-		let identifier_type_u16 = self.get_identifier_type()?;
-
-		IdentifierType::from_u16(identifier_type_u16).ok_or(IdentifierError::InvalidIdentifier)
+		let format = Prefix::get();
+		if let Some(ss58_identifier_format) = format {
+			Ss58Identifier::from_encoded(data, ss58_identifier_format)
+		} else {
+			Ss58Identifier::from_encoded(data, DEFAULT_SS58_IDENTIFIER_PREFIX)
+		}
 	}
 }
 

--- a/primitives/identifier/src/curi.rs
+++ b/primitives/identifier/src/curi.rs
@@ -45,8 +45,6 @@ pub enum IdentifierType {
 	Rating,
 }
 
-const DEFAULT_SS58_IDENTIFIER_PREFIX: u16 = 10029;
-
 /// The minimum length of a valid identifier.
 pub const MINIMUM_IDENTIFIER_LENGTH: usize = 2;
 /// The maximum length of a valid identifier.
@@ -78,26 +76,6 @@ pub enum IdentifierError {
 	/// Identifier timeline update failed
 	UpdateFailed,
 	MaxEventsHistoryExceeded,
-}
-
-pub trait IdentifierCreator {
-	fn create_identifier(
-		data: &[u8],
-	) -> Result<Ss58Identifier, IdentifierError>;
-}
-
-impl IdentifierCreator for Ss58Identifier {
-	fn create_identifier(
-		data: &[u8],
-	) -> Result<Ss58Identifier, IdentifierError> {
-		//let format = Prefix::get();
-		let format = Some(0);
-		if let Some(ss58_identifier_format) = format {
-			Ss58Identifier::from_encoded(data, ss58_identifier_format)
-		} else {
-			Ss58Identifier::from_encoded(data, DEFAULT_SS58_IDENTIFIER_PREFIX)
-		}
-	}
 }
 
 impl Ss58Identifier {

--- a/primitives/identifier/src/curi.rs
+++ b/primitives/identifier/src/curi.rs
@@ -90,7 +90,8 @@ impl IdentifierCreator for Ss58Identifier {
 	fn create_identifier(
 		data: &[u8],
 	) -> Result<Ss58Identifier, IdentifierError> {
-		let format = Prefix::get();
+		//let format = Prefix::get();
+		let format = Some(0);
 		if let Some(ss58_identifier_format) = format {
 			Ss58Identifier::from_encoded(data, ss58_identifier_format)
 		} else {

--- a/primitives/identifier/src/lib.rs
+++ b/primitives/identifier/src/lib.rs
@@ -22,18 +22,16 @@
 #![allow(clippy::unused_unit)]
 
 pub mod curi;
-pub use crate::curi::{
-	IdentifierError, IdentifierTimeline, IdentifierType, Ss58Identifier,
-};
+pub use crate::curi::{IdentifierError, IdentifierTimeline, IdentifierType, Ss58Identifier};
 use sp_runtime::BoundedVec;
 use sp_std::{prelude::Clone, str};
 pub mod types;
+pub use crate::pallet::*;
 pub use crate::types::*;
+use cord_primitives::DEFAULT_SS58_IDENTIFIER_PREFIX;
+use core::marker::PhantomData;
 use frame_support::traits::Get;
 use frame_system::pallet_prelude::BlockNumberFor;
-use core::marker::PhantomData;
-use cord_primitives::DEFAULT_SS58_IDENTIFIER_PREFIX;
-pub use crate::pallet::*;
 use sp_std::vec;
 
 #[cfg(any(feature = "mock", test))]
@@ -142,9 +140,7 @@ impl<T: Config> IdentifierUpdate<IdentifierOf, IdentifierTypeOf, EventEntryOf, I
 }
 
 impl<T: Config> Pallet<T> {
-	pub fn create_identifier(
-		data: &[u8],
-	) -> Result<Ss58Identifier, IdentifierError> {
+	pub fn create_identifier(data: &[u8]) -> Result<Ss58Identifier, IdentifierError> {
 		let format = Ss58Format::<T>::get();
 		if let Some(ss58_identifier_format) = format {
 			Ss58Identifier::from_encoded(data, ss58_identifier_format)

--- a/primitives/identifier/src/lib.rs
+++ b/primitives/identifier/src/lib.rs
@@ -23,7 +23,7 @@
 
 pub mod curi;
 pub use crate::curi::{
-	CordIdentifierType, IdentifierCreator, IdentifierError, IdentifierTimeline, IdentifierType,
+	IdentifierCreator, IdentifierError, IdentifierTimeline, IdentifierType,
 	Ss58Identifier,
 };
 use sp_runtime::BoundedVec;
@@ -32,6 +32,7 @@ pub mod types;
 pub use crate::types::*;
 use frame_support::traits::Get;
 use frame_system::pallet_prelude::BlockNumberFor;
+use core::marker::PhantomData;
 
 pub use crate::pallet::*;
 use sp_std::vec;
@@ -88,10 +89,31 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn prefix)]
+	pub type Prefix<T: Config> = StorageValue<_, u16>;
+
 	#[pallet::error]
 	pub enum Error<T> {
 		// Max exvents history exceeded
 		MaxEventsHistoryExceeded,
+		// Prefix Missing
+		PrefixNotFound,
+	}
+
+	#[pallet::genesis_config]
+	#[derive(frame_support::DefaultNoBound)]
+	pub struct GenesisConfig<T: Config> {
+		phantom: PhantomData<T>,
+		pub ss58_identifier_format: u16,
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+		fn build(&self) {
+			log::info!("Setting new prefix key {:?}", &self.ss58_identifier_format);
+			Prefix::<T>::put(&self.ss58_identifier_format);
+		}
 	}
 }
 

--- a/primitives/identifier/src/lib.rs
+++ b/primitives/identifier/src/lib.rs
@@ -26,8 +26,7 @@ pub use crate::curi::{IdentifierError, IdentifierTimeline, IdentifierType, Ss58I
 use sp_runtime::BoundedVec;
 use sp_std::{prelude::Clone, str};
 pub mod types;
-pub use crate::pallet::*;
-pub use crate::types::*;
+pub use crate::{pallet::*, types::*};
 use cord_primitives::DEFAULT_SS58_IDENTIFIER_PREFIX;
 use core::marker::PhantomData;
 use frame_support::traits::Get;

--- a/primitives/identifier/src/mock.rs
+++ b/primitives/identifier/src/mock.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
+use crate as identifier;
 use frame_support::{
 	construct_runtime, derive_impl, parameter_types,
 	traits::{ConstU32, ConstU64},
@@ -37,6 +38,14 @@ construct_runtime!(
 		System: frame_system
 	}
 );
+
+parameter_types! {
+	pub const MaxEventsHistory: u32 = 6u32;
+}
+
+impl identifier::Config for Test {
+	type MaxEventsHistory = MaxEventsHistory;
+}
 
 parameter_types! {
 	pub const SS58Prefix: u8 = 29;

--- a/primitives/identifier/src/tests.rs
+++ b/primitives/identifier/src/tests.rs
@@ -11,16 +11,13 @@ fn creating_a_invalid_identifier_length_should_fail() {
 
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			Ss58Identifier::create_identifier(&(space1).encode()[..], IdentifierType::Space),
+			identifier::Pallet::<T>::create_identifier(&(space1).encode()[..]),
 			IdentifierError::InvalidIdentifierLength
 		);
 		assert_err!(
-			Ss58Identifier::create_identifier(&(space2).encode()[..], IdentifierType::Space),
+			identifier::Pallet::<T>::create_identifier(&(space2).encode()[..]),
 			IdentifierError::InvalidIdentifierLength
 		);
-		assert_ok!(Ss58Identifier::create_identifier(
-			&(space3).encode()[..],
-			IdentifierType::Space
-		));
+		assert_ok!(identifier::Pallet::<T>::create_identifier(&(space3).encode()[..]));
 	});
 }

--- a/primitives/identifier/src/tests.rs
+++ b/primitives/identifier/src/tests.rs
@@ -11,13 +11,13 @@ fn creating_a_invalid_identifier_length_should_fail() {
 
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			identifier::Pallet::<T>::create_identifier(&(space1).encode()[..]),
+			Pallet::<Test>::create_identifier(&(space1).encode()[..]),
 			IdentifierError::InvalidIdentifierLength
 		);
 		assert_err!(
-			identifier::Pallet::<T>::create_identifier(&(space2).encode()[..]),
+			Pallet::<Test>::create_identifier(&(space2).encode()[..]),
 			IdentifierError::InvalidIdentifierLength
 		);
-		assert_ok!(identifier::Pallet::<T>::create_identifier(&(space3).encode()[..]));
+		assert_ok!(Pallet::<Test>::create_identifier(&(space3).encode()[..]));
 	});
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,6 +10,8 @@ function usage() {
   echo "  -a, --num-authorities Number of authorities (validators)"
   echo "  -s, --SECRET          Secret key or seed for generating new accounts"
   echo "  -o, --output-directory Directory where output files will be saved (default is current directory)"
+  echo "  -p, --ss58prefix      Prefix for ss58 identifiers"
+  echo "  -c, --chain-name      Name of the Network"
   echo ""
   echo "Description:"
   echo "  This script generates a configuration file for the CORD Custom Chain, including"
@@ -20,6 +22,8 @@ function usage() {
   echo "  The generated configuration is written to 'config.toml' and account details to 'accounts.txt'."
 }
 # Defaults
+NETWORK_NAME="CORD Custom Chain"
+SS58_PREFIX=29
 NUM_MEMBERS=6
 NUM_NODES=5
 NUM_AUTHORITIES=3
@@ -34,6 +38,8 @@ while getopts "m:n:a:s:o:" flag; do
   a) NUM_AUTHORITIES=${OPTARG} ;;
   s) SECRET=${OPTARG} ;;
   o) OUTPUT_DIR=${OPTARG} ;;
+  i) SS58_PREFIX=${OPTARG} ;;
+  c) NETWORK_NAME=${OPTARG} ;;
   *)
     usage
     exit
@@ -53,8 +59,9 @@ echo "
 # This configuration file defines the settings for the CORD Custom Chain.
 # Please review and customize the parameters as needed for your specific use case.
 " >>$CONFIG_FILE
-echo "chain_name = \"CORD Custom Chain\"" >>$CONFIG_FILE
+echo "chain_name = \"${NETWORK_NAME}\"" >>$CONFIG_FILE
 echo "chain_type = \"local\"" >>$CONFIG_FILE
+echo "ss58IdentifierFormat = ${SS58_PREFIX}" >>$CONFIG_FILE
 echo "" >>$CONFIG_FILE
 
 # Initialize Accounts files

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -31,7 +31,7 @@ NUM_AUTHORITIES=3
 SECRET="0xf32255f569d8b1a12086dfd194653a5377fafcb67345753987741ec5542920ce"
 OUTPUT_DIR="."
 
-while getopts "m:n:a:s:o:" flag; do
+while getopts "m:n:a:s:o:p:c:" flag; do
   case "${flag}" in
   m) NUM_MEMBERS=${OPTARG} ;;
   n) NUM_NODES=${OPTARG} ;;


### PR DESCRIPTION
This is not yet ready, and there is a compilation error.

The main thing to note with this effort is:

* Ability to pass a ss58IdentifierFormat from bootstrap file -> chain_spec file.

* ChainSpec file adds the fields to genesis_block/genesis_build of identifier and passes this information to pallet.

* With this, a network will always have identifier with same prefix and hence similar identifiers