### PR TITLE
statement: Add selective data keypairs as storage

### DIFF
--- a/pallets/statement/Cargo.toml
+++ b/pallets/statement/Cargo.toml
@@ -28,7 +28,6 @@ identifier = { workspace = true }
 pallet-chain-space = { workspace = true }
 pallet-schema = { workspace = true }
 
-
 # Substrate dependencies
 frame-benchmarking = { optional = true, workspace = true }
 frame-support = { workspace = true }

--- a/pallets/statement/src/benchmarking.rs
+++ b/pallets/statement/src/benchmarking.rs
@@ -73,7 +73,7 @@ benchmarks! {
 		pallet_chain_space::Pallet::<T>::create(origin.clone(), space_digest )?;
 		pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity ).expect("Approval should not fail.");
 
-	}: _<T::RuntimeOrigin>(origin, statement_digest, authorization_id, None)
+	}: _<T::RuntimeOrigin>(origin, statement_digest, authorization_id, None, None)
 	verify {
 		assert_last_event::<T>(Event::Register { identifier, digest: statement_digest, author: did}.into());
 	}
@@ -118,9 +118,9 @@ benchmarks! {
 		pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity ).expect("Approval should not fail.");
 
 		/* register the entry before update */
-		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None);
+		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None, None);
 
-	}: _<T::RuntimeOrigin>(origin, identifier.clone(), update_digest, authorization_id)
+	}: _<T::RuntimeOrigin>(origin, identifier.clone(), update_digest, authorization_id, None)
 	verify {
 		assert_last_event::<T>(Event::Update { identifier, digest: update_digest, author: did}.into());
 	}
@@ -158,7 +158,7 @@ benchmarks! {
 		pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity ).expect("Approval should not fail.");
 
 		/* register the entry before update */
-		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None);
+		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None, None);
 
 	}: _<T::RuntimeOrigin>(origin, identifier.clone(), authorization_id)
 	verify {
@@ -198,7 +198,7 @@ benchmarks! {
 		pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity ).expect("Approval should not fail.");
 
 		/* register the entry before update */
-		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None);
+		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None, None);
 		let _ = Pallet::<T>::revoke(origin.clone(), identifier.clone(), authorization_id.clone());
 
 	}: _<T::RuntimeOrigin>(origin, identifier.clone(), authorization_id)
@@ -241,7 +241,7 @@ benchmarks! {
 		pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity ).expect("Approval should not fail.");
 
 		/* register the entry before update */
-		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None);
+		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None, None);
 
 	}: _<T::RuntimeOrigin>(origin, identifier.clone(), authorization_id)
 	verify {
@@ -320,7 +320,7 @@ benchmarks! {
 		pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity ).expect("Approval should not fail.");
 
 		/* register the entry before update */
-		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None);
+		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None, None);
 
 	}: _<T::RuntimeOrigin>(origin, identifier.clone(), statement_digest, PresentationTypeOf::PDF, authorization_id)
 	verify {
@@ -361,7 +361,7 @@ benchmarks! {
 		pallet_chain_space::Pallet::<T>::approve(chain_space_origin, space_id, capacity ).expect("Approval should not fail.");
 
 		/* register the entry before update */
-		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None);
+		let _ = Pallet::<T>::register(origin.clone(), statement_digest, authorization_id.clone(), None, None);
 		let _ = Pallet::<T>::add_presentation(origin.clone(), identifier.clone(), statement_digest, PresentationTypeOf::PDF, authorization_id.clone());
 	}: _<T::RuntimeOrigin>(origin, identifier.clone(), statement_digest, authorization_id)
 	verify {

--- a/pallets/statement/src/mock.rs
+++ b/pallets/statement/src/mock.rs
@@ -69,6 +69,8 @@ parameter_types! {
 	#[derive(Debug, Clone)]
 	pub const MaxDigetsPerBatch: u16 = 5u16;
 	pub const MaxRemoveEntries: u16 = 5u16;
+	pub const MaxSelectiveDataKeyLength: u32 = 30u32;
+	pub const MaxSelectiveDataEntries: u32 = 25u32;
 }
 
 impl Config for Test {
@@ -77,6 +79,8 @@ impl Config for Test {
 	type OriginSuccess = mock_origin::DoubleOrigin<AccountId, SubjectId>;
 	type MaxDigestsPerBatch = MaxDigetsPerBatch;
 	type MaxRemoveEntries = MaxRemoveEntries;
+	type MaxSelectiveDataKeyLength = MaxSelectiveDataKeyLength;
+	type MaxSelectiveDataEntries = MaxSelectiveDataEntries;
 	type WeightInfo = weights::SubstrateWeight<Test>;
 }
 

--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -79,7 +79,8 @@ fn register_statement_should_succeed() {
 			DoubleOrigin(author, creator).into(),
 			statement_digest,
 			authorization_id,
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 	});
 }
