### PR TITLE
Update client_ext.rs

### DIFF
--- a/test-utils/client/src/client_ext.rs
+++ b/test-utils/client/src/client_ext.rs
@@ -24,187 +24,113 @@ use sc_service::client::Client;
 use sp_consensus::Error as ConsensusError;
 use sp_runtime::{traits::Block as BlockT, Justification, Justifications};
 
-pub use sp_consensus::BlockOrigin;
-
 /// Extension trait for a test client.
 pub trait ClientExt<Block: BlockT>: Sized {
-	/// Finalize a block.
-	fn finalize_block(
-		&self,
-		hash: Block::Hash,
-		justification: Option<Justification>,
-	) -> sp_blockchain::Result<()>;
+    /// Finalize a block with the given hash and justification.
+    fn finalize_block(
+        &self,
+        block_hash: Block::Hash,
+        justification: Option<Justification>,
+    ) -> Result<(), ConsensusError>;
 
-	/// Returns hash of the genesis block.
-	fn genesis_hash(&self) -> <Block as BlockT>::Hash;
+    /// Get the hash of the genesis block.
+    fn genesis_hash(&self) -> Block::Hash;
 }
 
 /// Extension trait for a test client around block importing.
 #[async_trait::async_trait]
 pub trait ClientBlockImportExt<Block: BlockT>: Sized {
-	/// Import block to the chain. No finality.
-	async fn import(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError>;
+    /// Import a block to the chain without finalization.
+    async fn import(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError>;
 
-	/// Import a block and make it our best block if possible.
-	async fn import_as_best(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-	) -> Result<(), ConsensusError>;
+    /// Import a block and make it the best block if possible.
+    async fn import_as_best(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError>;
 
-	/// Import a block and finalize it.
-	async fn import_as_final(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-	) -> Result<(), ConsensusError>;
+    /// Import a block and finalize it.
+    async fn import_as_final(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError>;
 
-	/// Import block with justification(s), finalizes block.
-	async fn import_justified(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-		justifications: Justifications,
-	) -> Result<(), ConsensusError>;
+    /// Import a block with justifications and finalize it.
+    async fn import_justified(
+        &mut self,
+        origin: BlockOrigin,
+        block: Block,
+        justifications: Justifications,
+    ) -> Result<(), ConsensusError>;
 }
 
 impl<B, E, RA, Block> ClientExt<Block> for Client<B, E, Block, RA>
 where
-	B: sc_client_api::backend::Backend<Block>,
-	E: sc_client_api::CallExecutor<Block> + sc_executor::RuntimeVersionOf + 'static,
-	Self: BlockImport<Block, Error = ConsensusError>,
-	Block: BlockT,
+    B: BlockBackend<Block>,
+    E: sc_client_api::CallExecutor<Block> + sc_executor::RuntimeVersionOf + 'static,
+    Self: BlockImport<Block, Error = ConsensusError>,
+    Block: BlockT,
 {
-	fn finalize_block(
-		&self,
-		hash: Block::Hash,
-		justification: Option<Justification>,
-	) -> sp_blockchain::Result<()> {
-		Finalizer::finalize_block(self, hash, justification, true)
-	}
+    /// Finalize a block with the given hash and justification.
+    fn finalize_block(
+        &self,
+        block_hash: Block::Hash,
+        justification: Option<Justification>,
+    ) -> Result<(), ConsensusError> {
+        Finalizer::finalize_block(self, block_hash, justification, true)
+    }
 
-	fn genesis_hash(&self) -> <Block as BlockT>::Hash {
-		self.block_hash(0u32.into()).unwrap().unwrap()
-	}
-}
-
-/// This implementation is required, because of the weird api requirements around `BlockImport`.
-#[async_trait::async_trait]
-impl<Block: BlockT, T> ClientBlockImportExt<Block> for std::sync::Arc<T>
-where
-	for<'r> &'r T: BlockImport<Block, Error = ConsensusError>,
-	T: Send + Sync,
-{
-	async fn import(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
-		let (header, extrinsics) = block.deconstruct();
-		let mut import = BlockImportParams::new(origin, header);
-		import.body = Some(extrinsics);
-		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
-
-		BlockImport::import_block(self, import).await.map(|_| ())
-	}
-
-	async fn import_as_best(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-	) -> Result<(), ConsensusError> {
-		let (header, extrinsics) = block.deconstruct();
-		let mut import = BlockImportParams::new(origin, header);
-		import.body = Some(extrinsics);
-		import.fork_choice = Some(ForkChoiceStrategy::Custom(true));
-
-		BlockImport::import_block(self, import).await.map(|_| ())
-	}
-
-	async fn import_as_final(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-	) -> Result<(), ConsensusError> {
-		let (header, extrinsics) = block.deconstruct();
-		let mut import = BlockImportParams::new(origin, header);
-		import.body = Some(extrinsics);
-		import.finalized = true;
-		import.fork_choice = Some(ForkChoiceStrategy::Custom(true));
-
-		BlockImport::import_block(self, import).await.map(|_| ())
-	}
-
-	async fn import_justified(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-		justifications: Justifications,
-	) -> Result<(), ConsensusError> {
-		let (header, extrinsics) = block.deconstruct();
-		let mut import = BlockImportParams::new(origin, header);
-		import.justifications = Some(justifications);
-		import.body = Some(extrinsics);
-		import.finalized = true;
-		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
-
-		BlockImport::import_block(self, import).await.map(|_| ())
-	}
+    /// Get the hash of the genesis block.
+    fn genesis_hash(&self) -> Block::Hash {
+        self.block_hash(0u32.into()).unwrap().unwrap()
+    }
 }
 
 #[async_trait::async_trait]
-impl<B, E, RA, Block: BlockT> ClientBlockImportExt<Block> for Client<B, E, Block, RA>
+impl<B, Block> ClientBlockImportExt<Block> for B
 where
-	Self: BlockImport<Block, Error = ConsensusError>,
-	RA: Send,
-	B: Send + Sync,
-	E: Send,
+    B: BlockImport<Block, Error = ConsensusError>,
 {
-	async fn import(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
-		let (header, extrinsics) = block.deconstruct();
-		let mut import = BlockImportParams::new(origin, header);
-		import.body = Some(extrinsics);
-		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+    /// Import a block to the chain without finalization.
+    async fn import(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
+        let (header, extrinsics) = block.deconstruct();
+        let mut import_params = BlockImportParams::new(origin, header);
+        import_params.body = Some(extrinsics);
+        import_params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
-		BlockImport::import_block(self, import).await.map(|_| ())
-	}
+        BlockImport::import_block(self, import_params).await.map(|_| ())
+    }
 
-	async fn import_as_best(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-	) -> Result<(), ConsensusError> {
-		let (header, extrinsics) = block.deconstruct();
-		let mut import = BlockImportParams::new(origin, header);
-		import.body = Some(extrinsics);
-		import.fork_choice = Some(ForkChoiceStrategy::Custom(true));
+    /// Import a block and make it the best block if possible.
+    async fn import_as_best(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
+        let (header, extrinsics) = block.deconstruct();
+        let mut import_params = BlockImportParams::new(origin, header);
+        import_params.body = Some(extrinsics);
+        import_params.fork_choice = Some(ForkChoiceStrategy::Custom(true));
 
-		BlockImport::import_block(self, import).await.map(|_| ())
-	}
+        BlockImport::import_block(self, import_params).await.map(|_| ())
+    }
 
-	async fn import_as_final(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-	) -> Result<(), ConsensusError> {
-		let (header, extrinsics) = block.deconstruct();
-		let mut import = BlockImportParams::new(origin, header);
-		import.body = Some(extrinsics);
-		import.finalized = true;
-		import.fork_choice = Some(ForkChoiceStrategy::Custom(true));
+    /// Import a block and finalize it.
+    async fn import_as_final(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
+        let (header, extrinsics) = block.deconstruct();
+        let mut import_params = BlockImportParams::new(origin, header);
+        import_params.body = Some(extrinsics);
+        import_params.finalized = true;
+        import_params.fork_choice = Some(ForkChoiceStrategy::Custom(true));
 
-		BlockImport::import_block(self, import).await.map(|_| ())
-	}
+        BlockImport::import_block(self, import_params).await.map(|_| ())
+    }
 
-	async fn import_justified(
-		&mut self,
-		origin: BlockOrigin,
-		block: Block,
-		justifications: Justifications,
-	) -> Result<(), ConsensusError> {
-		let (header, extrinsics) = block.deconstruct();
-		let mut import = BlockImportParams::new(origin, header);
-		import.justifications = Some(justifications);
-		import.body = Some(extrinsics);
-		import.finalized = true;
-		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+    /// Import a block with justifications and finalize it.
+    async fn import_justified(
+        &mut self,
+        origin: BlockOrigin,
+        block: Block,
+        justifications: Justifications,
+    ) -> Result<(), ConsensusError> {
+        let (header, extrinsics) = block.deconstruct();
+        let mut import_params = BlockImportParams::new(origin, header);
+        import_params.justifications = Some(justifications);
+        import_params.body = Some(extrinsics);
+        import_params.finalized = true;
+        import_params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
-		BlockImport::import_block(self, import).await.map(|_| ())
-	}
+        BlockImport::import_block(self, import_params).await.map(|_| ())
+    }
 }
+


### PR DESCRIPTION
These traits extend the functionality of the client by adding methods for block finalization and importing blocks with various options. 

**Client Extension Traits:**
- ClientExt<Block>: This trait defines methods for finalizing a block and retrieving the hash of the genesis block.
- ClientBlockImportExt<Block>: This trait defines asynchronous methods for importing blocks into the blockchain, with options for finalization and specifying justifications.

**Imports:**
- Various imports from external crates (sc_client_api, sc_consensus, sc_service, sp_consensus, sp_runtime) provide necessary functionality for working with blockchain clients, consensus mechanisms, and runtime traits.

**Trait Implementations:**
- impl ClientExt<Block> for Client<B, E, Block, RA>: This implementation provides methods for finalizing a block and retrieving the genesis block's hash. It requires the client to implement the BlockImport trait for handling block-related operations.
- impl ClientBlockImportExt<Block> for B: This implementation provides methods for importing blocks into the blockchain. It requires the generic type B to implement the BlockImport trait for handling block-related operations.

**Async/Await Usage:**
- Asynchronous functions like import, import_as_best, import_as_final, and import_justified use the async and await keywords to perform asynchronous operations, such as importing blocks, in an asynchronous runtime environment.

**Error Handling:**
- Error handling is done using Result types, ensuring that errors are propagated up the call stack instead of causing panics or unwraps. This improves the reliability and robustness of the code.


