### PR TITLE
Remove deprecated getter() calls from all pallets

### DIFF
--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -140,18 +140,15 @@ pub mod pallet {
 
 	/// asset entry identifiers with details stored on chain.
 	#[pallet::storage]
-	#[pallet::getter(fn assets)]
 	pub type Assets<T> = StorageMap<_, Blake2_128Concat, AssetIdOf, AssetEntryOf<T>, OptionQuery>;
 
 	/// asset vc entry idenitfiers with details stored on chain.
 	#[pallet::storage]
-	#[pallet::getter(fn vc_assets)]
 	pub type VCAssets<T> =
 		StorageMap<_, Blake2_128Concat, AssetIdOf, VCAssetEntryOf<T>, OptionQuery>;
 
 	/// asset entry identifiers with details stored on chain.
 	#[pallet::storage]
-	#[pallet::getter(fn distribution)]
 	pub type Distribution<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat,
@@ -162,7 +159,6 @@ pub mod pallet {
 
 	/// asset entry identifiers with  details stored on chain.
 	#[pallet::storage]
-	#[pallet::getter(fn issued)]
 	pub type Issuance<T> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -175,7 +171,6 @@ pub mod pallet {
 
 	/// asset vc entry identifiers with details stored on chain.
 	#[pallet::storage]
-	#[pallet::getter(fn vc_issued)]
 	pub type VCIssuance<T> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -187,7 +182,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn asset_lookup)]
 	pub type AssetLookup<T> =
 		StorageMap<_, Blake2_128Concat, EntryHashOf<T>, AssetIdOf, OptionQuery>;
 

--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -162,13 +162,11 @@ pub mod pallet {
 	/// Space information stored on chain.
 	/// It maps from an identifier to its details.
 	#[pallet::storage]
-	#[pallet::getter(fn spaces)]
 	pub type Spaces<T> = StorageMap<_, Blake2_128Concat, SpaceIdOf, SpaceDetailsOf<T>, OptionQuery>;
 
 	/// Space authorizations stored on-chain.
 	/// It maps from an identifier to delegates.
 	#[pallet::storage]
-	#[pallet::getter(fn authorizations)]
 	pub type Authorizations<T> =
 		StorageMap<_, Blake2_128Concat, AuthorizationIdOf, SpaceAuthorizationOf<T>, OptionQuery>;
 
@@ -176,7 +174,6 @@ pub mod pallet {
 	/// It maps from an identifier to a  bounded vec of delegates and
 	/// permissions.
 	#[pallet::storage]
-	#[pallet::getter(fn delegates)]
 	pub(super) type Delegates<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat,

--- a/pallets/did-name/src/lib.rs
+++ b/pallets/did-name/src/lib.rs
@@ -67,19 +67,16 @@ pub mod pallet {
 
 	/// Map of name -> ownership details.
 	#[pallet::storage]
-	#[pallet::getter(fn owner)]
 	pub type Owner<T> = StorageMap<_, Blake2_128Concat, DidNameOf<T>, DidNameOwnershipOf<T>>;
 
 	/// Map of owner -> name.
 	#[pallet::storage]
-	#[pallet::getter(fn names)]
 	pub type Names<T> = StorageMap<_, Blake2_128Concat, DidNameOwnerOf<T>, DidNameOf<T>>;
 
 	/// Map of name -> ().
 	///
 	/// If a name key is present, the name is currently banned.
 	#[pallet::storage]
-	#[pallet::getter(fn is_banned)]
 	pub type Banned<T> = StorageMap<_, Blake2_128Concat, DidNameOf<T>, ()>;
 
 	#[pallet::config]

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -277,14 +277,12 @@ pub mod pallet {
 	///
 	/// It maps from a DID identifier to the DID details.
 	#[pallet::storage]
-	#[pallet::getter(fn get_did)]
 	pub type Did<T> = StorageMap<_, Blake2_128Concat, DidIdentifierOf<T>, DidDetails<T>>;
 
 	/// Service endpoints associated with DIDs.
 	///
 	/// It maps from (DID identifier, service ID) to the service details.
 	#[pallet::storage]
-	#[pallet::getter(fn get_service_endpoints)]
 	pub type ServiceEndpoints<T> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -307,7 +305,6 @@ pub mod pallet {
 	/// It maps from a DID identifier to a unit tuple, for the sake of tracking
 	/// DID identifiers.
 	#[pallet::storage]
-	#[pallet::getter(fn get_deleted_did)]
 	pub(crate) type DidBlacklist<T> = StorageMap<_, Blake2_128Concat, DidIdentifierOf<T>, ()>;
 
 	#[pallet::event]

--- a/pallets/did/src/tests.rs
+++ b/pallets/did/src/tests.rs
@@ -55,7 +55,8 @@ fn check_successful_simple_ed25519_creation() {
 			Box::new(details),
 			did::DidSignature::from(signature),
 		));
-		let stored_did = Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+		let stored_did =
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(stored_did.authentication_key, generate_key_id(&auth_did_key.clone().into()));
 		assert_eq!(stored_did.key_agreement_keys.len(), 0);
 		assert_eq!(stored_did.delegation_key, None);
@@ -81,7 +82,8 @@ fn check_successful_simple_sr25519_creation() {
 			Box::new(details),
 			did::DidSignature::from(signature),
 		));
-		let stored_did = Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+		let stored_did =
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(stored_did.authentication_key, generate_key_id(&auth_did_key.clone().into()));
 		assert_eq!(stored_did.key_agreement_keys.len(), 0);
 		assert_eq!(stored_did.delegation_key, None);
@@ -107,7 +109,8 @@ fn check_successful_simple_ecdsa_creation() {
 			Box::new(details),
 			did::DidSignature::from(signature),
 		));
-		let stored_did = Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+		let stored_did =
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(stored_did.authentication_key, generate_key_id(&auth_did_key.clone().into()));
 		assert_eq!(stored_did.key_agreement_keys.len(), 0);
 		assert_eq!(stored_did.delegation_key, None);
@@ -153,7 +156,8 @@ fn check_successful_complete_creation() {
 			did::DidSignature::from(signature),
 		));
 
-		let stored_did = Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+		let stored_did =
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(stored_did.authentication_key, generate_key_id(&auth_did_key.clone().into()));
 		assert_eq!(stored_did.key_agreement_keys.len(), 2);
 		for key in enc_keys.iter().copied() {
@@ -188,7 +192,7 @@ fn check_successful_complete_creation() {
 		// We check that the service details in the creation operation have been all
 		// stored in the storage...
 		details.new_service_details.iter().for_each(|new_service| {
-			let stored_service = Did::get_service_endpoints(&alice_did, &new_service.id)
+			let stored_service = did::ServiceEndpoints::<Test>::get(&alice_did, &new_service.id)
 				.expect("Service endpoint should be stored.");
 			assert_eq!(stored_service.id, new_service.id);
 			assert_eq!(stored_service.urls, new_service.urls);
@@ -622,7 +626,7 @@ fn check_successful_authentication_key_update() {
 			DidVerificationKey::from(new_auth_key.public())
 		));
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.authentication_key,
 			generate_key_id(&DidVerificationKey::from(new_auth_key.public()).into())
@@ -665,7 +669,7 @@ fn check_successful_authentication_key_max_public_keys_update() {
 		));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.authentication_key,
 			generate_key_id(&DidVerificationKey::from(new_auth_key.public()).into())
@@ -704,7 +708,7 @@ fn check_reused_key_authentication_key_update() {
 		));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.authentication_key,
 			generate_key_id(&DidVerificationKey::from(new_auth_key.public()).into())
@@ -801,7 +805,7 @@ fn check_successful_delegation_key_update() {
 		assert_ok!(Did::set_delegation_key(origin, DidVerificationKey::from(new_del_key.public())));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.delegation_key,
 			Some(generate_key_id(&DidVerificationKey::from(new_del_key.public()).into()))
@@ -846,7 +850,7 @@ fn check_successful_delegation_key_max_public_keys_update() {
 		assert_ok!(Did::set_delegation_key(origin, DidVerificationKey::from(new_del_key.public())));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.delegation_key,
 			Some(generate_key_id(&DidVerificationKey::from(new_del_key.public()).into()))
@@ -882,7 +886,7 @@ fn check_reused_key_delegation_key_update() {
 		assert_ok!(Did::set_delegation_key(origin, DidVerificationKey::from(new_del_key.public())));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.delegation_key,
 			Some(generate_key_id(&DidVerificationKey::from(new_del_key.public()).into()))
@@ -1002,7 +1006,7 @@ fn check_successful_delegation_key_deletion() {
 		assert_ok!(Did::remove_delegation_key(origin));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert!(new_did_details.delegation_key.is_none());
 		let public_keys = new_did_details.public_keys;
 		// Total is -1 for the removal + auth key = 1
@@ -1032,7 +1036,7 @@ fn check_successful_reused_delegation_key_deletion() {
 		assert_ok!(Did::remove_delegation_key(origin));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert!(new_did_details.delegation_key.is_none());
 		let public_keys = new_did_details.public_keys;
 		// Total should be unchanged as the key was re-used so it is not completely
@@ -1096,7 +1100,7 @@ fn check_successful_assertion_key_update() {
 		System::set_block_number(new_block_number);
 		assert_ok!(Did::set_assertion_key(origin, DidVerificationKey::from(new_att_key.public())));
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.assertion_key,
 			Some(generate_key_id(&DidVerificationKey::from(new_att_key.public()).into()))
@@ -1140,7 +1144,7 @@ fn check_successful_assertion_key_max_public_keys_update() {
 		System::set_block_number(new_block_number);
 		assert_ok!(Did::set_assertion_key(origin, DidVerificationKey::from(new_att_key.public())));
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.assertion_key,
 			Some(generate_key_id(&DidVerificationKey::from(new_att_key.public()).into()))
@@ -1176,7 +1180,7 @@ fn check_reused_key_assertion_key_update() {
 		assert_ok!(Did::set_assertion_key(origin, DidVerificationKey::from(new_att_key.public())));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(
 			new_did_details.assertion_key,
 			Some(generate_key_id(&DidVerificationKey::from(new_att_key.public()).into()))
@@ -1296,7 +1300,7 @@ fn check_successful_assertion_key_deletion() {
 		assert_ok!(Did::remove_assertion_key(origin));
 
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert!(new_did_details.assertion_key.is_none());
 		let public_keys = new_did_details.public_keys;
 		// Total is -1 for the removal + auth key = 1
@@ -1325,7 +1329,7 @@ fn check_successful_reused_assertion_key_deletion() {
 		did::Did::<Test>::insert(alice_did.clone(), old_did_details.clone());
 		assert_ok!(Did::remove_assertion_key(origin));
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert!(new_did_details.assertion_key.is_none());
 		let public_keys = new_did_details.public_keys;
 		// Total should be unchanged as the key was re-used so it is not completely
@@ -1384,7 +1388,7 @@ fn check_successful_key_agreement_key_addition() {
 		System::set_block_number(new_block_number);
 		assert_ok!(Did::add_key_agreement_key(origin, new_key_agreement_key,));
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert_eq!(new_did_details.key_agreement_keys.len(), 1);
 		assert_eq!(
 			new_did_details.key_agreement_keys.iter().next().unwrap(),
@@ -1458,7 +1462,7 @@ fn check_successful_key_agreement_key_deletion() {
 		did::Did::<Test>::insert(alice_did.clone(), old_did_details);
 		assert_ok!(Did::remove_key_agreement_key(origin, generate_key_id(&old_enc_key.into()),));
 		let new_did_details =
-			Did::get_did(&alice_did).expect("ALICE_DID should be present on chain.");
+			did::Did::<Test>::get(&alice_did).expect("ALICE_DID should be present on chain.");
 		assert!(new_did_details.key_agreement_keys.is_empty());
 		let public_keys = new_did_details.public_keys;
 		// Total is -1 for the enc key removal + auth key = 1
@@ -1919,8 +1923,8 @@ fn check_successful_deletion_no_endpoints() {
 		did::Did::<Test>::insert(alice_did.clone(), did_details);
 		assert_eq!(did::pallet::DidEndpointsCount::<Test>::get(&alice_did), 0);
 		assert_ok!(Did::delete(origin, 0));
-		assert!(Did::get_did(alice_did.clone()).is_none());
-		assert!(Did::get_deleted_did(alice_did.clone()).is_some());
+		assert!(did::Did::<Test>::get(alice_did.clone()).is_none());
+		assert!(did::DidBlacklist::<Test>::get(alice_did.clone()).is_some());
 
 		assert_eq!(did::pallet::DidEndpointsCount::<Test>::get(&alice_did), 0);
 
@@ -1963,8 +1967,8 @@ fn check_successful_deletion_with_endpoints() {
 		assert_eq!(did::pallet::DidEndpointsCount::<Test>::get(&alice_did), 1);
 
 		assert_ok!(Did::delete(origin, 1));
-		assert!(Did::get_did(alice_did.clone()).is_none());
-		assert!(Did::get_deleted_did(alice_did.clone()).is_some());
+		assert!(did::Did::<Test>::get(alice_did.clone()).is_none());
+		assert!(did::DidBlacklist::<Test>::get(alice_did.clone()).is_some());
 
 		assert_eq!(did::pallet::DidEndpointsCount::<Test>::get(&alice_did), 0);
 
@@ -2584,8 +2588,8 @@ fn check_authentication_successful_operation_verification() {
 			&did::DidSignature::from(signature)
 		));
 		// Verify that the DID tx counter has increased
-		let did_details =
-			Did::get_did(&call_operation.operation.did).expect("DID should be present on chain.");
+		let did_details = did::Did::<Test>::get(&call_operation.operation.did)
+			.expect("DID should be present on chain.");
 		assert_eq!(did_details.last_tx_counter, mock_did.last_tx_counter + 1u64);
 	});
 }
@@ -2614,8 +2618,8 @@ fn check_assertion_successful_operation_verification() {
 			&did::DidSignature::from(signature)
 		));
 		// Verify that the DID tx counter has increased
-		let did_details =
-			Did::get_did(&call_operation.operation.did).expect("DID should be present on chain.");
+		let did_details = did::Did::<Test>::get(&call_operation.operation.did)
+			.expect("DID should be present on chain.");
 		assert_eq!(did_details.last_tx_counter, mock_did.last_tx_counter + 1u64);
 	});
 }
@@ -2644,8 +2648,8 @@ fn check_delegation_successful_operation_verification() {
 			&did::DidSignature::from(signature)
 		));
 		// Verify that the DID tx counter has increased
-		let did_details =
-			Did::get_did(&call_operation.operation.did).expect("DID should be present on chain.");
+		let did_details = did::Did::<Test>::get(&call_operation.operation.did)
+			.expect("DID should be present on chain.");
 		assert_eq!(did_details.last_tx_counter, mock_did.last_tx_counter + 1u64);
 	});
 }
@@ -2698,8 +2702,8 @@ fn check_tx_counter_wrap_operation_verification() {
 			&did::DidSignature::from(signature)
 		));
 		// Verify that the DID tx counter has wrapped around
-		let did_details =
-			Did::get_did(&call_operation.operation.did).expect("DID should be present on chain.");
+		let did_details = did::Did::<Test>::get(&call_operation.operation.did)
+			.expect("DID should be present on chain.");
 		assert_eq!(did_details.last_tx_counter, 0u64);
 	});
 }

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -170,7 +170,6 @@ pub mod pallet {
 
 	/// Information that is pertinent to identify the entity behind an account.
 	#[pallet::storage]
-	#[pallet::getter(fn identity)]
 	pub(super) type IdentityOf<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
@@ -181,7 +180,6 @@ pub mod pallet {
 	/// The super-identity of an alternative "sub" identity together with its name, within that
 	/// context. If the account is not some other account's sub-identity, then just `None`.
 	#[pallet::storage]
-	#[pallet::getter(fn super_of)]
 	pub(super) type SuperOf<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, (T::AccountId, Data), OptionQuery>;
 
@@ -191,7 +189,6 @@ pub mod pallet {
 	///
 	/// TWOX-NOTE: OK ― `AccountId` is a secure hash.
 	#[pallet::storage]
-	#[pallet::getter(fn subs_of)]
 	pub(super) type SubsOf<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
@@ -203,7 +200,6 @@ pub mod pallet {
 	/// The set of registrars. Not expected to get very big as can only be added
 	/// through a special origin (likely a council motion).
 	#[pallet::storage]
-	#[pallet::getter(fn registrars)]
 	pub(super) type Registrars<T: Config> = StorageValue<
 		_,
 		BoundedVec<
@@ -220,7 +216,6 @@ pub mod pallet {
 
 	/// A map of the accounts who are authorized to grant usernames.
 	#[pallet::storage]
-	#[pallet::getter(fn authority)]
 	pub(super) type UsernameAuthorities<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, AuthorityPropertiesOf<T>, OptionQuery>;
 
@@ -230,7 +225,6 @@ pub mod pallet {
 	/// Multiple usernames may map to the same `AccountId`, but `IdentityOf` will only map to one
 	/// primary username.
 	#[pallet::storage]
-	#[pallet::getter(fn username)]
 	pub(super) type AccountOfUsername<T: Config> =
 		StorageMap<_, Blake2_128Concat, Username<T>, T::AccountId, OptionQuery>;
 
@@ -241,7 +235,6 @@ pub mod pallet {
 	///
 	/// First tuple item is the account and second is the acceptance deadline.
 	#[pallet::storage]
-	#[pallet::getter(fn preapproved_usernames)]
 	pub type PendingUsernames<T: Config> = StorageMap<
 		_,
 		Blake2_128Concat,

--- a/pallets/membership/src/lib.rs
+++ b/pallets/membership/src/lib.rs
@@ -99,13 +99,11 @@ pub mod pallet {
 
 	/// The current membership, stored as an ordered Vec.
 	#[pallet::storage]
-	#[pallet::getter(fn members)]
 	pub type Members<T: Config<I>, I: 'static = ()> =
 		StorageValue<_, BoundedVec<T::AccountId, T::MaxMembers>, ValueQuery>;
 
 	/// The current prime member, if one exists.
 	#[pallet::storage]
-	#[pallet::getter(fn prime)]
 	pub type Prime<T: Config<I>, I: 'static = ()> = StorageValue<_, T::AccountId, OptionQuery>;
 
 	#[pallet::genesis_config]
@@ -333,7 +331,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			T::PrimeOrigin::ensure_origin(origin)?;
 			let who = T::Lookup::lookup(who)?;
-			let members = Self::members();
+			let members = <Members<T, I>>::get();
 			members.binary_search(&who).ok().ok_or(Error::<T, I>::NotMember)?;
 			Prime::<T, I>::put(&who);
 			T::MembershipChanged::set_prime(Some(who));
@@ -367,13 +365,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 impl<T: Config<I>, I: 'static> Contains<T::AccountId> for Pallet<T, I> {
 	fn contains(t: &T::AccountId) -> bool {
-		Self::members().binary_search(t).is_ok()
+		<Members<T, I>>::get().binary_search(t).is_ok()
 	}
 }
 
 impl<T: Config<I>, I: 'static> SortedMembers<T::AccountId> for Pallet<T, I> {
 	fn sorted_members() -> Vec<T::AccountId> {
-		Self::members().to_vec()
+		<Members<T, I>>::get().to_vec()
 	}
 
 	fn count() -> usize {

--- a/pallets/network-membership/src/lib.rs
+++ b/pallets/network-membership/src/lib.rs
@@ -81,7 +81,6 @@ pub mod pallet {
 
 	// maps author identity with expire block
 	#[pallet::storage]
-	#[pallet::getter(fn members)]
 	pub(super) type Members<T: Config> = CountedStorageMap<
 		_,
 		Blake2_128Concat,

--- a/pallets/network-membership/src/tests.rs
+++ b/pallets/network-membership/src/tests.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{mock::*, Error, Event, MemberData};
+use crate::{mock::*, Error, Event, MemberData, Members};
 
 use frame_support::{assert_err, assert_ok, error::BadOrigin};
 use frame_system::RawOrigin;
@@ -27,7 +27,7 @@ fn test_genesis_build() {
 		run_to_block(1);
 		// Verify state
 		assert_eq!(
-			NetworkMembership::members(AccountId::new([11u8; 32])),
+			Members::<Test>::get(AccountId::new([11u8; 32])),
 			Some(MemberData { expire_on: 5 })
 		);
 		assert_eq!(NetworkMembership::members_count(), 1);
@@ -51,7 +51,7 @@ fn test_add_member_request() {
 
 		// This ensures that the account was successfully added
 		assert_eq!(
-			NetworkMembership::members(AccountId::new([13u8; 32])),
+			Members::<Test>::get(AccountId::new([13u8; 32])),
 			Some(MemberData { expire_on: 1 + MembershipPeriod::get() })
 		);
 
@@ -124,7 +124,7 @@ fn test_renew_membership() {
 
 		// This ensures that the account was successfully added
 		assert_eq!(
-			NetworkMembership::members(AccountId::new([13u8; 32])),
+			Members::<Test>::get(AccountId::new([13u8; 32])),
 			Some(MemberData { expire_on: 6 + MembershipPeriod::get() })
 		);
 
@@ -270,7 +270,7 @@ fn test_renew_membership_again_should_fail() {
 
 		// This ensures that the account was successfully added
 		assert_eq!(
-			NetworkMembership::members(AccountId::new([13u8; 32])),
+			Members::<Test>::get(AccountId::new([13u8; 32])),
 			Some(MemberData { expire_on: 6 + MembershipPeriod::get() })
 		);
 

--- a/pallets/network-score/src/lib.rs
+++ b/pallets/network-score/src/lib.rs
@@ -212,14 +212,12 @@ pub mod pallet {
 
 	/// rating entry identifiers with rating details stored on chain.
 	#[pallet::storage]
-	#[pallet::getter(fn rating_entries)]
 	pub type RatingEntries<T> =
 		StorageMap<_, Blake2_128Concat, RatingEntryIdOf, RatingEntryOf<T>, OptionQuery>;
 
 	/// aggregated network score - aggregated and mapped to an entity
 	/// identifier.
 	#[pallet::storage]
-	#[pallet::getter(fn aggregate_scores)]
 	pub type AggregateScores<T> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -231,7 +229,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn message_identifiers)]
 	pub type MessageIdentifiers<T> = StorageDoubleMap<
 		_,
 		Twox64Concat,

--- a/pallets/node-authorization/src/lib.rs
+++ b/pallets/node-authorization/src/lib.rs
@@ -101,17 +101,14 @@ pub mod pallet {
 
 	/// The set of well known nodes. This is stored sorted (just by value).
 	#[pallet::storage]
-	#[pallet::getter(fn well_known_nodes)]
 	pub type WellKnownNodes<T> = StorageValue<_, BTreeSet<PeerId>, ValueQuery>;
 
 	/// A map that maintains the ownership of each node.
 	#[pallet::storage]
-	#[pallet::getter(fn owners)]
 	pub type Owners<T: Config> = StorageMap<_, Blake2_128Concat, PeerId, NodeInfoOf<T>>;
 
 	/// The additional adapative connections of each node.
 	#[pallet::storage]
-	#[pallet::getter(fn additional_connection)]
 	pub type AdditionalConnections<T> =
 		StorageMap<_, Blake2_128Concat, PeerId, BTreeSet<PeerId>, ValueQuery>;
 

--- a/pallets/offences/src/lib.rs
+++ b/pallets/offences/src/lib.rs
@@ -86,7 +86,6 @@ pub mod pallet {
 	/// The primary structure that holds all offence records keyed by report
 	/// identifiers.
 	#[pallet::storage]
-	#[pallet::getter(fn reports)]
 	pub type Reports<T: Config> = StorageMap<
 		_,
 		Twox64Concat,

--- a/pallets/schema/src/lib.rs
+++ b/pallets/schema/src/lib.rs
@@ -120,7 +120,6 @@ pub mod pallet {
 	/// schemas stored on chain.
 	/// It maps from a schema identifier to its details.
 	#[pallet::storage]
-	#[pallet::getter(fn schemas)]
 	pub type Schemas<T> = StorageMap<_, Blake2_128Concat, SchemaIdOf, SchemaEntryOf<T>>;
 
 	#[pallet::event]

--- a/pallets/statement/src/lib.rs
+++ b/pallets/statement/src/lib.rs
@@ -165,14 +165,12 @@ pub mod pallet {
 	/// It maps from an identifier to its details.
 	/// Only stores the latest state.
 	#[pallet::storage]
-	#[pallet::getter(fn statements)]
 	pub type Statements<T> =
 		StorageMap<_, Blake2_128Concat, StatementIdOf, StatementDetailsOf<T>, OptionQuery>;
 
 	/// statement uniques stored on chain.
 	/// It maps from a statement identifier and hash to its details.
 	#[pallet::storage]
-	#[pallet::getter(fn entries)]
 	pub type Entries<T> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -186,7 +184,6 @@ pub mod pallet {
 	/// statement uniques stored on chain.
 	/// It maps from a statement identifier and hash to its details.
 	#[pallet::storage]
-	#[pallet::getter(fn presentations)]
 	pub type Presentations<T> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -200,7 +197,6 @@ pub mod pallet {
 	/// Revocation registry of statement entries stored on chain.
 	/// It maps from a statement identifier and hash to its details.
 	#[pallet::storage]
-	#[pallet::getter(fn revocation_list)]
 	pub type RevocationList<T> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -214,7 +210,6 @@ pub mod pallet {
 	/// Storage for Identifier lookup.
 	/// It maps from a statement entry digest and registry id to an identifier.
 	#[pallet::storage]
-	#[pallet::getter(fn identifier_lookup)]
 	pub type IdentifierLookup<T> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,

--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -244,7 +244,7 @@ fn updating_a_registered_statement_should_succeed() {
 			authorization_id,
 		));
 
-		let revoked_statements = Statement::revocation_list(statement_id, statement_digest)
+		let revoked_statements = RevocationList::<Test>::get(statement_id, statement_digest)
 			.expect("Old Statement digest should be present on the revoked list.");
 
 		assert!(revoked_statements.revoked);
@@ -536,7 +536,7 @@ fn revoking_a_registered_statement_should_succeed() {
 			authorization_id,
 		));
 
-		let revoked_statements = Statement::revocation_list(statement_id, statement_digest)
+		let revoked_statements = RevocationList::<Test>::get(statement_id, statement_digest)
 			.expect("Old Statement digest should be present on the revoked list.");
 
 		assert!(revoked_statements.revoked);
@@ -699,8 +699,9 @@ fn restoring_a_revoked_statement_should_succeed() {
 			authorization_id.clone(),
 		));
 
-		let revoked_statements = Statement::revocation_list(statement_id.clone(), statement_digest)
-			.expect("Old Statement digest should be present on the revoked list.");
+		let revoked_statements =
+			RevocationList::<Test>::get(statement_id.clone(), statement_digest)
+				.expect("Old Statement digest should be present on the revoked list.");
 
 		assert!(revoked_statements.revoked);
 

--- a/primitives/identifier/src/lib.rs
+++ b/primitives/identifier/src/lib.rs
@@ -77,7 +77,6 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
 	#[pallet::storage]
-	#[pallet::getter(fn identifiers)]
 	pub type Identifiers<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,

--- a/runtime/authorities/src/lib.rs
+++ b/runtime/authorities/src/lib.rs
@@ -105,22 +105,18 @@ pub mod pallet {
 
 	/// list incoming authorities
 	#[pallet::storage]
-	#[pallet::getter(fn incoming)]
 	pub type IncomingAuthorities<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
 	/// list outgoing authorities
 	#[pallet::storage]
-	#[pallet::getter(fn outgoing)]
 	pub type OutgoingAuthorities<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
 	/// maps member id to member data
 	#[pallet::storage]
-	#[pallet::getter(fn member)]
 	pub type Members<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
 	// Blacklist.
 	#[pallet::storage]
-	#[pallet::getter(fn blacklist)]
 	pub type BlackList<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
 	#[pallet::genesis_config]

--- a/test-utils/runtime/src/cord_test_pallet.rs
+++ b/test-utils/runtime/src/cord_test_pallet.rs
@@ -52,6 +52,7 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
 
+	/* TODO:: Remove deprecated getter call, instead use Authorities<Type>::get() */
 	#[pallet::storage]
 	#[pallet::getter(fn authorities)]
 	pub type Authorities<T> = StorageValue<_, Vec<Public>, ValueQuery>;

--- a/test-utils/runtime/src/cord_test_pallet.rs
+++ b/test-utils/runtime/src/cord_test_pallet.rs
@@ -53,7 +53,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::storage]
-	#[pallet::getter(fn authorities)]
 	pub type Authorities<T> = StorageValue<_, Vec<Public>, ValueQuery>;
 
 	#[pallet::genesis_config]

--- a/test-utils/runtime/src/cord_test_pallet.rs
+++ b/test-utils/runtime/src/cord_test_pallet.rs
@@ -53,6 +53,7 @@ pub mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::storage]
+	#[pallet::getter(fn authorities)]
 	pub type Authorities<T> = StorageValue<_, Vec<Public>, ValueQuery>;
 
 	#[pallet::genesis_config]

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -79,6 +79,8 @@ pub type AuraId = sp_consensus_aura::sr25519::AuthorityId;
 #[cfg(feature = "std")]
 pub use extrinsic::{ExtrinsicBuilder, Transfer};
 
+//use crate::cord_test_pallet::Authorities;
+
 const LOG_TARGET: &str = "cord-test-runtime";
 
 // Include the WASM binary
@@ -629,6 +631,10 @@ impl_runtime_apis! {
 			sp_consensus_aura::SlotDuration::from_millis(1000)
 		}
 
+		/* TODO:: Remove deprecated way of accessing storage through getter,
+		 * instead use Authorities<Type>::get().
+		 * Currently type resolution is failing to fulfill above.
+		 */
 		fn authorities() -> Vec<AuraId> {
 			CordTest::authorities().into_iter().map(AuraId::from).collect()
 		}


### PR DESCRIPTION
- Remove deprecated `getter()`storage calls from all pallets.

Updates: #426 