### PR TITLE
rustfmt: Fix rustfmt errors

### DIFF
--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -801,8 +801,8 @@ pub mod pallet {
 				ensure!(
 					(parent_details.txn_capacity >=
 						(parent_details.txn_count +
-							parent_details.txn_reserve + new_txn_capacity -
-							space_details.txn_capacity)),
+							parent_details.txn_reserve +
+							new_txn_capacity - space_details.txn_capacity)),
 					Error::<T>::CapacityLessThanUsage
 				);
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -1137,8 +1137,8 @@ impl<T: Config> Pallet<T> {
 				(
 					valid &&
 						(cur_char.is_ascii_lowercase() ||
-							cur_char.is_ascii_digit() || cur_char == b'.') &&
-						!(last_char == Some(b'.') && cur_char == b'.'),
+							cur_char.is_ascii_digit() ||
+							cur_char == b'.') && !(last_char == Some(b'.') && cur_char == b'.'),
 					Some(cur_char),
 				)
 			})

--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -252,7 +252,8 @@ impl<Block: BlockT, D, Backend, G: GenesisInit>
 		client::LocalCallExecutor<Block, Backend, NativeElseWasmExecutor<D>>,
 		Backend,
 		G,
-	> where
+	>
+where
 	D: sc_executor::NativeExecutionDispatch,
 {
 	/// Build the test client with the given native executor.

--- a/test-utils/runtime/client/src/lib.rs
+++ b/test-utils/runtime/client/src/lib.rs
@@ -210,7 +210,8 @@ impl<B> TestClientBuilderExt<B>
 			NativeElseWasmExecutor<LocalExecutorDispatch>,
 		>,
 		B,
-	> where
+	>
+where
 	B: sc_client_api::backend::Backend<cord_test_runtime::Block> + 'static,
 {
 	fn genesis_init_mut(&mut self) -> &mut GenesisParameters {


### PR DESCRIPTION
The upstream `rustfmt` ran a nightly format based on GNU which used to give errors, even though locally it was fine. 
This was because of local version ran a Darwin based cargo fmt. Fix remaining files of format errors. This blocked new PRs with rustfmt errors.