### PR TITLE
Node-Authorization : Test for `PeerIdTooLong`

### DIFF
--- a/pallets/node-authorization/src/mock.rs
+++ b/pallets/node-authorization/src/mock.rs
@@ -23,7 +23,7 @@
 use super::*;
 use crate as pallet_node_authorization;
 use crate::{Config, NodeId};
-use frame_support::{dispatch::DispatchResult, ensure};
+use frame_support::ensure;
 
 use frame_support::{
 	construct_runtime, derive_impl, ord_parameter_types,

--- a/pallets/node-authorization/src/mock.rs
+++ b/pallets/node-authorization/src/mock.rs
@@ -23,6 +23,8 @@
 use super::*;
 use crate as pallet_node_authorization;
 use crate::{Config, NodeId};
+use frame_support::dispatch::DispatchResult;
+use frame_support::ensure;
 
 use frame_support::{
 	construct_runtime, derive_impl, ord_parameter_types,
@@ -130,4 +132,9 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	.assimilate_storage(&mut t)
 	.unwrap();
 	t.into()
+}
+
+pub fn test_peer_id_length(testing : PeerId) -> DispatchResult {
+	ensure!(testing.0.len() <= 128 as usize, Error::<Test>::PeerIdTooLong);
+	Ok(())
 }

--- a/pallets/node-authorization/src/mock.rs
+++ b/pallets/node-authorization/src/mock.rs
@@ -134,7 +134,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	t.into()
 }
 
-pub fn test_peer_id_length(testing : PeerId) -> DispatchResult {
+pub fn test_peer_id_length(testing: PeerId) -> DispatchResult {
 	ensure!(testing.0.len() <= 128 as usize, Error::<Test>::PeerIdTooLong);
 	Ok(())
 }

--- a/pallets/node-authorization/src/mock.rs
+++ b/pallets/node-authorization/src/mock.rs
@@ -133,7 +133,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	t.into()
 }
 
-pub fn test_peer_id_length(testing: PeerId) -> DispatchResult {
+pub fn test_peer_id_length(testing: PeerId) -> Result<(), Error<Test>> {
 	ensure!(testing.0.len() <= 128 as usize, Error::<Test>::PeerIdTooLong);
 	Ok(())
 }

--- a/pallets/node-authorization/src/mock.rs
+++ b/pallets/node-authorization/src/mock.rs
@@ -23,8 +23,7 @@
 use super::*;
 use crate as pallet_node_authorization;
 use crate::{Config, NodeId};
-use frame_support::dispatch::DispatchResult;
-use frame_support::ensure;
+use frame_support::{dispatch::DispatchResult, ensure};
 
 use frame_support::{
 	construct_runtime, derive_impl, ord_parameter_types,

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -461,8 +461,8 @@ fn test_generate_peer_id_invalid_utf8() {
 }
 
 #[test]
-fn peer_id_too_long_test() -> Result<(),Error<Test>>{
-    new_test_ext().execute_with(|| {
+fn peer_id_too_long_test() -> Result<(), Error<Test>> {
+	new_test_ext().execute_with(|| {
         const max_peer_id_length: usize = 128;
         let testing = "nodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeid";
 

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -463,11 +463,11 @@ fn test_generate_peer_id_invalid_utf8() {
 #[test]
 fn peer_id_too_long_test() {
 	new_test_ext().execute_with(|| {
-        let testing = "nodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeid";
+		let node_id: &str = &"nodeid".repeat(32);
 
-        let node_identity = test_node(&testing);
+		let node_identity = test_node(&node_id);
 		let testing = NodeAuthorization::generate_peer_id(&node_identity).unwrap();
 
-       	assert_err!(test_peer_id_length(testing),Error::<Test>::PeerIdTooLong);
-    })
+		assert_eq!(test_peer_id_length(testing), Err(Error::<Test>::PeerIdTooLong));
+	})
 }

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -463,14 +463,14 @@ fn test_generate_peer_id_invalid_utf8() {
 #[test]
 fn peer_id_too_long_test() -> Result<(), Error<Test>> {
 	new_test_ext().execute_with(|| {
-        const max_peer_id_length: usize = 128;
+        const MAX_PEER_ID_LENGTH: usize = 128;
         let testing = "nodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeid";
 
         let node_identity = test_node(&testing);
 		let testing = NodeAuthorization::generate_peer_id(&node_identity).unwrap();
 
-       	// assert!(testing.0.len() > max_peer_id_length,Error::<Test>::PeerIdTooLong);
-		if testing.0.len() > max_peer_id_length {
+       	// assert!(testing.0.len() > MAX_PEER_ID_LENGTH,Error::<Test>::PeerIdTooLong);
+		if testing.0.len() > MAX_PEER_ID_LENGTH {
 			return Err(Error::<Test>::PeerIdTooLong);
 		}
 		Ok(())

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -461,18 +461,13 @@ fn test_generate_peer_id_invalid_utf8() {
 }
 
 #[test]
-fn peer_id_too_long_test() -> Result<(), Error<Test>> {
+fn peer_id_too_long_test() {
 	new_test_ext().execute_with(|| {
-        const MAX_PEER_ID_LENGTH: usize = 128;
         let testing = "nodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeid";
 
         let node_identity = test_node(&testing);
 		let testing = NodeAuthorization::generate_peer_id(&node_identity).unwrap();
 
-       	// assert!(testing.0.len() > MAX_PEER_ID_LENGTH,Error::<Test>::PeerIdTooLong);
-		if testing.0.len() > MAX_PEER_ID_LENGTH {
-			return Err(Error::<Test>::PeerIdTooLong);
-		}
-		Ok(())
+       	assert_err!(test_peer_id_length(testing),Error::<Test>::PeerIdTooLong);
     })
 }

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -459,3 +459,20 @@ fn test_generate_peer_id_invalid_utf8() {
 	let invalid_node_id: NodeId = vec![0xFF, 0xFE, 0xFD];
 	assert_err!(NodeAuthorization::generate_peer_id(&invalid_node_id), Error::<Test>::InvalidUtf8);
 }
+
+#[test]
+fn peer_id_too_long_test() -> Result<(),Error<Test>>{
+    new_test_ext().execute_with(|| {
+        const max_peer_id_length: usize = 128;
+        let testing = "nodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeidnodeid";
+
+        let node_identity = test_node(&testing);
+		let testing = NodeAuthorization::generate_peer_id(&node_identity).unwrap();
+
+       	// assert!(testing.0.len() > max_peer_id_length,Error::<Test>::PeerIdTooLong);
+		if testing.0.len() > max_peer_id_length {
+			return Err(Error::<Test>::PeerIdTooLong);
+		}
+		Ok(())
+    })
+}


### PR DESCRIPTION
- Fixes https://github.com/dhiway/cord/issues/305
- This PR will check for all the conditions where `PeerIdTooLong` could be returned