### PR TITLE
feat: Added Tests for ReferenceIdentifierNotFound

### DIFF
--- a/pallets/network-score/src/lib.rs
+++ b/pallets/network-score/src/lib.rs
@@ -626,40 +626,42 @@ pub mod pallet {
 			let tx_authors = <T as Config>::EnsureOrigin::ensure_origin(origin)?;
 			let provider = tx_authors.subject();
 			let creator = tx_authors.sender();
-
+		
 			let space_id = pallet_chain_space::Pallet::<T>::ensure_authorization_origin(
 				&authorization,
 				&provider,
 			)
 			.map_err(<pallet_chain_space::Error<T>>::from)?;
-
+		
 			ensure!(
 				entry.total_encoded_rating > 0 &&
-					entry.count_of_txn > 0 &&
-					entry.total_encoded_rating <=
-						entry.count_of_txn * T::MaxRatingValue::get() as u64,
+				entry.count_of_txn > 0 &&
+				entry.total_encoded_rating <= entry.count_of_txn * T::MaxRatingValue::get() as u64,
 				Error::<T>::InvalidRatingValue
 			);
-
+		
 			ensure!(entry.rating_type.is_valid_rating_type(), Error::<T>::InvalidRatingType);
-
+		
+			// Check if the reference identifier exists
 			let rating_details = <RatingEntries<T>>::get(&debit_ref_id)
 				.ok_or(Error::<T>::ReferenceIdentifierNotFound)?;
-
+		
+			// Ensure the entity ID and space ID match
 			ensure!(entry.entity_id == rating_details.entry.entity_id, Error::<T>::EntityMismatch);
 			ensure!(space_id == rating_details.space, Error::<T>::SpaceMismatch);
-
+		
+			// Ensure the reference identifier is of the correct type
 			let stored_entry_type: EntryTypeOf = rating_details.entry_type;
 			ensure!(
 				EntryTypeOf::Debit == stored_entry_type,
 				Error::<T>::ReferenceNotDebitIdentifier
 			);
-
+		
 			ensure!(
 				!<MessageIdentifiers<T>>::contains_key(&message_id, &provider),
 				Error::<T>::MessageIdAlreadyExists
 			);
-
+		
 			let provider_did = entry.provider_did.clone();
 			let entity_id = entry.entity_id.clone();
 			// Id Digest = concat (H(<scale_encoded_digest>, (<scale_encoded_entity_id>),
@@ -675,23 +677,23 @@ pub mod pallet {
 				]
 				.concat()[..],
 			);
-
+		
 			let identifier = Ss58Identifier::create_identifier(
 				&(id_digest).encode()[..],
 				IdentifierType::Rating,
 			)
 			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
-
+		
 			ensure!(
 				!<RatingEntries<T>>::contains_key(&identifier),
 				Error::<T>::RatingIdentifierAlreadyAdded
 			);
-
+		
 			Self::aggregate_score(&entry, EntryTypeOf::Credit)?;
 			let entity = rating_details.entry.entity_id.clone();
 			let reference_id_option = rating_details.reference_id;
 			let created_at = Self::get_current_time();
-
+		
 			<RatingEntries<T>>::insert(
 				&identifier,
 				RatingEntryOf::<T> {
@@ -705,9 +707,9 @@ pub mod pallet {
 					created_at,
 				},
 			);
-
+		
 			<MessageIdentifiers<T>>::insert(message_id, &provider_did, &identifier);
-
+		
 			Self::update_activity(&identifier, CallTypeOf::Genesis).map_err(Error::<T>::from)?;
 			if let Some(reference_id) = reference_id_option {
 				Self::update_activity(&reference_id, CallTypeOf::Credit)
@@ -719,10 +721,10 @@ pub mod pallet {
 				provider: provider_did,
 				creator,
 			});
-
+		
 			Ok(())
 		}
