### PR TITLE
asset: Add instance digest to storage on change

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -88,8 +88,13 @@ pub mod pallet {
 	pub type VCAssetEntryOf<T> =
 		VCAssetEntry<AssetStatusOf, AssetCreatorOf<T>, BlockNumberFor<T>, EntryHashOf<T>>;
 
-	pub type VCAssetDistributionEntryOf<T> =
-		VCAssetDistributionEntry<AssetStatusOf, AssetCreatorOf<T>, BlockNumberFor<T>, AssetIdOf>;
+	pub type VCAssetDistributionEntryOf<T> = VCAssetDistributionEntry<
+		AssetStatusOf,
+		AssetCreatorOf<T>,
+		EntryHashOf<T>,
+		BlockNumberFor<T>,
+		AssetIdOf,
+	>;
 
 	pub type AssetDistributionEntryOf<T> = AssetDistributionEntry<
 		AssetDescriptionOf<T>,
@@ -598,6 +603,7 @@ pub mod pallet {
 				VCAssetDistributionEntryOf::<T> {
 					asset_qty: issuance_qty,
 					asset_instance_parent: entry.asset_id.clone(),
+					digest,
 					asset_instance_status: AssetStatusOf::ACTIVE,
 					asset_instance_issuer: issuer,
 					asset_instance_owner: entry.asset_owner,
@@ -622,7 +628,7 @@ pub mod pallet {
 		pub fn vc_transfer(
 			origin: OriginFor<T>,
 			entry: AssetTransferEntryOf<T>,
-			_digest: EntryHashOf<T>,
+			digest: EntryHashOf<T>,
 		) -> DispatchResult {
 			let owner = <T as Config>::EnsureOrigin::ensure_origin(origin)?.subject();
 
@@ -650,6 +656,7 @@ pub mod pallet {
 				&entry.asset_instance_id,
 				VCAssetDistributionEntryOf::<T> {
 					asset_instance_owner: entry.new_asset_owner.clone(),
+					digest,
 					created_at: block_number,
 					..instance
 				},

--- a/pallets/asset/src/types.rs
+++ b/pallets/asset/src/types.rs
@@ -137,10 +137,18 @@ pub struct AssetDistributionEntry<
 #[derive(
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, PartialOrd, Ord, TypeInfo, MaxEncodedLen,
 )]
-pub struct VCAssetDistributionEntry<AssetStatusOf, AssetCreatorOf, BlockNumber, AssetId> {
+pub struct VCAssetDistributionEntry<
+	AssetStatusOf,
+	AssetCreatorOf,
+	EntryHashOf,
+	BlockNumber,
+	AssetId,
+> {
 	pub asset_qty: AssetQtyOf,
 	/// asset parent reference
 	pub asset_instance_parent: AssetId,
+	/// asset instance digest
+	pub digest: EntryHashOf,
 	/// status of the asset
 	pub asset_instance_status: AssetStatusOf,
 	/// asset issuer


### PR DESCRIPTION
Add instance digest into storage so can check when the entry changes (change in ownership, entry etc).