@@ -117,7 +118,8 @@ fn trying_to_register_statement_to_a_non_existent_space_should_fail() {
 				DoubleOrigin(author, delegate).into(),
 				statement_digest,
 				authorization_id,
-				Some(schema_id)
+				Some(schema_id),
+				None
 			),
 			pallet_chain_space::Error::<Test>::AuthorizationNotFound
 		);
@@ -172,7 +174,8 @@ fn trying_to_register_statement_by_a_non_delegate_should_fail() {
 				DoubleOrigin(author, delegate).into(),
 				statement_digest,
 				authorization_id,
-				Some(schema_id)
+				Some(schema_id),
+				None
 			),
 			pallet_chain_space::Error::<Test>::UnauthorizedOperation
 		);
@@ -234,7 +237,8 @@ fn updating_a_registered_statement_should_succeed() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_ok!(Statement::update(
@@ -242,6 +246,7 @@ fn updating_a_registered_statement_should_succeed() {
 			statement_id.clone(),
 			new_statement_digest,
 			authorization_id,
+			None
 		));
 
 		let revoked_statements = RevocationList::<Test>::get(statement_id, statement_digest)
@@ -318,7 +323,8 @@ fn updating_a_registered_statement_by_a_space_delegate_should_succeed() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_ok!(Statement::update(
@@ -326,6 +332,7 @@ fn updating_a_registered_statement_by_a_space_delegate_should_succeed() {
 			statement_id,
 			new_statement_digest,
 			delegate_authorization_id,
+			None
 		));
 	});
 }
@@ -390,7 +397,8 @@ fn trying_to_update_a_registered_statement_by_a_non_space_delegate_should_fail()
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_err!(
@@ -399,6 +407,7 @@ fn trying_to_update_a_registered_statement_by_a_non_space_delegate_should_fail()
 				statement_id,
 				new_statement_digest,
 				delegate_authorization_id,
+				None
 			),
 			pallet_chain_space::Error::<Test>::AuthorizationNotFound
 		);
@@ -459,7 +468,8 @@ fn trying_to_update_a_non_registered_statement_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			new_statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_err!(
@@ -468,6 +478,7 @@ fn trying_to_update_a_non_registered_statement_should_fail() {
 				statement_id,
 				statement_digest,
 				authorization_id,
+				None
 			),
 			Error::<Test>::StatementNotFound
 		);
