### PR TITLE
Implement MembershipNotFound Error Handling

### DIFF
--- a/pallets/network-membership/src/tests.rs
+++ b/pallets/network-membership/src/tests.rs
@@ -304,3 +304,60 @@ fn test_revoke_membership_with_wrong_account_id_should_fail() {
 		);
 	});
 }
+
+#[test]
+fn test_revoke_membership_non_existent() {
+	new_test_ext().execute_with(|| {
+		run_to_block(1);
+
+		// Attempt to revoke a membership for a non-existent account
+		assert_err!(
+			NetworkMembership::revoke(RawOrigin::Root.into(), AccountId::new([99u8; 32]),),
+			Error::<Test>::MembershipNotFound
+		);
+
+		assert_eq!(NetworkMembership::members_count(), 1); // No changes to member count
+	});
+}
+
+#[test]
+fn test_check_membership_non_existent() {
+	new_test_ext().execute_with(|| {
+		run_to_block(1);
+
+		// Check if a non-existent account is a member
+		// assert!(!NetworkMembership::is_member(&AccountId::new([99u8; 32])));
+
+		assert_err!(
+			NetworkMembership::nominate(
+				RuntimeOrigin::signed(AccountId::new([11u8; 32])),
+				AccountId::new([13u8; 32]),
+				true
+			),
+			BadOrigin
+		);
+
+		assert_eq!(NetworkMembership::is_member(&AccountId::new([99u8; 32])), false);
+	});
+}
+
+#[test]
+fn test_auto_expire_non_existent_membership() {
+	new_test_ext().execute_with(|| {
+		run_to_block(1);
+
+		// Check that a non-existent account cannot expire
+		run_to_block(10); // Advance time beyond the expiration period
+
+		assert_err!(
+			NetworkMembership::nominate(
+				RuntimeOrigin::signed(AccountId::new([11u8; 32])),
+				AccountId::new([13u8; 32]),
+				true
+			),
+			BadOrigin
+		);
+
+		assert_eq!(NetworkMembership::is_member(&AccountId::new([99u8; 32])), false);
+	});
+}


### PR DESCRIPTION
Fixes #291 

## Description
This PR enhances the membership management functionality in the pallet-network-membership by introducing tests that validate the behavior of the system when interacting with non-existent memberships. The following tests have been added:

### Test for Revoking Non-Existent Membership:

Implemented the `test_revoke_membership_non_existent` to ensure that attempting to revoke a membership for an account that does not exist correctly raises the MembershipNotFound error.
This test checks that the member count remains unchanged when the revoke operation is attempted on a non-existent account.
Test for Checking Non-Existent Membership:

Added `test_check_membership_non_existent` to verify that the system correctly identifies a non-existent account as not being a member. This ensures the integrity of the membership verification process.
Test for Auto Expiration of Non-Existent Membership:

Included `test_auto_expire_non_existent_membership` to confirm that a non-existent account does not trigger any expiration logic. This test advances the block number to simulate the passage of time and checks that the account remains non-existent.

## Testing 
Tested using ` cargo test -p pallet-network-membership test`

## Screenshots

![image](https://github.com/user-attachments/assets/f781b202-9a56-4081-b6d3-613a79111eac)