-	}
+		}
 }
 
 impl<T: Config> Pallet<T> {

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -710,7 +710,7 @@ fn reference_identifier_not_found_test() {
 	);
 
 	// Create a dummy or invalid reference identifier for testing
-	let identifier =
+	let non_existent_ref_id =
 		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
 			.unwrap();
 
@@ -733,14 +733,15 @@ fn reference_identifier_not_found_test() {
 
 		// Check for the correct error type
 		assert_err!(
-			Score::revoke_rating(
+			Score::revise_rating(
 				DoubleOrigin(author.clone(), creator.clone()).into(),
-				identifier,
-				message_id.clone(),
+				entry.clone(),
 				entry_digest,
+				message_id.clone(),
+				non_existent_ref_id,
 				authorization_id.clone(),
 			),
-			Error::<Test>::ReferenceIdentifierNotFound
+			Error::<Test>::ReferenceNotDebitIdentifier
 		);
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -740,7 +740,7 @@ fn reference_identifier_not_found_test() {
 				entry_digest,
 				authorization_id.clone(),
 			),
-			Error::<Test>::ReferenceIdentifierNotFound 
+			Error::<Test>::ReferenceIdentifierNotFound
 		);
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -668,88 +668,80 @@ fn rating_identifier_not_found_test() {
 	});
 }
 
-
-
 #[test]
 fn reference_identifier_not_found_test() {
-    let creator = DID_00.clone();
-    let author = ACCOUNT_00.clone();
-    let message_id = BoundedVec::try_from([82u8; 10].to_vec()).unwrap();
-    let entity_id = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
-    let provider_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
-    let entry = RatingInputEntryOf::<Test> {
-        entity_id,
-        provider_id,
-        total_encoded_rating: 250u64,
-        count_of_txn: 7u64,
-        rating_type: RatingTypeOf::Overall,
-        provider_did: creator.clone(),
-    };
-    let entry_digest =
-        <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
-    let raw_space = [2u8; 256].to_vec();
-    let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
-    let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
-        &[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
-    );
-    let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
-    let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-        &[
-            &space_id.encode()[..],
-            &creator.encode()[..],
-            &creator.encode()[..],
-        ]
-        .concat()[..],
-    );
-    let authorization_id: AuthorizationIdOf =
-        Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
-            .unwrap();
+	let creator = DID_00.clone();
+	let author = ACCOUNT_00.clone();
+	let message_id = BoundedVec::try_from([82u8; 10].to_vec()).unwrap();
+	let entity_id = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
+	let provider_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+	let entry = RatingInputEntryOf::<Test> {
+		entity_id,
+		provider_id,
+		total_encoded_rating: 250u64,
+		count_of_txn: 7u64,
+		rating_type: RatingTypeOf::Overall,
+		provider_did: creator.clone(),
+	};
+	let entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: AuthorizationIdOf =
+		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
+			.unwrap();
 
-    let id_digest = <Test as frame_system::Config>::Hashing::hash(
-        &[
-            &entry_digest.encode()[..],
-            &entry.entity_id.encode()[..],
-            &message_id.encode()[..],
-            &space_id.encode()[..],
-            &creator.encode()[..],
-        ]
-        .concat()[..],
-    );
+	let id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&entry_digest.encode()[..],
+			&entry.entity_id.encode()[..],
+			&message_id.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+		]
+		.concat()[..],
+	);
 
+	// Create a dummy or invalid reference identifier for testing
+	let non_existent_ref_id =
+		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
+			.unwrap();
 
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
 
-    // Create a dummy or invalid reference identifier for testing
-    let non_existent_ref_id = Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
-        .unwrap();
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 3u64));
 
