### PR TITLE
Fix NetworkPermission errors

### DIFF
--- a/pallets/asset/src/mock.rs
+++ b/pallets/asset/src/mock.rs
@@ -18,6 +18,7 @@
 
 use super::*;
 use crate as pallet_asset;
+use pallet_chain_space::IsPermissioned;
 use cord_utilities::mock::{mock_origin, SubjectId};
 use frame_support::{derive_impl, parameter_types};
 
@@ -81,6 +82,14 @@ parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 5u32;
 }
 
+/* For test/mock/bench env assume it is a permissioned chain */
+pub struct TestIsPermissioned;
+impl IsPermissioned for TestIsPermissioned {
+	fn is_permissioned() -> bool {
+		true
+	}
+}
+
 impl pallet_chain_space::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
@@ -88,6 +97,7 @@ impl pallet_chain_space::Config for Test {
 	type SpaceCreatorId = SubjectId;
 	type MaxSpaceDelegates = MaxSpaceDelegates;
 	type ChainSpaceOrigin = EnsureRoot<AccountId>;
+	type NetworkPermission = TestIsPermissioned;
 	type WeightInfo = ();
 }
 

--- a/pallets/chain-space/src/benchmarking.rs
+++ b/pallets/chain-space/src/benchmarking.rs
@@ -415,7 +415,7 @@ benchmarks! {
 			 Pallet::<T>::create(origin.clone(), space_digest )?;
 			 Pallet::<T>::approve(RawOrigin::Root.into(), space_id.clone(), capacity )?;
 
-		 }: _<T::RuntimeOrigin>(origin, subspace_digest, 10u64, space_id.clone())
+		 }: _<T::RuntimeOrigin>(origin, subspace_digest, Some(10u64), space_id.clone())
 		 verify {
 			 assert_last_event::<T>(Event::Create { space: subspace_id, creator: did, authorization: authorization_id }.into());
 		 }

--- a/pallets/chain-space/src/mock.rs
+++ b/pallets/chain-space/src/mock.rs
@@ -17,6 +17,7 @@
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
 use crate as pallet_chain_space;
+use crate::IsPermissioned;
 use cord_utilities::mock::{mock_origin, SubjectId};
 use frame_support::{derive_impl, parameter_types};
 
@@ -65,6 +66,14 @@ parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 5u32;
 }
 
+/* For test/mock/bench env assume it is a permissioned chain */
+pub struct TestIsPermissioned;
+impl IsPermissioned for TestIsPermissioned {
+	fn is_permissioned() -> bool {
+		true
+	}
+}
+
 impl pallet_chain_space::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
@@ -72,6 +81,7 @@ impl pallet_chain_space::Config for Test {
 	type SpaceCreatorId = SubjectId;
 	type MaxSpaceDelegates = MaxSpaceDelegates;
 	type ChainSpaceOrigin = EnsureRoot<AccountId>;
+	type NetworkPermission = TestIsPermissioned;
 	type WeightInfo = ();
 }
 

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -19,6 +19,7 @@
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
 use crate as pallet_did;
+use pallet_chain_space::IsPermissioned;
 use codec::{Decode, Encode};
 use cord_utilities::mock::*;
 use frame_support::{derive_impl, parameter_types};
@@ -134,6 +135,14 @@ parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 5u32;
 }
 
+/* For test/mock/bench env assume it is a permissioned chain */
+pub struct TestIsPermissioned;
+impl IsPermissioned for TestIsPermissioned {
+	fn is_permissioned() -> bool {
+		true
+	}
+}
+
 impl pallet_chain_space::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
@@ -141,6 +150,7 @@ impl pallet_chain_space::Config for Test {
 	type SpaceCreatorId = SubjectId;
 	type MaxSpaceDelegates = MaxSpaceDelegates;
 	type ChainSpaceOrigin = EnsureRoot<AccountId>;
+	type NetworkPermission = TestIsPermissioned;
 	type WeightInfo = ();
 }
 

--- a/pallets/network-score/src/mock.rs
+++ b/pallets/network-score/src/mock.rs
@@ -18,6 +18,7 @@
 
 use super::*;
 use crate as pallet_score;
+use pallet_chain_space::IsPermissioned;
 use cord_utilities::mock::{mock_origin, SubjectId};
 use frame_support::{derive_impl, parameter_types, traits::ConstU64};
 use frame_system::EnsureRoot;
@@ -83,6 +84,14 @@ parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 5u32;
 }
 
+/* For test/mock/bench env assume it is a permissioned chain */
+pub struct TestIsPermissioned;
+impl IsPermissioned for TestIsPermissioned {
+	fn is_permissioned() -> bool {
+		true
+	}
+}
+
 impl pallet_chain_space::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
@@ -90,6 +99,7 @@ impl pallet_chain_space::Config for Test {
 	type SpaceCreatorId = SubjectId;
 	type MaxSpaceDelegates = MaxSpaceDelegates;
 	type ChainSpaceOrigin = EnsureRoot<AccountId>;
+	type NetworkPermission = TestIsPermissioned;
 	type WeightInfo = ();
 }
 

--- a/pallets/schema/src/mock.rs
+++ b/pallets/schema/src/mock.rs
@@ -19,6 +19,7 @@
 use crate as pallet_schema;
 use cord_utilities::mock::{mock_origin, SubjectId};
 use frame_support::{derive_impl, parameter_types};
+use pallet_chain_space::IsPermissioned;
 use frame_system::EnsureRoot;
 use sp_runtime::{
 	traits::{IdentifyAccount, IdentityLookup, Verify},
@@ -79,6 +80,14 @@ parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 5u32;
 }
 
+/* For test/mock/bench env assume it is a permissioned chain */
+pub struct TestIsPermissioned;
+impl IsPermissioned for TestIsPermissioned {
+	fn is_permissioned() -> bool {
+		true
+	}
+}
+
 impl pallet_chain_space::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
@@ -86,6 +95,7 @@ impl pallet_chain_space::Config for Test {
 	type SpaceCreatorId = SubjectId;
 	type MaxSpaceDelegates = MaxSpaceDelegates;
 	type ChainSpaceOrigin = EnsureRoot<AccountId>;
+	type NetworkPermission = TestIsPermissioned;
 	type WeightInfo = ();
 }
 

--- a/pallets/statement/src/mock.rs
+++ b/pallets/statement/src/mock.rs
@@ -18,6 +18,7 @@
 
 use super::*;
 use crate as pallet_statement;
+use pallet_chain_space::IsPermissioned;
 use cord_utilities::mock::{mock_origin, SubjectId};
 use frame_support::{derive_impl, parameter_types};
 
@@ -84,6 +85,14 @@ parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 5u32;
 }
 
+/* For test/mock/bench env assume it is a permissioned chain */
+pub struct TestIsPermissioned;
+impl IsPermissioned for TestIsPermissioned {
+	fn is_permissioned() -> bool {
+		true
+	}
+}
+
 impl pallet_chain_space::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
@@ -91,6 +100,7 @@ impl pallet_chain_space::Config for Test {
 	type SpaceCreatorId = SubjectId;
 	type MaxSpaceDelegates = MaxSpaceDelegates;
 	type ChainSpaceOrigin = EnsureRoot<AccountId>;
+	type NetworkPermission = TestIsPermissioned;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
Fix un-implemented traits for `NetworkPermission`.
Set `NetworkPermission` to `true` or `permissioned` for all test/mock/benchmarks scenarios.

Verified by the test by removing  `}: _<T::RuntimeOrigin>(origin, subspace_digest, None, space_id.clone())` which will failed since for permissioned chain, `capacity` is required.
