### PR TITLE
scripts [Minor]: Remove collective from list of pallets

### DIFF
--- a/scripts/run_benches_for_pallets.sh
+++ b/scripts/run_benches_for_pallets.sh
@@ -60,7 +60,6 @@ CORD=./target/production/cord
 # Manually exclude some pallets.
 PALLETS=(
   "pallet_chain_space"
-  "pallet_collective"
   "pallet_did"
   "pallet_did_name"
   "pallet_identity"
@@ -92,9 +91,6 @@ for PALLET in "${PALLETS[@]}"; do
   case $PALLET in
   pallet_chain_space)
     FOLDER="chain-space"
-    ;;
-  pallet_collective)
-    FOLDER="collective"
     ;;
   pallet_did)
     FOLDER="did"


### PR DESCRIPTION
Since now the pallet `collective` has been removed from the CORDs pallet list, but exists in runtime more as a dependency.
Remove `PALLET_COLLECTIVE` from the list of pallets for which the weight must be generated.