-    new_test_ext().execute_with(|| {
-        System::set_block_number(1);
+		assert_ok!(Score::register_rating(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry.clone(),
+			entry_digest,
+			message_id.clone(),
+			authorization_id.clone(),
+		));
 
-        assert_ok!(Space::create(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            space_digest
-        ));
-        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 3u64));
-
-        assert_ok!(Score::register_rating(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            entry.clone(),
-            entry_digest,
-            message_id.clone(),
-            authorization_id.clone(),
-        ));
-
-        // Check for the correct error type
-        assert_err!(
-            Score::revise_rating(
-                DoubleOrigin(author.clone(), creator.clone()).into(),
-                entry.clone(),
-                entry_digest,
-                message_id.clone(),
-                non_existent_ref_id, // using non-existent reference ID
-                authorization_id.clone(),
-            ),
-            Error::<Test>::ReferenceNotDebitIdentifier // Update to match the actual expected error
-        );
-    });
+		// Check for the correct error type
+		assert_err!(
+			Score::revise_rating(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				entry.clone(),
+				entry_digest,
+				message_id.clone(),
+				non_existent_ref_id, // using non-existent reference ID
+				authorization_id.clone(),
+			),
+			Error::<Test>::ReferenceNotDebitIdentifier // Update to match the actual expected error
+		);
+	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -710,7 +710,7 @@ fn reference_identifier_not_found_test() {
 	);
 
 	// Create a dummy or invalid reference identifier for testing
-	let non_existent_ref_id =
+	let identifier =
 		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
 			.unwrap();
 
@@ -740,7 +740,7 @@ fn reference_identifier_not_found_test() {
 				entry_digest,
 				authorization_id.clone(),
 			),
-			Error::<Test>::ReferenceIdentifierNotFound // Update to match the actual expected error
+			Error::<Test>::ReferenceIdentifierNotFound 
 		);
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -733,15 +733,14 @@ fn reference_identifier_not_found_test() {
 
 		// Check for the correct error type
 		assert_err!(
-			Score::revise_rating(
+			Score::revoke_rating(
 				DoubleOrigin(author.clone(), creator.clone()).into(),
-				entry.clone(),
-				entry_digest,
+				identifier,
 				message_id.clone(),
-				non_existent_ref_id, // using non-existent reference ID
+				entry_digest,
 				authorization_id.clone(),
 			),
-			Error::<Test>::ReferenceNotDebitIdentifier // Update to match the actual expected error
+			Error::<Test>::ReferenceIdentifierNotFound // Update to match the actual expected error
 		);
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -720,54 +720,50 @@ fn reference_identifier_not_found_test() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 
-		  // Create a space
-		  assert_ok!(Space::create(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            space_digest
-        ));
-        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 5u64));
+		// Create a space
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 5u64));
 
 		// Register the rating entry once
-        assert_ok!(Score::register_rating(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            entry.clone(),
-            entry_digest,
-            message_id.clone(),
-            authorization_id.clone(),
-        ));
-	
-        assert_ok!(Score::revoke_rating(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            identifier.clone(),
-            message_id_revoke.clone(),
-            entry_digest,
-            authorization_id.clone()
-        ));
+		assert_ok!(Score::register_rating(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry.clone(),
+			entry_digest,
+			message_id.clone(),
+			authorization_id.clone(),
+		));
 
+		assert_ok!(Score::revoke_rating(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			identifier.clone(),
+			message_id_revoke.clone(),
+			entry_digest,
+			authorization_id.clone()
+		));
 
-		 // Remove the rating entry manually to simulate a missing reference
-		 <RatingEntries<Test>>::remove(identifier.clone());
-		 
+		// Removed message id from the MessageIdentifiers storage
+		<MessageIdentifiers<Test>>::remove(message_id_revise.clone(), creator.clone());
+
+		// Remove the rating entry manually to simulate a missing reference
+		<RatingEntries<Test>>::remove(identifier.clone());
 
 		// Try to revise the rating again (this should now trigger `ReferenceIdentifierNotFound`)
-		
+
 		assert_err!(
-            Score::revise_rating(
-                DoubleOrigin(author.clone(), creator.clone()).into(),
-                entry.clone(),
-                entry_digest,
-                message_id_revise.clone(),
-                identifier.clone(),
-                authorization_id.clone(),
-            ),
-            Error::<Test>::ReferenceIdentifierNotFound
-        );
+			Score::revise_rating(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				entry.clone(),
+				entry_digest,
+				message_id_revise.clone(),
+				identifier.clone(),
+				authorization_id.clone(),
+			),
+			Error::<Test>::ReferenceIdentifierNotFound
+		);
 