@@ -527,7 +538,8 @@ fn revoking_a_registered_statement_should_succeed() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_ok!(Statement::revoke(
@@ -623,7 +635,8 @@ fn revoking_a_registered_statement_by_a_non_delegate_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_err!(
@@ -690,7 +703,8 @@ fn restoring_a_revoked_statement_should_succeed() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_ok!(Statement::revoke(
@@ -766,7 +780,8 @@ fn trying_to_restore_a_non_revoked_statement_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_err!(
@@ -860,7 +875,8 @@ fn trying_to_restore_a_revoked_statement_by_a_non_delegate_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_ok!(Statement::revoke(
@@ -934,7 +950,8 @@ fn registering_a_statement_again_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id.clone())
+			Some(schema_id.clone()),
+			None
 		));
 
 		assert_err!(
@@ -942,7 +959,8 @@ fn registering_a_statement_again_should_fail() {
 				DoubleOrigin(author, creator).into(),
 				statement_digest,
 				authorization_id,
-				Some(schema_id)
+				Some(schema_id),
+				None
 			),
 			Error::<Test>::StatementAlreadyAnchored
 		);
@@ -1004,7 +1022,8 @@ fn updating_a_registered_statement_again_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		assert_ok!(Statement::update(
@@ -1012,6 +1031,7 @@ fn updating_a_registered_statement_again_should_fail() {
 			statement_id.clone(),
 			new_statement_digest,
 			authorization_id.clone(),
+			None
 		));
 
 		assert_err!(
@@ -1020,6 +1040,7 @@ fn updating_a_registered_statement_again_should_fail() {
 				statement_id,
 				new_statement_digest,
 				authorization_id,
+				None
 			),
 			Error::<Test>::StatementDigestAlreadyAnchored
 		);
@@ -1064,6 +1085,7 @@ fn removing_nonexistent_presentation_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
+			None,
 			None
 		));
 
@@ -1130,7 +1152,8 @@ fn bulk_registering_statements_with_same_digest_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digests[0],
 			authorization_id.clone(),
-			Some(schema_id.clone())
+			Some(schema_id.clone()),
+			None
 		));
 
 		assert_err!(
@@ -1199,7 +1222,8 @@ fn trying_to_update_or_revoke_or_add_presentation_for_revoked_statement_should_f
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
-			Some(schema_id)
+			Some(schema_id),
+			None
 		));
 
 		// Revoke the statement
@@ -1216,6 +1240,7 @@ fn trying_to_update_or_revoke_or_add_presentation_for_revoked_statement_should_f
 				statement_id.clone(),
 				new_statement_digest,
 				authorization_id.clone(),
+				None
 			),
 			Error::<Test>::StatementRevoked
 		);
@@ -1282,6 +1307,7 @@ fn nonexistent_presentation_should_fail() {
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			statement_digest,
 			authorization_id.clone(),
+			None,
 			None
 		));
 

