### PR TITLE
chain-space: Fix bug of Space Creator Delegating Themselves

### DIFF
--- a/pallets/asset/src/benchmarking.rs
+++ b/pallets/asset/src/benchmarking.rs
@@ -66,7 +66,7 @@ benchmarks! {
 			);
 
 			let auth_digest = <T as frame_system::Config>::Hashing::hash(
-				&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			);
 			let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
 
@@ -127,7 +127,7 @@ benchmarks! {
 			);
 
 			let auth_digest = <T as frame_system::Config>::Hashing::hash(
-				&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			);
 			let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
 
@@ -207,7 +207,7 @@ benchmarks! {
 			);
 
 			let auth_digest = <T as frame_system::Config>::Hashing::hash(
-				&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			);
 			let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
 
@@ -297,7 +297,7 @@ benchmarks! {
 			);
 
 			let auth_digest = <T as frame_system::Config>::Hashing::hash(
-				&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			);
 			let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
 

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -48,7 +48,7 @@ fn asset_create_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -101,7 +101,7 @@ fn asset_create_duplicate_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -164,7 +164,7 @@ fn asset_issue_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -240,7 +240,7 @@ fn asset_overissuance_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -328,7 +328,7 @@ fn asset_transfer_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -434,7 +434,7 @@ fn asset_status_change_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -530,7 +530,7 @@ fn asset_vc_create_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -583,7 +583,7 @@ fn asset_vc_create_duplicate_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -646,7 +646,7 @@ fn asset_vc_issue_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -722,7 +722,7 @@ fn asset_vc_overissuance_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -810,7 +810,7 @@ fn asset_vc_transfer_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -916,7 +916,7 @@ fn asset_vc_status_change_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -1014,7 +1014,7 @@ fn changing_status_of_asset_instance_with_same_status_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -1116,7 +1116,7 @@ fn changing_status_of_vc_asset_instance_with_same_status_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -1217,7 +1217,7 @@ fn changing_status_of_asset_with_same_status_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -1306,7 +1306,7 @@ fn changing_status_of_vc_asset_with_same_status_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -1392,7 +1392,7 @@ fn asset_over_issuance_should_not_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -1472,7 +1472,7 @@ fn asset_over_issuance_vc_status_change_should_not_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -1576,7 +1576,7 @@ fn asset_id_not_found_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -1721,7 +1721,7 @@ fn asset_instance_not_found_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -1835,7 +1835,7 @@ fn asset_vc_instance_not_found_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -1947,7 +1947,7 @@ fn asset_not_active_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -2035,7 +2035,7 @@ fn asset_instance_not_active_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -2152,7 +2152,7 @@ fn asset_vc_instance_not_active_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -2266,7 +2266,7 @@ fn asset_issue_with_wrong_asset_id_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
@@ -2344,7 +2344,7 @@ fn asset_transfer_with_wrong_asset_id_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
@@ -2454,7 +2454,7 @@ fn asset_status_change_with_wrong_asset_id_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
@@ -2555,7 +2555,7 @@ fn asset_vc_issue_with_wrong_asset_id_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -2635,7 +2635,7 @@ fn asset_vc_transfer_with_wrong_asset_id_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
@@ -2750,7 +2750,7 @@ fn asset_vc_status_change_with_wrong_asset_id_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);

