### PR TITLE
Add test for invalid UTF8

### DIFF
--- a/pallets/node-authorization/src/lib.rs
+++ b/pallets/node-authorization/src/lib.rs
@@ -150,6 +150,7 @@ pub mod pallet {
 	}
 
 	#[pallet::error]
+	#[derive(PartialEq)]
 	pub enum Error<T> {
 		/// The Node identifier is too long.
 		NodeIdTooLong,

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -22,7 +22,7 @@
 
 use super::*;
 use crate::mock::*;
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, assert_err};
 use sp_runtime::traits::BadOrigin;
 
 #[test]
@@ -452,4 +452,11 @@ fn adding_already_connected_connection_should_fail() {
 			Error::<Test>::AlreadyConnected
 		);
 	});
+}
+
+#[test]
+fn test_generate_peer_id_invalid_utf8() {
+	let invalid_node_id: NodeId = vec![0xFF, 0xFE, 0xFD];
+	let result = Pallet::<Test>::generate_peer_id(&invalid_node_id);
+	assert_noop!(result, Error::<Test>::InvalidUtf8);
 }

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -22,7 +22,7 @@
 
 use super::*;
 use crate::mock::*;
-use frame_support::{assert_noop, assert_ok, assert_err};
+use frame_support::{assert_err, assert_noop, assert_ok};
 use sp_runtime::traits::BadOrigin;
 
 #[test]

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -457,6 +457,5 @@ fn adding_already_connected_connection_should_fail() {
 #[test]
 fn test_generate_peer_id_invalid_utf8() {
 	let invalid_node_id: NodeId = vec![0xFF, 0xFE, 0xFD];
-	let result = Pallet::<Test>::generate_peer_id(&invalid_node_id);
-	assert_noop!(result, Error::<Test>::InvalidUtf8);
+	assert_err!(NodeAuthorization::generate_peer_id(&invalid_node_id), Error::<Test>::InvalidUtf8);
 }


### PR DESCRIPTION
Fixes #307 

I have added a test which will check for `InvalidUtf8` when the nodeId is not proper.

I tried adding separate test for `InvalidUtf8` error code but Rust doesn't allow setting invalid utf-8 characters in a string. Hence have created a separate test.