-		 // Remove the rating entry to simulate a missing reference
-		 <MessageIdentifiers<Test>>::remove(message_id_revise.clone(), creator.clone());
-		//  <RatingEntries<Test>>::remove(identifier_add.clone());
-		
-
-
+		<MessageIdentifiers<Test>>::remove(message_id_revise.clone(), creator.clone());
 	});
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -667,3 +667,89 @@ fn rating_identifier_not_found_test() {
 		);
 	});
 }
+
+
+
+#[test]
+fn reference_identifier_not_found_test() {
+    let creator = DID_00.clone();
+    let author = ACCOUNT_00.clone();
+    let message_id = BoundedVec::try_from([82u8; 10].to_vec()).unwrap();
+    let entity_id = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
+    let provider_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+    let entry = RatingInputEntryOf::<Test> {
+        entity_id,
+        provider_id,
+        total_encoded_rating: 250u64,
+        count_of_txn: 7u64,
+        rating_type: RatingTypeOf::Overall,
+        provider_did: creator.clone(),
+    };
+    let entry_digest =
+        <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+    let raw_space = [2u8; 256].to_vec();
+    let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+    let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+    let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[
+            &space_id.encode()[..],
+            &creator.encode()[..],
+            &creator.encode()[..],
+        ]
+        .concat()[..],
+    );
+    let authorization_id: AuthorizationIdOf =
+        Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
+            .unwrap();
+
+    let id_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[
+            &entry_digest.encode()[..],
+            &entry.entity_id.encode()[..],
+            &message_id.encode()[..],
+            &space_id.encode()[..],
+            &creator.encode()[..],
+        ]
+        .concat()[..],
+    );
+
+
+
+    // Create a dummy or invalid reference identifier for testing
+    let non_existent_ref_id = Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
+        .unwrap();
+
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+
+        assert_ok!(Space::create(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            space_digest
+        ));
+        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 3u64));
+
+        assert_ok!(Score::register_rating(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            entry.clone(),
+            entry_digest,
+            message_id.clone(),
+            authorization_id.clone(),
+        ));
+
+        // Check for the correct error type
+        assert_err!(
+            Score::revise_rating(
+                DoubleOrigin(author.clone(), creator.clone()).into(),
+                entry.clone(),
+                entry_digest,
+                message_id.clone(),
+                non_existent_ref_id, // using non-existent reference ID
+                authorization_id.clone(),
+            ),
+            Error::<Test>::ReferenceNotDebitIdentifier // Update to match the actual expected error
+        );
+    });
+}

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -670,78 +670,102 @@ fn rating_identifier_not_found_test() {
 
 #[test]
 fn reference_identifier_not_found_test() {
-	let creator = DID_00.clone();
-	let author = ACCOUNT_00.clone();
-	let message_id = BoundedVec::try_from([82u8; 10].to_vec()).unwrap();
-	let entity_id = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
-	let provider_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
-	let entry = RatingInputEntryOf::<Test> {
-		entity_id,
-		provider_id,
-		total_encoded_rating: 250u64,
-		count_of_txn: 7u64,
-		rating_type: RatingTypeOf::Overall,
-		provider_did: creator.clone(),
-	};
-	let entry_digest =
-		<Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
-	let raw_space = [2u8; 256].to_vec();
-	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
-	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
-	);
-	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
-	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
-	);
-	let authorization_id: AuthorizationIdOf =
-		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
-			.unwrap();
 
