### PR TITLE
Add custom metadata storage

### DIFF
--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -175,7 +175,7 @@ benchmarks! {
 			pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity).expect("Approval should not fail.");
 			Pallet::<T>::create(origin.clone(), entry, digest, authorization_id.clone())?;
 
-		}: _<T::RuntimeOrigin>(origin, issue_entry, issue_entry_digest, authorization_id)
+		}: _<T::RuntimeOrigin>(origin, issue_entry, issue_entry_digest, authorization_id, None)
 		verify {
 			assert_last_event::<T>(Event::Issue { identifier: asset_id, instance: instance_id }.into());
 		}
@@ -265,7 +265,7 @@ benchmarks! {
 			pallet_chain_space::Pallet::<T>::create(origin.clone(), space_digest )?;
 			pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity).expect("Approval should not fail.");
 			Pallet::<T>::create(origin.clone(), entry, digest, authorization_id.clone())?;
-			Pallet::<T>::issue(origin.clone(), issue_entry, issue_entry_digest, authorization_id)?;
+			Pallet::<T>::issue(origin.clone(), issue_entry, issue_entry_digest, authorization_id, None)?;
 
 		}: _<T::RuntimeOrigin>(origin, transfer_entry, transfer_entry_digest)
 		verify {
@@ -346,7 +346,7 @@ benchmarks! {
 			pallet_chain_space::Pallet::<T>::create(origin.clone(), space_digest )?;
 			pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity).expect("Approval should not fail.");
 			Pallet::<T>::create(origin.clone(), entry, digest, authorization_id.clone())?;
-			Pallet::<T>::issue(origin.clone(), issue_entry, issue_entry_digest, authorization_id)?;
+			Pallet::<T>::issue(origin.clone(), issue_entry, issue_entry_digest, authorization_id, None)?;
 
 		}: _<T::RuntimeOrigin>(origin, asset_id.clone(), Some(instance_id.clone()), new_status.clone())
 		verify {

--- a/pallets/asset/src/mock.rs
+++ b/pallets/asset/src/mock.rs
@@ -65,6 +65,7 @@ impl mock_origin::Config for Test {
 parameter_types! {
 	pub const MaxEncodedValueLength: u32 = 1_024;
 	pub const MaxAssetDistribution: u32 = u32::MAX;
+	pub const MaxMetaPairLength: u32 = 5;
 }
 
 impl Config for Test {
@@ -73,6 +74,7 @@ impl Config for Test {
 	type OriginSuccess = mock_origin::DoubleOrigin<AccountId, SubjectId>;
 	type MaxEncodedValueLength = MaxEncodedValueLength;
 	type MaxAssetDistribution = MaxAssetDistribution;
+	type MaxMetaPairLength = MaxMetaPairLength;
 	type WeightInfo = ();
 }
 

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -158,7 +158,8 @@ fn asset_issue_should_succeed() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			issue_entry.clone(),
 			issue_entry_digest,
-			authorization_id
+			authorization_id,
+			None
 		));
 	});
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -798,6 +798,7 @@ impl pallet_network_score::Config for Runtime {
 parameter_types! {
 	pub const MaxEncodedValueLength: u32 = 1_024;
 	pub const MaxAssetDistribution: u32 = u32::MAX;
+	pub const MaxMetaPairLength: u32 = 5;
 }
 
 impl pallet_asset::Config for Runtime {
@@ -806,6 +807,7 @@ impl pallet_asset::Config for Runtime {
 	type OriginSuccess = pallet_did::DidRawOrigin<AccountId, DidIdentifier>;
 	type MaxEncodedValueLength = MaxEncodedValueLength;
 	type MaxAssetDistribution = MaxAssetDistribution;
+	type MaxMetaPairLength = MaxMetaPairLength;
 	type WeightInfo = weights::pallet_asset::WeightInfo<Runtime>;
 }
 


### PR DESCRIPTION
This is a draft implementation of having a custom `metadata` of `MaxMetaPairLength` in asset, but in general this can be replicated across the chain.
One of the current use-case would be to store `created_at: UTC of old_chain_block` after migration so apps can access this value instead of newly created block time.

### How it is implemented?
- For demonstration have made this to `asset` specific.
- Create a storage named `AssetMeta` to store metadata of storage. It allows to custom k:v of `MaxMetaPairLength` currently set to 5, where the `identifier` of the asset is the first key, and second key is a custom type. 
- When lookup'ed on using the identifier we get a list of all the `k:v` of the pallet metadata, but when used with a custom `key` it produces a result with the `custom value`.

Ex:
- Create a metapairs on the SDK, with `string` type `k:v` which has custom keys and values attached to the identifier of the asset.
```typescript
    const metaPairs: [string, string][] = [
      ["key1", "value1"],
      ["key2", "value2"],
      ["key3", "value3"],
      ["key4", "value4"],
      ["key5", "value5"],
    ];

    const tx = api.tx.asset.issue(
      assetEntry.entry,
      assetEntry.digest,
      authorizationId,
      metaPairs
    )
```

- Chain-state after execution with all `k:v` seen,
<img width="1512" alt="Screenshot 2024-05-13 at 3 06 54 PM" src="https://github.com/dhiway/cord/assets/53152913/42d7cd59-c941-4b7e-8416-f8e2d4b80c77">


- Chain-state after execution with a particular key query,
<img width="1512" alt="Screenshot 2024-05-13 at 3 07 13 PM" src="https://github.com/dhiway/cord/assets/53152913/4b067e77-1acc-4eb5-aa10-cc9c4df3a1f3">
