### PR TITLE
Added test for RatingIdentifierAlreadyExist

### DIFF
--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -254,6 +254,7 @@ fn test_register_rating_id_already_exists() {
 	let message_id = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
 	let entity_uid = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
 	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+	let debit_ref_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
 	let entry = RatingInputEntryOf::<Test> {
 		entity_uid,
 		provider_uid,

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -255,7 +255,7 @@ fn test_register_rating_id_already_exists() {
 	let entity_uid = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
 	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
 	let entry = RatingInputEntryOf::<Test> {
-		entity_uid.clone(),
+		entity_uid: entity_uid.clone(),
 		provider_uid,
 		total_encoded_rating: 250u64,
 		count_of_txn: 7u64,

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -255,7 +255,7 @@ fn test_register_rating_id_already_exists() {
 	let entity_uid = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
 	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
 	let entry = RatingInputEntryOf::<Test> {
-		entity_uid: entity_uid.clone(),
+		entity_uid,
 		provider_uid,
 		total_encoded_rating: 250u64,
 		count_of_txn: 7u64,
@@ -377,8 +377,6 @@ fn test_revoked_rating_id_already_exists() {
 			authorization_id.clone(),
 		));
 
-		// Remove message_id and provider_did from entries
-		<MessageIdentifiers<Test>>::remove(message_id.clone(), creator.clone());
 		// Attempt to revoke a rating entry with the same identifier
 		assert_err!(
 			Score::revise_rating(

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -277,7 +277,7 @@ fn test_register_rating_id_already_exists() {
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
 			.unwrap();
-		
+
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -255,7 +255,7 @@ fn test_register_rating_id_already_exists() {
 	let entity_uid = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
 	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
 	let entry = RatingInputEntryOf::<Test> {
-		entity_uid,
+		entity_uid.clone(),
 		provider_uid,
 		total_encoded_rating: 250u64,
 		count_of_txn: 7u64,

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -277,20 +277,7 @@ fn test_register_rating_id_already_exists() {
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
 			.unwrap();
-
-	let id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[
-			&entry_digest.encode()[..],
-			&entity_uid.clone().encode()[..],
-			&message_id.encode()[..],
-			&space_id.encode()[..],
-			&creator.clone().encode()[..],
-		]
-		.concat()[..],
-	);
-
-	let identifier =
-		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating);
+		
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -310,5 +310,17 @@ fn test_register_rating_id_already_exists() {
 			),
 			Error::<Test>::RatingIdentifierAlreadyAdded
 		);
+		// Attempt to revoke a rating entry with the same identifier
+		assert_err!(
+			Score::revise_rating(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				entry.clone(),
+				entry_digest,
+				message_id.clone(),
+				debit_ref_id.clone(),
+				authorization_id.clone(),
+			),
+			Error::<Test>::RatingIdentifierAlreadyAdded
+		)
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -330,7 +330,7 @@ fn test_register_rating_id_already_exists() {
 				entry.clone(),
 				entry_digest,
 				message_id.clone(),
-				debit_ref_id.clone(),
+				identifier.clone(),
 				authorization_id.clone(),
 			),
 			Error::<Test>::RatingIdentifierAlreadyAdded

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -386,7 +386,7 @@ fn test_revoked_rating_id_already_exists() {
 				identifier.unwrap(),
 				authorization_id.clone(),
 			),
-			Error::<Test>::Reference
+			Error::<Test>::ReferenceNotDebitIdentifier
 		)
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -254,7 +254,6 @@ fn test_register_rating_id_already_exists() {
 	let message_id = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
 	let entity_uid = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
 	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
-	let debit_ref_id = Ss58Identifier::try_from([74u8; 10].to_vec()).unwrap();
 	let entry = RatingInputEntryOf::<Test> {
 		entity_uid,
 		provider_uid,

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -281,7 +281,7 @@ fn test_register_rating_id_already_exists() {
 	let id_digest = <Test as frame_system::Config>::Hashing::hash(
 		&[
 			&entry_digest.encode()[..],
-			&entity_uid.encode()[..],
+			&entity_uid.clone().encode()[..],
 			&message_id.encode()[..],
 			&space_id.encode()[..],
 			&creator.clone().encode()[..],

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -330,7 +330,7 @@ fn test_register_rating_id_already_exists() {
 				entry.clone(),
 				entry_digest,
 				message_id.clone(),
-				identifier.clone(),
+				identifier.unwrap(),
 				authorization_id.clone(),
 			),
 			Error::<Test>::RatingIdentifierAlreadyAdded

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -254,7 +254,7 @@ fn test_register_rating_id_already_exists() {
 	let message_id = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
 	let entity_uid = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
 	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
-	let debit_ref_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+	let debit_ref_id = Ss58Identifier::try_from([74u8; 10].to_vec()).unwrap();
 	let entry = RatingInputEntryOf::<Test> {
 		entity_uid,
 		provider_uid,

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -318,12 +318,10 @@ fn test_revoked_rating_id_already_exists() {
 	// Define test parameters
 	let creator = DID_00.clone();
 	let author = ACCOUNT_00.clone();
-	let message_id = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
-	let entity_uid = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
 	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
 	let entry = RatingInputEntryOf::<Test> {
-		entity_uid: entity_uid.clone(),
-		provider_uid,
+		entity_uid: BoundedVec::try_from([73u8; 10].to_vec()).unwrap(),
+		provider_uid: BoundedVec::try_from([73u8; 10].to_vec()).unwrap(),
 		total_encoded_rating: 250u64,
 		count_of_txn: 7u64,
 		entity_type: EntityTypeOf::Logistic,
@@ -387,7 +385,7 @@ fn test_revoked_rating_id_already_exists() {
 				identifier.unwrap(),
 				authorization_id.clone(),
 			),
-			Error::<Test>::RatingIdentifierAlreadyAdded
+			Error::<Test>::ReferenceNotDebitIdentifier
 		)
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -319,9 +319,10 @@ fn test_revoked_rating_id_already_exists() {
 	let creator = DID_00.clone();
 	let author = ACCOUNT_00.clone();
 	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+	let entity_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
 	let entry = RatingInputEntryOf::<Test> {
-		entity_uid: BoundedVec::try_from([73u8; 10].to_vec()).unwrap(),
-		provider_uid: BoundedVec::try_from([73u8; 10].to_vec()).unwrap(),
+		entity_uid,
+		provider_uid,
 		total_encoded_rating: 250u64,
 		count_of_txn: 7u64,
 		entity_type: EntityTypeOf::Logistic,
@@ -385,7 +386,7 @@ fn test_revoked_rating_id_already_exists() {
 				identifier.unwrap(),
 				authorization_id.clone(),
 			),
-			Error::<Test>::ReferenceNotDebitIdentifier
+			Error::<Test>::Reference
 		)
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -323,6 +323,75 @@ fn test_register_rating_id_already_exists() {
 			),
 			Error::<Test>::RatingIdentifierAlreadyAdded
 		);
+	});
+}
+
+#[test]
+fn test_revoked_rating_id_already_exists() {
+	// Define test parameters
+	let creator = DID_00.clone();
+	let author = ACCOUNT_00.clone();
+	let message_id = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let entity_uid = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
+	let provider_uid = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+	let entry = RatingInputEntryOf::<Test> {
+		entity_uid: entity_uid.clone(),
+		provider_uid,
+		total_encoded_rating: 250u64,
+		count_of_txn: 7u64,
+		entity_type: EntityTypeOf::Logistic,
+		rating_type: RatingTypeOf::Overall,
+		provider_did: creator.clone(),
+	};
+	let entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: AuthorizationIdOf =
+		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
+			.unwrap();
+
+	let id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&entry_digest.encode()[..],
+			&entity_uid.clone().encode()[..],
+			&message_id.encode()[..],
+			&space_id.encode()[..],
+			&creator.clone().encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let identifier =
+		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating);
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		// Create a space
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 3u64));
+
+		// Register the rating entry once
+		assert_ok!(Score::register_rating(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry.clone(),
+			entry_digest,
+			message_id.clone(),
+			authorization_id.clone(),
+		));
+
+		// Remove message_id and provider_did from entries
+		<MessageIdentifiers<Test>>::remove(message_id.clone(), creator.clone());
 		// Attempt to revoke a rating entry with the same identifier
 		assert_err!(
 			Score::revise_rating(

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -279,6 +279,19 @@ fn test_register_rating_id_already_exists() {
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
 			.unwrap();
 
+	let id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&entry_digest.encode()[..],
+			&entity_uid.encode()[..],
+			&message_id.encode()[..],
+			&space_id.encode()[..],
+			&creator.clone().encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let identifier =
+		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating);
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 


### PR DESCRIPTION
- Implemented the `revise_rating()` method in the existing test to give error `RatingIdentifierAlreadyExist` 
-Fixes https://github.com/dhiway/cord/issues/298