### PR TITLE
Pallet/asset: Add tests for AssetIdNotFound

### DIFF
--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -1057,3 +1057,590 @@ fn asset_over_issuance_vc_status_change_should_not_succeed() {
 		);
 	});
 }
+
+#[test]
+fn asset_issue_with_wrong_asset_id_should_fail() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry,
+			digest,
+			authorization_id.clone()
+		));
+
+		let wrong_issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&digest.encode()[..], &creator.encode()[..]].concat()[..],
+		);
+
+		let asset_id: Ss58Identifier = generate_asset_id::<Test>(&wrong_issue_id_digest);
+
+		let issue_entry = AssetIssuanceEntryOf::<Test> {
+			asset_id,
+			asset_owner: creator.clone(),
+			asset_issuance_qty: Some(10),
+		};
+
+		let issue_entry_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&issue_entry.encode()[..]].concat()[..],
+		);
+
+		assert_err!(
+			Asset::issue(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				issue_entry.clone(),
+				issue_entry_digest,
+				authorization_id
+			),
+			Error::<Test>::AssetIdNotFound
+		);
+	});
+}
+
+#[test]
+fn asset_transfer_with_wrong_asset_id_should_fail() {
+	let creator = DID_00;
+	let new_owner = DID_01;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+	let issue_entry = AssetIssuanceEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_owner: creator.clone(),
+		asset_issuance_qty: Some(10),
+	};
+
+	let issue_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&issue_entry.encode()[..]].concat()[..]);
+
+	let instance_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&asset_id.encode()[..],
+			&creator.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+			&issue_entry_digest.encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let instance_id = generate_asset_instance_id::<Test>(&instance_id_digest);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_ok!(Asset::issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			authorization_id
+		));
+		let wrong_entry_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&issue_entry.encode()[..]].concat()[..],
+		);
+		let asset_id: Ss58Identifier = generate_asset_id::<Test>(&wrong_entry_digest);
+
+		let transfer_entry = AssetTransferEntryOf::<Test> {
+			asset_id: asset_id.clone(),
+			asset_instance_id: instance_id.clone(),
+			asset_owner: creator.clone(),
+			new_asset_owner: new_owner.clone(),
+		};
+
+		let transfer_entry_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&transfer_entry.encode()[..]].concat()[..],
+		);
+
+		assert_err!(
+			Asset::transfer(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				transfer_entry.clone(),
+				transfer_entry_digest
+			),
+			Error::<Test>::AssetIdNotFound
+		);
+	});
+}
+
+#[test]
+fn asset_status_change_with_wrong_asset_id_should_fail() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+	let issue_entry = AssetIssuanceEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_owner: creator.clone(),
+		asset_issuance_qty: Some(10),
+	};
+
+	let issue_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&issue_entry.encode()[..]].concat()[..]);
+
+	let instance_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&asset_id.encode()[..],
+			&creator.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+			&issue_entry_digest.encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let instance_id = generate_asset_instance_id::<Test>(&instance_id_digest);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_ok!(Asset::issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			authorization_id
+		));
+		let wrong_issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&digest.encode()[..], &creator.encode()[..]].concat()[..],
+		);
+		let asset_id: Ss58Identifier = generate_asset_id::<Test>(&wrong_issue_id_digest);
+
+		assert_err!(
+			Asset::status_change(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				asset_id.clone(),
+				Some(instance_id.clone()),
+				AssetStatusOf::INACTIVE
+			),
+			Error::<Test>::AssetIdNotFound
+		);
+	});
+}
+
+#[test]
+fn asset_vc_issue_with_wrong_asset_id_should_fail() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
+			authorization_id.clone()
+		));
+		let wrong_issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&digest.encode()[..], &creator.encode()[..]].concat()[..],
+		);
+		let asset_id: Ss58Identifier = generate_asset_id::<Test>(&wrong_issue_id_digest);
+
+		let issue_entry = AssetIssuanceEntryOf::<Test> {
+			asset_id,
+			asset_owner: creator.clone(),
+			asset_issuance_qty: Some(10),
+		};
+
+		let issue_entry_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&issue_entry.encode()[..]].concat()[..],
+		);
+
+		assert_err!(
+			Asset::vc_issue(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				issue_entry.clone(),
+				issue_entry_digest,
+				authorization_id
+			),
+			Error::<Test>::AssetIdNotFound
+		);
+	});
+}
+
+#[test]
+fn asset_vc_transfer_with_wrong_asset_id_should_fail() {
+	let creator = DID_00;
+	let new_owner = DID_01;
+
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+	let issue_entry = AssetIssuanceEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_owner: creator.clone(),
+		asset_issuance_qty: Some(10),
+	};
+
+	let issue_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&issue_entry.encode()[..]].concat()[..]);
+
+	let instance_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&asset_id.encode()[..],
+			&creator.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+			&issue_entry_digest.encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let instance_id = generate_asset_instance_id::<Test>(&instance_id_digest);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_ok!(Asset::vc_issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			authorization_id
+		));
+
+		let wrong_issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&digest.encode()[..], &creator.encode()[..]].concat()[..],
+		);
+		let asset_id: Ss58Identifier = generate_asset_id::<Test>(&wrong_issue_id_digest);
+
+		let transfer_entry = AssetTransferEntryOf::<Test> {
+			asset_id: asset_id.clone(),
+			asset_instance_id: instance_id.clone(),
+			asset_owner: creator.clone(),
+			new_asset_owner: new_owner.clone(),
+		};
+
+		let transfer_entry_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&transfer_entry.encode()[..]].concat()[..],
+		);
+
+		assert_err!(
+			Asset::vc_transfer(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				transfer_entry.clone(),
+				transfer_entry_digest
+			),
+			Error::<Test>::AssetIdNotFound
+		);
+	});
+}
+
+#[test]
+fn asset_vc_status_change_with_wrong_asset_id_should_fail() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+	let issue_entry = AssetIssuanceEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_owner: creator.clone(),
+		asset_issuance_qty: Some(10),
+	};
+
+	let issue_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&issue_entry.encode()[..]].concat()[..]);
+
+	let instance_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&asset_id.encode()[..],
+			&creator.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+			&issue_entry_digest.encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let instance_id = generate_asset_instance_id::<Test>(&instance_id_digest);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_ok!(Asset::vc_issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			authorization_id
+		));
+
+		let wrong_issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+			&[&digest.encode()[..], &creator.encode()[..]].concat()[..],
+		);
+		let asset_id: Ss58Identifier = generate_asset_id::<Test>(&wrong_issue_id_digest);
+
+		assert_err!(
+			Asset::vc_status_change(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				asset_id.clone(),
+				Some(instance_id.clone()),
+				AssetStatusOf::INACTIVE
+			),
+			Error::<Test>::AssetIdNotFound
+		);
+	});
+}


### PR DESCRIPTION
Issue Reference: [#375](https://github.com/dhiway/cord/issues/375)

This Pull Request addresses the issue described in [Issue #375](https://github.com/dhiway/cord/issues/375), which pertains to the AssetIdNotFound error being emitted in six different functions within the pallet.

This error is emitted in six different functions: issue, transfer, status_change, vc_issue, vc_transfer, and vc_status_change. Tests have been written for each of these functions.