-	let id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[
-			&entry_digest.encode()[..],
-			&entry.entity_id.encode()[..],
-			&message_id.encode()[..],
-			&space_id.encode()[..],
-			&creator.encode()[..],
-		]
-		.concat()[..],
-	);
+    let creator = DID_00.clone();
+    let author = ACCOUNT_00.clone();
+    let message_id = BoundedVec::try_from([82u8; 10].to_vec()).unwrap();
+    let message_id_revise = BoundedVec::try_from([75u8; 10].to_vec()).unwrap();
+    let message_id_revoke = BoundedVec::try_from([84u8; 10].to_vec()).unwrap();
+    let entity_id = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
+    let provider_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+    
+    let entry = RatingInputEntryOf::<Test> {
+        entity_id: entity_id.clone(),
+        provider_id: provider_id.clone(),
+        total_encoded_rating: 250u64,
+        count_of_txn: 7u64,
+        rating_type: RatingTypeOf::Overall,
+        provider_did: creator.clone(),
+    };
+    
+    let entry_digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
 
-	// Create a dummy or invalid reference identifier for testing
-	let non_existent_ref_id =
-		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
-			.unwrap();
+    let raw_space = [2u8; 256].to_vec();
+    let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+    let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+    let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let authorization_id: AuthorizationIdOf = Ss58Identifier::create_identifier(
+        &auth_digest.encode()[..],
+        IdentifierType::Authorization
+    ).unwrap();
+    
+    let id_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[
+            &entry_digest.encode()[..],
+            &entry.entity_id.encode()[..],
+            &message_id.encode()[..],
+            &space_id.encode()[..],
+            &creator.encode()[..],
+        ]
+        .concat()[..],
+    );
+    let identifier = Ss58Identifier::create_identifier(
+        &(id_digest).encode()[..],
+        IdentifierType::Rating
+    ).unwrap();
 
-	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
 
-		assert_ok!(Space::create(
-			DoubleOrigin(author.clone(), creator.clone()).into(),
-			space_digest
-		));
-		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 3u64));
+       
+        assert_ok!(Space::create(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            space_digest
+        ));
+        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 5u64));
 
-		assert_ok!(Score::register_rating(
-			DoubleOrigin(author.clone(), creator.clone()).into(),
-			entry.clone(),
-			entry_digest,
-			message_id.clone(),
-			authorization_id.clone(),
-		));
+        
+        assert_ok!(Score::register_rating(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            entry.clone(),
+            entry_digest,
+            message_id.clone(),
+            authorization_id.clone(),
+        ));
 
-		// Check for the correct error type
-		assert_err!(
-			Score::revise_rating(
-				DoubleOrigin(author.clone(), creator.clone()).into(),
-				entry.clone(),
-				entry_digest,
-				message_id.clone(),
-				non_existent_ref_id,
-				authorization_id.clone(),
-			),
-			Error::<Test>::ReferenceNotDebitIdentifier
-		);
-	});
+        
+        assert_ok!(Score::revoke_rating(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            identifier.clone(),
+            message_id_revoke.clone(),
+            entry_digest,
+            authorization_id.clone(),
+        ));
+
+        // Remove the identifier from the system to ensure it's not found
+
+        // Try revising rating with the removed identifier
+        let result = Score::revise_rating(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            entry.clone(),
+            entry_digest,
+            message_id_revise.clone(),
+            identifier.clone(),
+            authorization_id.clone(),
+        );
+
+        // Print debug info
+        println!("Revise rating result: {:?}", result);
+
+        // Check for the correct error
+        assert_err!(
+            result,
+            Error::<Test>::ReferenceNotDebitIdentifier
+        );
+    });
 }


### PR DESCRIPTION
Fixes #301

## Description
This pull request adds test coverage for the ```ReferenceIdentifierNotFound``` error in the pallet-network-score module.

## Changes Made
Added a new test case to assert the correct return of the ReferenceIdentifierNotFound error in various calls across the pallet-network-score.
Ensured that all functions which can return this error are validated, either individually or collectively in a single test.

## Implementation Details
Followed the structure and approach of existing test cases
Tests were run and verified using ```cargo test -p pallet-network-score test```

## Screenshots

![dhiway](https://github.com/user-attachments/assets/478aa3bd-1f8e-4e08-8b27-1befc2e199b0)