--- a/pallets/chain-space/src/benchmarking.rs
+++ b/pallets/chain-space/src/benchmarking.rs
@@ -42,7 +42,7 @@ benchmarks! {
 			let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			);
 			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -78,7 +78,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -112,7 +112,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -147,7 +147,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -181,7 +181,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -205,7 +205,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -232,7 +232,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -259,7 +259,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -288,7 +288,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -316,7 +316,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -343,7 +343,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -370,7 +370,7 @@ benchmarks! {
 			 let space_id: SpaceIdOf = generate_space_id::<T>(&id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 
@@ -405,7 +405,7 @@ benchmarks! {
 			 let subspace_id: SpaceIdOf = generate_space_id::<T>(&sub_id_digest);
 
 			 let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
-				 &[&subspace_id.encode()[..], &did.encode()[..]].concat()[..],
+				 &[&subspace_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 			 );
 			 let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
 

--- a/pallets/chain-space/src/lib.rs
+++ b/pallets/chain-space/src/lib.rs
@@ -525,8 +525,10 @@ pub mod pallet {
 			// Construct the authorization_id from the provided parameters.
 			// Id Digest = concat (H(<scale_encoded_space_identifier>,
 			// <scale_encoded_creator_identifier> ))
-			let auth_id_digest =
-				T::Hashing::hash(&[&identifier.encode()[..], &creator.encode()[..]].concat()[..]);
+			let auth_id_digest = T::Hashing::hash(
+				&[&identifier.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()
+					[..],
+			);
 
 			let authorization_id = Ss58Identifier::create_identifier(
 				&auth_id_digest.encode(),
@@ -1042,8 +1044,10 @@ pub mod pallet {
 			// Construct the authorization_id from the provided parameters.
 			// Id Digest = concat (H(<scale_encoded_space_identifier>,
 			// <scale_encoded_creator_identifier> ))
-			let auth_id_digest =
-				T::Hashing::hash(&[&identifier.encode()[..], &creator.encode()[..]].concat()[..]);
+			let auth_id_digest = T::Hashing::hash(
+				&[&identifier.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()
+					[..],
+			);
 
 			let authorization_id = Ss58Identifier::create_identifier(
 				&auth_id_digest.encode(),

--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -37,7 +37,7 @@ fn add_delegate_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -74,7 +74,7 @@ fn add_admin_delegate_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -111,7 +111,7 @@ fn add_admin_delegate_should_fail_if_admin_delegate_already_exists() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -158,7 +158,7 @@ fn add_delegator_should_succeed() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -195,7 +195,7 @@ fn add_delegator_should_fail_if_delegator_already_exists() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -241,7 +241,7 @@ fn add_delegate_should_fail_if_space_is_not_created() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -274,7 +274,7 @@ fn add_admin_delegate_should_fail_if_space_is_not_created() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -307,7 +307,7 @@ fn add_delegator_should_fail_if_space_is_not_created() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -341,7 +341,7 @@ fn add_delegate_should_fail_if_the_regisrty_is_archived() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -385,7 +385,7 @@ fn add_delegate_should_fail_if_the_space_is_not_approved() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -423,7 +423,7 @@ fn add_delegate_should_fail_if_a_non_delegate_tries_to_add() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -462,7 +462,7 @@ fn add_delegate_should_fail_if_the_space_capacity_is_full() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -506,7 +506,7 @@ fn add_delegate_should_fail_if_delegate_already_exists() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -628,10 +628,11 @@ fn archiving_a_space_should_succeed() {
 
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+	let delegate = DID_01;
 
 	new_test_ext().execute_with(|| {
 		assert_ok!(Space::create(
@@ -649,7 +650,7 @@ fn archiving_a_space_should_succeed() {
 			Space::add_delegate(
 				DoubleOrigin(author.clone(), creator.clone()).into(),
 				space_id,
-				SubjectId(AccountId32::new([1u8; 32])),
+				delegate,
 				authorization_id,
 			),
 			Error::<Test>::ArchivedSpace
@@ -669,7 +670,7 @@ fn archiving_a_non_exixtent_space_should_fail() {
 
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -695,10 +696,11 @@ fn restoring_an_archived_a_space_should_succeed() {
 
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+	let delegate = DID_01;
 
 	new_test_ext().execute_with(|| {
 		assert_ok!(Space::create(
@@ -721,7 +723,7 @@ fn restoring_an_archived_a_space_should_succeed() {
 		assert_ok!(Space::add_delegate(
 			DoubleOrigin(author.clone(), creator.clone()).into(),
 			space_id,
-			SubjectId(AccountId32::new([1u8; 32])),
+			delegate,
 			authorization_id,
 		));
 	});
@@ -740,7 +742,7 @@ fn restoring_an_non_archived_a_space_should_fail() {
 
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
 	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
@@ -1103,8 +1105,8 @@ fn add_delegate_should_fail_if_space_delegates_limit_exceeded() {
 			space_digest,
 		));
 
-		// Add the maximum number of delegates to the space
-		for delegate_count in 0..4 {
+		// Add the maximum number of delegates to the space (1 + 4)
+		for delegate_count in 2..6 {
 			assert_ok!(Space::space_delegate_addition(
 				space_id.clone(),
 				SubjectId(AccountId32::new([delegate_count; 32])),
@@ -1118,11 +1120,131 @@ fn add_delegate_should_fail_if_space_delegates_limit_exceeded() {
 		assert_err!(
 			Space::space_delegate_addition(
 				space_id.clone(),
-				SubjectId(AccountId32::new([4u8; 32])),
+				SubjectId(AccountId32::new([6u8; 32])),
 				creator.clone(),
 				Permissions::all(),
 			),
 			Error::<Test>::SpaceDelegatesLimitExceeded
+		);
+	});
+}
+
+#[test]
+fn add_delegate_should_fail_for_space_creator_delegating_themselves() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let space = [2u8; 256].to_vec();
+	let capacity = 3u64;
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&space.encode()[..]);
+
+	let id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
+
+	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id.clone(), capacity));
+
+		// Addding the Delegate same as the Creator should fail.
+		assert_err!(
+			Space::add_delegate(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				space_id,
+				creator.clone(),
+				authorization_id,
+			),
+			Error::<Test>::DelegateAlreadyAdded
+		);
+	});
+}
+
+#[test]
+fn add_admin_delegate_should_fail_for_space_creator_delegating_themselves() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let space = [2u8; 256].to_vec();
+	let capacity = 3u64;
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&space.encode()[..]);
+
+	let id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
+
+	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id.clone(), capacity));
+
+		// Adding the Admin Delegate who is the Creator of the Space should fail.
+		assert_err!(
+			Space::add_admin_delegate(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				space_id,
+				creator.clone(),
+				authorization_id,
+			),
+			Error::<Test>::DelegateAlreadyAdded
+		);
+	});
+}
+
+#[test]
+fn add_delegator_should_fail_for_space_creator_delegating_themselves() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let space = [2u8; 256].to_vec();
+	let capacity = 3u64;
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&space.encode()[..]);
+
+	let id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&id_digest);
+
+	let auth_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id.clone(), capacity));
+
+		// Adding the `delegator` who is the Creator of the Space should fail.
+		assert_err!(
+			Space::add_delegator(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				space_id,
+				creator.clone(),
+				authorization_id,
+			),
+			Error::<Test>::DelegateAlreadyAdded
 		);
 	});
 }

--- a/pallets/network-score/src/benchmarking.rs
+++ b/pallets/network-score/src/benchmarking.rs
@@ -77,7 +77,7 @@ benchmarks! {
 		);
 		let space_id: SpaceIdOf = generate_space_id::<T>(&space_id_digest);
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did1.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did1.encode()[..], &did1.encode()[..]].concat()[..],
 		);
 		let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_digest);
 
