### PR TITLE
tests.rs

### DIFF
--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -495,3 +495,69 @@ fn asset_vc_status_change_should_succeed() {
 		));
 	});
 }
+
+
+// This test asset_create_should_fail_invalid_signature checks if the Asset::create function correctly
+// returns InvalidSignature error when provided with an invalid signature for asset creation in the 
+//pallet-asset module.
+#[test]
+fn asset_create_should_fail_invalid_signature() {
+    let creator = DID_00;
+    let author = ACCOUNT_00;
+    let capacity = 5u64;
+
+    let raw_space = [2u8; 256].to_vec();
+    let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+    let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+    let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let authorization_id: Ss58Identifier =
+        generate_authorization_id::<Test>(&auth_digest);
+
+    let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_qty = 10;
+    let asset_value = 10;
+    let asset_type = AssetTypeOf::MF;
+
+    let entry = AssetInputEntryOf::<Test> {
+        asset_desc,
+        asset_qty,
+        asset_type,
+        asset_value,
+        asset_tag,
+        asset_meta,
+    };
+
+    let invalid_signature: Signature = Signature::from([1u8; 64]);
+
+    let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+    new_test_ext().execute_with(|| {
+        assert_ok!(Space::create(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            space_digest,
+        ));
+
+        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+        // Attempt to create asset with invalid signature
+        assert_err!(
+            Asset::create(
+                DoubleOrigin(author.clone(), creator.clone()).into(),
+                entry,
+                digest,
+                authorization_id,
+                invalid_signature, // Pass invalid signature
+            ),
+            Error::<Test>::InvalidSignature
+        );
+    });
+}
+


### PR DESCRIPTION
FIXES #370
We're creating a new test function asset_create_should_fail_invalid_signature. We're setting up the necessary variables such as creator, author, capacity, etc. We generate an invalid_signature that will intentionally trigger the InvalidSignature error.