### PR TITLE
chain_spec: Set weave to `permissioned: false`

### DIFF
--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -557,7 +557,7 @@ fn weave_local_genesis(
 		"balances": {
 			"balances": initial_authorities.iter().map(|k| (k.0.clone(), ENDOWMENT)).collect::<Vec<_>>(),
 		},
-		"networkParameters": {"permissioned": true},
+		"networkParameters": {"permissioned": false},
 		"nodeAuthorization":  {
 			"nodes": initial_well_known_nodes.iter().map(|x| (x.0.clone(), x.1.clone())).collect::<Vec<_>>(),
 		},


### PR DESCRIPTION
Since `weave` is a permission less network, set the chain-spec genesis config to `permissioned: false`. So chain-space can make decision based on it.