@@ -139,7 +139,7 @@ benchmarks! {
 		let identifier_revoke = generate_rating_id::<T>(&id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did1.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did1.encode()[..], &did1.encode()[..]].concat()[..],
 		);
 		let authorization_id: AuthorizationIdOf =
 			generate_authorization_id::<T>(&auth_digest);
@@ -215,7 +215,7 @@ benchmarks! {
 		let identifier_revise = generate_rating_id::<T>(&id_digest_revise);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 		let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_digest);
 

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -64,7 +64,7 @@ fn check_successful_rating_creation() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
@@ -118,7 +118,7 @@ fn check_duplicate_message_id() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
@@ -185,7 +185,7 @@ fn revise_rating_with_entry_entity_mismatch_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
@@ -268,7 +268,7 @@ fn register_rating_with_existing_rating_identifier_should_fail() {
 	);
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
@@ -333,7 +333,7 @@ fn revoke_rating_with_existing_rating_identifier_should_fail() {
 	);
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
@@ -424,7 +424,7 @@ fn revise_rating_with_existing_rating_identifier_should_fail() {
 	);
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
@@ -536,7 +536,7 @@ fn reference_identifier_not_debit_test() {
 	);
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
@@ -614,7 +614,7 @@ fn rating_identifier_not_found_test() {
 	);
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: AuthorizationIdOf =
 		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)

--- a/pallets/schema/src/benchmarking.rs
+++ b/pallets/schema/src/benchmarking.rs
@@ -81,7 +81,7 @@ benchmarks! {
 		let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);

--- a/pallets/schema/src/tests.rs
+++ b/pallets/schema/src/tests.rs
@@ -126,7 +126,7 @@ fn check_successful_schema_creation() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -177,7 +177,7 @@ fn check_duplicate_schema_creation() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -220,7 +220,7 @@ fn check_empty_schema_creation() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -266,7 +266,7 @@ fn test_schema_lookup() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 