--- a/runtimes/braid/src/lib.rs
+++ b/runtimes/braid/src/lib.rs
@@ -742,7 +742,7 @@ impl pallet_chain_space::Config for Runtime {
 parameter_types! {
 	pub const MaxDigestsPerBatch: u16 = 1_000;
 	pub const MaxRemoveEntries: u16 = 1_000;
-	pub const MaxSelectiveDataKeyLength: u32 = 100;
+	pub const MaxSelectiveDataKeyLength: u32 = 64;
 	pub const MaxSelectiveDataEntries: u32 = 25;
 }
 

--- a/runtimes/braid/src/lib.rs
+++ b/runtimes/braid/src/lib.rs
@@ -742,6 +742,8 @@ impl pallet_chain_space::Config for Runtime {
 parameter_types! {
 	pub const MaxDigestsPerBatch: u16 = 1_000;
 	pub const MaxRemoveEntries: u16 = 1_000;
+	pub const MaxSelectiveDataKeyLength: u32 = 100;
+	pub const MaxSelectiveDataEntries: u32 = 25;
 }
 
 impl pallet_statement::Config for Runtime {
@@ -751,6 +753,8 @@ impl pallet_statement::Config for Runtime {
 	type WeightInfo = weights::pallet_statement::WeightInfo<Runtime>;
 	type MaxDigestsPerBatch = MaxDigestsPerBatch;
 	type MaxRemoveEntries = MaxRemoveEntries;
+	type MaxSelectiveDataKeyLength = MaxSelectiveDataKeyLength;
+	type MaxSelectiveDataEntries = MaxSelectiveDataEntries;
 }
 
 impl pallet_remark::Config for Runtime {

--- a/runtimes/loom/src/lib.rs
+++ b/runtimes/loom/src/lib.rs
@@ -885,6 +885,8 @@ impl pallet_chain_space::Config for Runtime {
 parameter_types! {
 	pub const MaxDigestsPerBatch: u16 = 1_000;
 	pub const MaxRemoveEntries: u16 = 1_000;
+	pub const MaxSelectiveDataKeyLength: u32 = 100;
+	pub const MaxSelectiveDataEntries: u32 = 25;
 }
 
 impl pallet_statement::Config for Runtime {
@@ -894,6 +896,8 @@ impl pallet_statement::Config for Runtime {
 	type WeightInfo = weights::pallet_statement::WeightInfo<Runtime>;
 	type MaxDigestsPerBatch = MaxDigestsPerBatch;
 	type MaxRemoveEntries = MaxRemoveEntries;
+	type MaxSelectiveDataKeyLength = MaxSelectiveDataKeyLength;
+	type MaxSelectiveDataEntries = MaxSelectiveDataEntries;
 }
 
 impl pallet_remark::Config for Runtime {

--- a/runtimes/loom/src/lib.rs
+++ b/runtimes/loom/src/lib.rs
@@ -885,7 +885,7 @@ impl pallet_chain_space::Config for Runtime {
 parameter_types! {
 	pub const MaxDigestsPerBatch: u16 = 1_000;
 	pub const MaxRemoveEntries: u16 = 1_000;
-	pub const MaxSelectiveDataKeyLength: u32 = 100;
+	pub const MaxSelectiveDataKeyLength: u32 = 64;
 	pub const MaxSelectiveDataEntries: u32 = 25;
 }
 

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -885,6 +885,8 @@ impl pallet_chain_space::Config for Runtime {
 parameter_types! {
 	pub const MaxDigestsPerBatch: u16 = 1_000;
 	pub const MaxRemoveEntries: u16 = 1_000;
+	pub const MaxSelectiveDataKeyLength: u32 = 100;
+	pub const MaxSelectiveDataEntries: u32 = 25;
 }
 
 impl pallet_statement::Config for Runtime {
@@ -894,6 +896,8 @@ impl pallet_statement::Config for Runtime {
 	type WeightInfo = weights::pallet_statement::WeightInfo<Runtime>;
 	type MaxDigestsPerBatch = MaxDigestsPerBatch;
 	type MaxRemoveEntries = MaxRemoveEntries;
+	type MaxSelectiveDataKeyLength = MaxSelectiveDataKeyLength;
+	type MaxSelectiveDataEntries = MaxSelectiveDataEntries;
 }
 
 impl pallet_remark::Config for Runtime {

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -885,7 +885,7 @@ impl pallet_chain_space::Config for Runtime {
 parameter_types! {
 	pub const MaxDigestsPerBatch: u16 = 1_000;
 	pub const MaxRemoveEntries: u16 = 1_000;
-	pub const MaxSelectiveDataKeyLength: u32 = 100;
+	pub const MaxSelectiveDataKeyLength: u32 = 64;
 	pub const MaxSelectiveDataEntries: u32 = 25;
 }
 


### PR DESCRIPTION
This PR allows to have `selective data` as storage in the chain-state.
This feature allows to have individual fields of digest in a document, with a maximum of 25 k:v's.
The key is custom, and value must be a digest of 32 length.

This implementation allows to check for availability of individual fields of a document has been anchored or not instead of whole document itself. This is crucial when verification is done using a non-digital copy as a reference digest.

Updates:

- `register`: Optional argument `selective_data` to add.
- `update`: Optional argument `selective_data` to update existing `selective_data`.
- `update_selective_data`: Update just the `selective_data`.

#
- `remove_selective_data`: Remove existing `selective_data` to free up space entry usage.