--- a/pallets/statement/src/benchmarking.rs
+++ b/pallets/statement/src/benchmarking.rs
@@ -62,7 +62,7 @@ benchmarks! {
 		let identifier = generate_statement_id::<T>(&id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
@@ -103,7 +103,7 @@ benchmarks! {
 		let identifier = generate_statement_id::<T>(&statement_id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
@@ -146,7 +146,7 @@ benchmarks! {
 		let identifier = generate_statement_id::<T>(&statement_id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
@@ -187,7 +187,7 @@ benchmarks! {
 		let identifier = generate_statement_id::<T>(&statement_id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
@@ -229,7 +229,7 @@ benchmarks! {
 		let identifier = generate_statement_id::<T>(&statement_id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
@@ -271,7 +271,7 @@ benchmarks! {
 		let statement_digest2 = <T as frame_system::Config>::Hashing::hash(&statement2[..]);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
@@ -308,7 +308,7 @@ benchmarks! {
 		let identifier = generate_statement_id::<T>(&statement_id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);
@@ -349,7 +349,7 @@ benchmarks! {
 		let identifier = generate_statement_id::<T>(&statement_id_digest);
 
 		let auth_digest = <T as frame_system::Config>::Hashing::hash(
-			&[&space_id.encode()[..], &did.encode()[..]].concat()[..],
+			&[&space_id.encode()[..], &did.encode()[..], &did.encode()[..]].concat()[..],
 		);
 
 		let authorization_id: Ss58Identifier = generate_authorization_id::<T>(&auth_digest);

--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -57,7 +57,7 @@ fn register_statement_should_succeed() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -107,7 +107,7 @@ fn trying_to_register_statement_to_a_non_existent_space_should_fail() {
 	);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -149,7 +149,7 @@ fn trying_to_register_statement_by_a_non_delegate_should_fail() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -206,7 +206,7 @@ fn updating_a_registered_statement_should_succeed() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -278,7 +278,7 @@ fn updating_a_registered_statement_by_a_space_delegate_should_succeed() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -357,7 +357,7 @@ fn trying_to_update_a_registered_statement_by_a_non_space_delegate_should_fail()
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -431,7 +431,7 @@ fn trying_to_update_a_non_registered_statement_should_fail() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -499,7 +499,7 @@ fn revoking_a_registered_statement_should_succeed() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -577,7 +577,7 @@ fn revoking_a_registered_statement_by_a_non_delegate_should_fail() {
 	let new_space_id: SpaceIdOf = generate_space_id::<Test>(&new_space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -588,7 +588,7 @@ fn revoking_a_registered_statement_by_a_non_delegate_should_fail() {
 	let statement_id: StatementIdOf = generate_statement_id::<Test>(&statement_id_digest);
 
 	let delegate_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&new_space_id.encode()[..], &delegate.encode()[..]].concat()[..],
+		&[&new_space_id.encode()[..], &delegate.encode()[..], &delegate.encode()[..]].concat()[..],
 	);
 	let delegate_authorization_id = generate_authorization_id::<Test>(&delegate_id_digest);
 
@@ -662,7 +662,7 @@ fn restoring_a_revoked_statement_should_succeed() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -738,7 +738,7 @@ fn trying_to_restore_a_non_revoked_statement_should_fail() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -814,7 +814,7 @@ fn trying_to_restore_a_revoked_statement_by_a_non_delegate_should_fail() {
 	let new_space_id: SpaceIdOf = generate_space_id::<Test>(&new_space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -825,7 +825,7 @@ fn trying_to_restore_a_revoked_statement_by_a_non_delegate_should_fail() {
 	let statement_id: StatementIdOf = generate_statement_id::<Test>(&statement_id_digest);
 
 	let delegate_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&new_space_id.encode()[..], &delegate.encode()[..]].concat()[..],
+		&[&new_space_id.encode()[..], &delegate.encode()[..], &delegate.encode()[..]].concat()[..],
 	);
 	let delegate_authorization_id = generate_authorization_id::<Test>(&delegate_id_digest);
 
@@ -905,7 +905,7 @@ fn registering_a_statement_again_should_fail() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -976,7 +976,7 @@ fn updating_a_registered_statement_again_should_fail() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -1043,7 +1043,7 @@ fn removing_nonexistent_presentation_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -1108,7 +1108,7 @@ fn bulk_registering_statements_with_same_digest_should_fail() {
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -1171,7 +1171,7 @@ fn trying_to_update_or_revoke_or_add_presentation_for_revoked_statement_should_f
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 
@@ -1261,7 +1261,7 @@ fn nonexistent_presentation_should_fail() {
 	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
 
 	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..]].concat()[..],
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
 	);
 	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
 


### PR DESCRIPTION
This PR adds a check which disallows `creator` of the space delegating themselves, thereby avoiding two entries of `delegates` belonging to the same source `did`, anyway `creator` will have `7` permission bits.
This avoids potential case of getting `UnAuthorizedOperation` even though the account posses sufficient permissions.
