### PR TITLE
schema-accounts: Add pallet for accounts based schema management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "authority-membership"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1234,7 +1234,7 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cord-braid-runtime"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "authority-membership",
  "cord-braid-runtime-constants",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cord-braid-runtime-constants"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "cord-identifier"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "blake2-rfc",
  "bs58 0.5.1",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "cord-loom-runtime"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "authority-membership",
  "cord-identifier",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "cord-loom-runtime-constants"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-cli"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "array-bytes",
  "assert_cmd",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-inspect"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-rpc"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-primitives",
  "jsonrpsee",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "cord-primitives"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "cord-runtime-common"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-primitives",
  "frame-benchmarking",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "cord-utilities"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "cord-weave-runtime"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "authority-membership",
  "cord-identifier",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "cord-weave-runtime-constants"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "network-membership"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-runtime-api"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-chain-space"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "bitflags 1.3.2",
  "cord-identifier",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-config"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-primitives",
  "frame-benchmarking",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-identifier",
  "cord-utilities",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-name"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-utilities",
  "frame-benchmarking",
@@ -6331,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-runtime-api"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-entries"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6389,7 +6389,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6454,7 +6454,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-network-membership"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6502,7 +6502,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-network-score"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6523,7 +6523,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-node-authorization"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "bs58 0.5.1",
  "cord-primitives",
@@ -6540,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-registries"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "bitflags 1.3.2",
  "cord-identifier",
@@ -6622,7 +6622,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-runtime-upgrade"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schema"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schema-accounts"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -6724,7 +6724,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-statement"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-weight-runtime-api"
-version = "0.9.4"
+version = "0.9.3-1"
 dependencies = [
  "frame-support",
  "pallet-network-membership",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "authority-membership"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1234,7 +1234,7 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cord-braid-runtime"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "authority-membership",
  "cord-braid-runtime-constants",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cord-braid-runtime-constants"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "cord-identifier"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "blake2-rfc",
  "bs58 0.5.1",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "cord-loom-runtime"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "authority-membership",
  "cord-identifier",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "cord-loom-runtime-constants"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "array-bytes",
  "assert_cmd",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-inspect"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-rpc"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "jsonrpsee",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "cord-primitives"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "cord-runtime-common"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "frame-benchmarking",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "cord-utilities"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "cord-weave-runtime"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "authority-membership",
  "cord-identifier",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "cord-weave-runtime-constants"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "network-membership"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-runtime-api"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-chain-space"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bitflags 1.3.2",
  "cord-identifier",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-config"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "frame-benchmarking",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-utilities",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-name"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-utilities",
  "frame-benchmarking",
@@ -6331,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-runtime-api"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-entries"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6389,7 +6389,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6454,7 +6454,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-network-membership"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6502,7 +6502,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-network-score"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6523,7 +6523,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-node-authorization"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bs58 0.5.1",
  "cord-primitives",
@@ -6540,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-registries"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bitflags 1.3.2",
  "cord-identifier",
@@ -6622,7 +6622,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-runtime-upgrade"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schema"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schema-accounts"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -6724,7 +6724,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-statement"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-weight-runtime-api"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "pallet-network-membership",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,7 @@ dependencies = [
  "pallet-runtime-upgrade",
  "pallet-scheduler",
  "pallet-schema",
+ "pallet-schema-accounts",
  "pallet-session",
  "pallet-session-benchmarking",
  "pallet-statement",
@@ -1415,6 +1416,7 @@ dependencies = [
  "pallet-runtime-upgrade",
  "pallet-scheduler",
  "pallet-schema",
+ "pallet-schema-accounts",
  "pallet-session",
  "pallet-session-benchmarking",
  "pallet-statement",
@@ -1939,6 +1941,7 @@ dependencies = [
  "pallet-runtime-upgrade",
  "pallet-scheduler",
  "pallet-schema",
+ "pallet-schema-accounts",
  "pallet-session",
  "pallet-session-benchmarking",
  "pallet-statement",
@@ -6657,6 +6660,26 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-chain-space",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-schema-accounts"
+version = "0.9.3"
+dependencies = [
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 
 [workspace.package]
-version = "0.9.3"
+version = "0.9.4"
 authors = ['Dhiway Networks <info@dhiway.com>']
 edition = "2021"
 homepage = "https://cord.network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.3-1"
 authors = ['Dhiway Networks <info@dhiway.com>']
 edition = "2021"
 homepage = "https://cord.network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,8 @@ pallet-did-runtime-api = { path = "runtimes/common/api/did", default-features = 
 pallet-transaction-weight-runtime-api = { path = "runtimes/common/api/weight", default-features = false }
 pallet-registries = { path = "pallets/registries", default-features = false }
 pallet-entries = { path = "pallets/entries", default-features = false }
+pallet-schema-accounts = { path = "pallets/schema-accounts", default-features = false }
+
 
 # substrate dependencies
 frame-benchmarking = { git = "https://github.com/dhiway/substrate-sdk", default-features = false, branch = "release-v1.15.0" }

--- a/pallets/schema-accounts/Cargo.toml
+++ b/pallets/schema-accounts/Cargo.toml
@@ -1,0 +1,73 @@
+[package]
+name = 'pallet-schema-accounts'
+description = 'Account Based To Manage Schemas'
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dev-dependencies]
+sp-core = { features = ["std"], workspace = true }
+sp-keystore = { features = ["std"], workspace = true }
+cord-utilities = { features = ["mock"], workspace = true }
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+scale-info = { features = ["derive"], workspace = true }
+cord-primitives = { workspace = true }
+cord-utilities = { workspace = true }
+identifier = { workspace = true }
+
+log = { workspace = true }
+
+# Substrate dependencies
+frame-benchmarking = { optional = true, workspace = true }
+frame-system = { workspace = true }
+frame-support = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+sp-core = { optional = true, workspace = true }
+sp-io = { optional = true, workspace = true }
+sp-keystore = { optional = true, workspace = true }
+
+[features]
+default = ['std']
+std = [
+	"codec/std",
+	"scale-info/std",
+	"identifier/std",
+	"frame-support/std",
+	"frame-system/std",
+	"frame-benchmarking?/std",
+	"cord-primitives/std",
+	"cord-utilities/std",
+	"sp-runtime/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-std/std",
+	"log/std",
+	"sp-keystore?/std"
+]
+mock = ["sp-core", "sp-io", "sp-keystore"]
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"cord-utilities/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"identifier/try-runtime",
+	"cord-utilities/try-runtime",
+	"sp-runtime/try-runtime"
+]

--- a/pallets/schema-accounts/src/lib.rs
+++ b/pallets/schema-accounts/src/lib.rs
@@ -1,0 +1,260 @@
+// This file is part of CORD – https://cord.network
+
+// Copyright (C) Dhiway Networks Pvt. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// CORD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CORD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CORD. If not, see <https://www.gnu.org/licenses/>.
+
+//! # Schema Accounts Pallet
+//!
+//! A account based pallet which enables users to generate Schema Identifier,
+//! store the Schema hash (blake2b as hex string) on chain and
+//!  associate it with their account id.
+//!
+//! - [`Config`]
+//! - [`Call`]
+//! - [`Pallet`]
+//!
+//! ### Terminology
+//!
+//! - **Schema:**: Schemas are templates used to guarantee the structure, and by extension the
+//!   semantics, of the set of claims comprising a Stream/Verifiable Credential. A shared Schema
+//!   allows all parties to reference data in a known way. An identifier can optionally link to a
+//!   valid schema identifier.
+//!
+//! ## Assumptions
+//!
+//! - The Schema hash was created using CORD SDK.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[cfg(any(feature = "mock", test))]
+pub mod mock;
+
+/// Test module for Schemas
+#[cfg(test)]
+pub mod tests;
+
+use identifier::{
+	types::{CallTypeOf, IdentifierTypeOf, Timepoint},
+	EventEntryOf,
+};
+use sp_runtime::traits::UniqueSaturatedInto;
+
+/// Extra Types for Schema
+pub mod types;
+
+pub use crate::types::*;
+use frame_support::ensure;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	pub use cord_utilities::traits::CallSources;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	pub use frame_system::WeightInfo;
+	pub use identifier::{IdentifierCreator, IdentifierTimeline, IdentifierType, Ss58Identifier};
+	use sp_runtime::traits::Hash;
+
+	/// The current storage version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
+	/// Schema Identifier
+	pub type SchemaIdOf = Ss58Identifier;
+	/// Hash of the schema.
+	pub type SchemaHashOf<T> = <T as frame_system::Config>::Hash;
+	/// Type of a CORD account.
+	pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+	/// Type of a Schema creator.
+	pub type SchemaCreatorOf<T> = AccountIdOf<T>;
+	/// Type for an input schema
+	pub type InputSchemaOf<T> = BoundedVec<u8, <T as Config>::MaxEncodedSchemaLength>;
+	/// Type for a schema entry
+	pub type SchemaEntryOf<T> = SchemaEntry<InputSchemaOf<T>, SchemaHashOf<T>, SchemaCreatorOf<T>>;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config + identifier::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		#[pallet::constant]
+		type MaxEncodedSchemaLength: Get<u32>;
+
+		/// Weight information for extrinsics in this pallet.
+		type WeightInfo: WeightInfo;
+	}
+
+	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	/// schemas stored on chain.
+	/// It maps from a schema identifier to its details.
+	#[pallet::storage]
+	pub type Schemas<T> = StorageMap<_, Blake2_128Concat, SchemaIdOf, SchemaEntryOf<T>>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A new schema has been created.
+		/// \[schema identifier, digest, author\]
+		Created { identifier: SchemaIdOf, creator: SchemaCreatorOf<T> },
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Schema identifier is not unique.
+		SchemaAlreadyAnchored,
+		/// Schema identifier not found.
+		SchemaNotFound,
+		// Invalid Schema Identifier Length.
+		InvalidIdentifierLength,
+		/// The paying account was unable to pay the fees for creating a schema.
+		UnableToPayFees,
+		/// Creator DID information not found.
+		CreatorNotFound,
+		/// Schema limit exceeds the permitted size.
+		MaxEncodedSchemaLimitExceeded,
+		/// Empty transaction.
+		EmptyTransaction,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Create a new schema and associates with its identifier.
+		/// `create` takes a `InputSchemaOf<T>` and returns a `DispatchResult`
+		///
+		/// Arguments:
+		///
+		/// * `origin`: The origin of the transaction.
+		/// * `tx_schema`: The schema that is being anchored.
+		///
+		/// Returns:
+		///
+		/// DispatchResult
+		#[pallet::call_index(0)]
+		#[pallet::weight({0})]
+		pub fn create(origin: OriginFor<T>, tx_schema: InputSchemaOf<T>) -> DispatchResult {
+			let creator = ensure_signed(origin)?;
+
+			ensure!(tx_schema.len() > 0, Error::<T>::EmptyTransaction);
+			ensure!(
+				tx_schema.len() <= T::MaxEncodedSchemaLength::get() as usize,
+				Error::<T>::MaxEncodedSchemaLimitExceeded
+			);
+
+			// Id Digest = concat (H(<scale_encoded_schema_input>,
+			// <scale_encoded_creator_identifier>))
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&tx_schema.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let identifier = Ss58Identifier::create_identifier(
+				&(id_digest).encode()[..],
+				IdentifierType::SchemaAccounts,
+			)
+			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+
+			ensure!(!<Schemas<T>>::contains_key(&identifier), Error::<T>::SchemaAlreadyAnchored);
+
+			let digest = <T as frame_system::Config>::Hashing::hash(&tx_schema[..]);
+			let block_number = frame_system::Pallet::<T>::block_number();
+
+			log::debug!(
+				"Schema created with identifier: {:?}, schema: {:?} digest: {:?}, creator:
+			{:?}, block_number: {:?}",
+				identifier,
+				tx_schema,
+				digest,
+				creator,
+				block_number
+			);
+
+			<Schemas<T>>::insert(
+				&identifier,
+				SchemaEntryOf::<T> { schema: tx_schema, digest, creator: creator.clone() },
+			);
+
+			Self::update_activity(&identifier, CallTypeOf::Genesis).map_err(<Error<T>>::from)?;
+
+			Self::deposit_event(Event::Created { identifier, creator });
+
+			Ok(())
+		}
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	/// `ensure!` is a macro that takes a boolean expression and an error type.
+	/// If the expression is false, it returns the error
+	///
+	/// Arguments:
+	///
+	/// * `tx_ident`: The identifier of the transaction to check.
+	///
+	/// Returns:
+	///
+	/// A Result<(), Error<T>>
+	pub fn is_valid(tx_ident: &SchemaIdOf) -> Result<(), Error<T>> {
+		ensure!(<Schemas<T>>::contains_key(tx_ident), Error::<T>::SchemaNotFound);
+		Ok(())
+	}
+
+	/// Updates the global timeline with a new activity event for a schema.
+	///
+	/// An `EventEntryOf` struct is created, encapsulating the type of action
+	/// (`tx_action`) and the `Timepoint` of the event, which is obtained by
+	/// calling the `timepoint` function. This entry is then passed to the
+	/// `update_timeline` function of the `identifier` pallet, which integrates
+	/// it into the global timeline.
+	///
+	/// # Parameters
+	/// - `tx_id`: The identifier of the schema that the activity pertains to.
+	/// - `tx_action`: The type of action taken on the schema, encapsulated within `CallTypeOf`.
+	///
+	/// # Returns
+	/// Returns `Ok(())` after successfully updating the timeline. If any errors
+	/// occur within the `update_timeline` function, they are not captured here
+	/// and the function will still return `Ok(())`.
+	pub fn update_activity(tx_id: &SchemaIdOf, tx_action: CallTypeOf) -> Result<(), Error<T>> {
+		let tx_moment = Self::timepoint();
+
+		let tx_entry = EventEntryOf { action: tx_action, location: tx_moment };
+		let _ = IdentifierTimeline::update_timeline::<T>(
+			tx_id,
+			IdentifierTypeOf::SchemaAccounts,
+			tx_entry,
+		);
+		Ok(())
+	}
+
+	/// Retrieves the current timepoint.
+	///
+	/// This function returns a `Timepoint` structure containing the current
+	/// block number and extrinsic index. It is typically used in conjunction
+	/// with `update_activity` to record when an event occurred.
+	///
+	/// # Returns
+	/// - `Timepoint`: A structure containing the current block number and extrinsic index.
+	pub fn timepoint() -> Timepoint {
+		Timepoint {
+			height: frame_system::Pallet::<T>::block_number().unique_saturated_into(),
+			index: frame_system::Pallet::<T>::extrinsic_index().unwrap_or_default(),
+		}
+	}
+}

--- a/pallets/schema-accounts/src/lib.rs
+++ b/pallets/schema-accounts/src/lib.rs
@@ -158,11 +158,8 @@ pub mod pallet {
 				Error::<T>::MaxEncodedSchemaLimitExceeded
 			);
 
-			// Id Digest = concat (H(<scale_encoded_schema_input>,
-			// <scale_encoded_creator_identifier>))
-			let id_digest = <T as frame_system::Config>::Hashing::hash(
-				&[&tx_schema.encode()[..], &creator.encode()[..]].concat()[..],
-			);
+			// Id Digest = H(<scale_encoded_schema_input>)
+			let id_digest = <T as frame_system::Config>::Hashing::hash(&tx_schema.encode()[..]);
 
 			let identifier = Ss58Identifier::create_identifier(
 				&(id_digest).encode()[..],

--- a/pallets/schema-accounts/src/mock.rs
+++ b/pallets/schema-accounts/src/mock.rs
@@ -1,0 +1,92 @@
+// This file is part of CORD – https://cord.network
+
+// Copyright (C) Dhiway Networks Pvt. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// CORD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CORD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CORD. If not, see <https://www.gnu.org/licenses/>.
+
+use crate as pallet_schema_accounts;
+use cord_utilities::mock::{mock_origin, SubjectId};
+use frame_support::{derive_impl, parameter_types};
+use sp_runtime::{
+	traits::{IdentifyAccount, IdentityLookup, Verify},
+	BuildStorage, MultiSignature,
+};
+
+type Signature = MultiSignature;
+type AccountPublic = <Signature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+pub(crate) type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test
+	{
+		System: frame_system,
+		SchemaAccounts: pallet_schema_accounts,
+		Identifier: identifier,
+		MockOrigin: mock_origin,
+	}
+);
+
+parameter_types! {
+	pub const SS58Prefix: u8 = 29;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Block = Block;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type SS58Prefix = SS58Prefix;
+}
+
+impl mock_origin::Config for Test {
+	type RuntimeOrigin = RuntimeOrigin;
+	type AccountId = AccountId;
+	type SubjectId = SubjectId;
+}
+
+parameter_types! {
+	pub const MaxEncodedSchemaLength: u32 = 15_360;
+}
+
+impl pallet_schema_accounts::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type MaxEncodedSchemaLength = MaxEncodedSchemaLength;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const MaxEventsHistory: u32 = 6u32;
+}
+
+impl identifier::Config for Test {
+	type MaxEventsHistory = MaxEventsHistory;
+}
+
+#[allow(dead_code)]
+pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
+	let t: sp_runtime::Storage =
+		frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	#[cfg(feature = "runtime-benchmarks")]
+	let keystore = sp_keystore::testing::MemoryKeystore::new();
+	#[cfg(feature = "runtime-benchmarks")]
+	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/pallets/schema-accounts/src/tests.rs
+++ b/pallets/schema-accounts/src/tests.rs
@@ -98,9 +98,7 @@ fn check_successful_schema_creation() {
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
 	let digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -197,9 +195,7 @@ fn test_schema_lookup() {
 		for schema in schemas {
 			let digest: SchemaHashOf<Test> =
 				<Test as frame_system::Config>::Hashing::hash(&schema[..]);
-			let id_digest = <Test as frame_system::Config>::Hashing::hash(
-				&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-			);
+			let id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 			let schema_id: SchemaIdOf = generate_schema_id::<Test>(&id_digest);
 
 			let stored_schema = Schemas::<Test>::get(&schema_id)

--- a/pallets/schema-accounts/src/tests.rs
+++ b/pallets/schema-accounts/src/tests.rs
@@ -1,0 +1,213 @@
+// This file is part of CORD – https://cord.network
+
+// Copyright (C) Dhiway Networks Pvt. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// CORD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CORD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CORD. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use crate::mock::*;
+use codec::Encode;
+use frame_support::{assert_err, assert_ok, BoundedVec};
+use sp_core::H256;
+use sp_runtime::traits::Hash;
+use sp_std::prelude::*;
+const DEFAULT_SCHEMA_HASH_SEED: u64 = 1u64;
+const ALTERNATIVE_SCHEMA_HASH_SEED: u64 = 2u64;
+
+/// Retrieves the schema hash based on a specified condition.
+///
+/// This function returns the schema hash of type `SchemaHashOf<T>` based on the
+/// value of the `default` parameter. If `default` is `true`, the default schema
+/// hash seed is used to generate the schema hash. If `default` is `false`,
+/// an alternative schema hash seed is used instead. The resulting schema hash
+/// is returned.
+///
+/// # Arguments
+///
+/// * `default` - A boolean value indicating whether to use the default schema hash seed or an
+///   alternative one.
+///
+/// # Type Parameters
+///
+/// * `T` - The runtime configuration trait.
+///
+/// # Returns
+///
+/// A `SchemaHashOf<T>` representing the generated schema hash.
+pub fn get_schema_hash<T>(default: bool) -> SchemaHashOf<T>
+where
+	T: Config,
+	T::Hash: From<H256>,
+{
+	if default {
+		H256::from_low_u64_be(DEFAULT_SCHEMA_HASH_SEED).into()
+	} else {
+		H256::from_low_u64_be(ALTERNATIVE_SCHEMA_HASH_SEED).into()
+	}
+}
+
+/// Generates a schema ID from a schema digest.
+///
+/// This function takes a schema digest and converts it into a schema ID using
+/// the SS58 encoding scheme. The resulting schema ID is returned.
+///
+/// # Arguments
+///
+/// * `digest` - A reference to the schema digest.
+///
+/// # Type Parameters
+///
+/// * `T` - The runtime configuration trait.
+///
+/// # Returns
+///
+/// A `SchemaIdOf` representing the generated schema ID.
+///
+/// # Panics
+///
+/// This function will panic if the conversion from digest to schema ID fails.
+pub fn generate_schema_id<T: Config>(digest: &SchemaHashOf<T>) -> SchemaIdOf {
+	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::SchemaAccounts)
+		.unwrap()
+}
+
+// submit_schema_creation_operation
+pub(crate) const ACCOUNT_00: AccountId = AccountId::new([1u8; 32]);
+
+// This test verifies the successful creation of a schema.
+// It creates a schema with a given creator, and schema data, and then
+// checks if the schema is stored correctly in the storage. The test passes if
+// all the assertions are successful.
+#[test]
+fn check_successful_schema_creation() {
+	let creator = ACCOUNT_00;
+
+	let raw_schema = [2u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
+	new_test_ext().execute_with(|| {
+		// Author Transaction
+		assert_ok!(SchemaAccounts::create(
+			frame_system::RawOrigin::Signed(creator.clone()).into(),
+			schema.clone()
+		));
+
+		// Storage Checks
+		let stored_schema = Schemas::<Test>::get(&schema_id)
+			.expect("Schema Identifier should be present on chain.");
+
+		// Verify the Schema has the right owner
+		assert_eq!(stored_schema.creator, creator);
+		// Verify the Schema digest is mapped correctly
+		assert_eq!(stored_schema.digest, digest);
+	});
+}
+
+// This test checks the behavior when trying to create a duplicate schema. It
+// creates a schema with a given creator and author, and then attempts to create
+// the same schema again. The test expects the second creation to fail with the
+// `SchemaAlreadyAnchored` error.
+#[test]
+fn check_duplicate_schema_creation() {
+	let creator = ACCOUNT_00;
+	let raw_schema = [9u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+
+	new_test_ext().execute_with(|| {
+		// Author Transaction
+		assert_ok!(SchemaAccounts::create(
+			frame_system::RawOrigin::Signed(creator.clone()).into(),
+			schema.clone(),
+		));
+		// Try Author the same schema again. should fail.
+		assert_err!(
+			SchemaAccounts::create(frame_system::RawOrigin::Signed(creator.clone()).into(), schema),
+			Error::<Test>::SchemaAlreadyAnchored
+		);
+	});
+}
+
+// This test case ensures that the creation of a schema with empty schema data
+// fails with the EmptyTransaction error.
+#[test]
+fn check_empty_schema_creation() {
+	let creator = ACCOUNT_00;
+	let empty_schema: InputSchemaOf<Test> = BoundedVec::default();
+
+	new_test_ext().execute_with(|| {
+		// Author Transaction
+		assert_err!(
+			SchemaAccounts::create(
+				frame_system::RawOrigin::Signed(creator.clone()).into(),
+				empty_schema,
+			),
+			Error::<Test>::EmptyTransaction
+		);
+	});
+}
+
+// This test creates multiple schemas, stores them on the chain, and then
+// retrieves each schema based on its identifier. It verifies that the retrieved
+// schemas match the expected values.
+#[test]
+fn test_schema_lookup() {
+	let creator = ACCOUNT_00;
+
+	// Create multiple schemas
+	let schema1: InputSchemaOf<Test> = BoundedVec::try_from([1u8; 256].to_vec()).unwrap();
+	let schema2: InputSchemaOf<Test> = BoundedVec::try_from([2u8; 256].to_vec()).unwrap();
+	let schema3: InputSchemaOf<Test> = BoundedVec::try_from([3u8; 256].to_vec()).unwrap();
+
+	new_test_ext().execute_with(|| {
+		// Create the schemas
+		assert_ok!(SchemaAccounts::create(
+			frame_system::RawOrigin::Signed(creator.clone()).into(),
+			schema1.clone()
+		));
+		assert_ok!(SchemaAccounts::create(
+			frame_system::RawOrigin::Signed(creator.clone()).into(),
+			schema2.clone()
+		));
+		assert_ok!(SchemaAccounts::create(
+			frame_system::RawOrigin::Signed(creator.clone()).into(),
+			schema3.clone()
+		));
+
+		// Retrieve and verify each schema
+		let schemas = vec![schema1, schema2, schema3];
+		for schema in schemas {
+			let digest: SchemaHashOf<Test> =
+				<Test as frame_system::Config>::Hashing::hash(&schema[..]);
+			let id_digest = <Test as frame_system::Config>::Hashing::hash(
+				&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+			let schema_id: SchemaIdOf = generate_schema_id::<Test>(&id_digest);
+
+			let stored_schema = Schemas::<Test>::get(&schema_id)
+				.expect("Schema Identifier should be present on chain.");
+
+			assert_eq!(stored_schema.schema, schema);
+			assert_eq!(stored_schema.digest, digest);
+			assert_eq!(stored_schema.creator, creator);
+		}
+	});
+}

--- a/pallets/schema-accounts/src/types.rs
+++ b/pallets/schema-accounts/src/types.rs
@@ -1,0 +1,31 @@
+// This file is part of CORD – https://cord.network
+
+// Copyright (C) Dhiway Networks Pvt. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// CORD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CORD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CORD. If not, see <https://www.gnu.org/licenses/>.
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_runtime::RuntimeDebug;
+
+/// An on-chain schema details mapped to an identifier.
+#[derive(Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, TypeInfo)]
+pub struct SchemaEntry<InputSchemaOf, SchemaHashOf, SchemaCreatorOf> {
+	/// The Schema
+	pub schema: InputSchemaOf,
+	/// Schema hash.
+	pub digest: SchemaHashOf,
+	/// Schema controller.
+	pub creator: SchemaCreatorOf,
+}

--- a/primitives/identifier/src/curi.rs
+++ b/primitives/identifier/src/curi.rs
@@ -46,6 +46,7 @@ pub enum IdentifierType {
 	Registries,
 	Entries,
 	RegistryAuthorization,
+	SchemaAccounts,
 }
 
 impl IdentifierType {
@@ -61,6 +62,7 @@ impl IdentifierType {
 	const IDENT_REGISTRIES: u16 = 9274;
 	const IDENT_ENTRIES: u16 = 9944;
 	const IDENT_REGISTRYAUTH: u16 = 10001;
+	const IDENT_SCHEMA_ACCOUNTS: u16 = 10501;
 
 	fn ident_value(&self) -> u16 {
 		match self {
@@ -76,6 +78,7 @@ impl IdentifierType {
 			IdentifierType::Registries => Self::IDENT_REGISTRIES,
 			IdentifierType::Entries => Self::IDENT_ENTRIES,
 			IdentifierType::RegistryAuthorization => Self::IDENT_REGISTRYAUTH,
+			IdentifierType::SchemaAccounts => Self::IDENT_SCHEMA_ACCOUNTS,
 		}
 	}
 	fn from_u16(value: u16) -> Option<Self> {
@@ -92,6 +95,7 @@ impl IdentifierType {
 			9274 => Some(IdentifierType::Registries),
 			9944 => Some(IdentifierType::Entries),
 			10001 => Some(IdentifierType::RegistryAuthorization),
+			10501 => Some(IdentifierType::SchemaAccounts),
 			_ => None,
 		}
 	}

--- a/primitives/identifier/src/types.rs
+++ b/primitives/identifier/src/types.rs
@@ -84,4 +84,5 @@ pub enum IdentifierTypeOf {
 	Registries,
 	Entries,
 	RegistryAuthorization,
+	SchemaAccounts,
 }

--- a/runtimes/braid/Cargo.toml
+++ b/runtimes/braid/Cargo.toml
@@ -53,6 +53,7 @@ pallet-network-score = { workspace = true }
 pallet-session-benchmarking = { workspace = true }
 pallet-registries = { workspace = true }
 pallet-entries = { workspace = true }
+pallet-schema-accounts = { workspace = true }
 
 # Internal runtime API (with default disabled)
 pallet-did-runtime-api = { workspace = true }
@@ -169,6 +170,7 @@ std = [
 	"pallet-statement/std",
 	"pallet-registries/std",
 	"pallet-entries/std",
+	"pallet-schema-accounts/std",
 	"pallet-network-score/std",
 	"pallet-network-membership/std",
 	"pallet-runtime-upgrade/std",
@@ -268,6 +270,7 @@ try-runtime = [
 	"pallet-runtime-upgrade/try-runtime",
 	"pallet-remark/try-runtime",
 	"pallet-registries/try-runtime",
+	"pallet-schema-accounts/try-runtime",
 	"pallet-entries/try-runtime",
 	"cord-runtime-common/try-runtime",
 	"authority-membership/try-runtime",

--- a/runtimes/braid/src/lib.rs
+++ b/runtimes/braid/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("braid"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9400,
+	spec_version: 9310,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/braid/src/lib.rs
+++ b/runtimes/braid/src/lib.rs
@@ -735,6 +735,12 @@ impl pallet_schema::Config for Runtime {
 	type WeightInfo = weights::pallet_schema::WeightInfo<Runtime>;
 }
 
+impl pallet_schema_accounts::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type MaxEncodedSchemaLength = MaxEncodedSchemaLength;
+	type WeightInfo = ();
+}
+
 parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 10_000;
 }
@@ -988,6 +994,9 @@ mod runtime {
 
 	#[runtime::pallet_index(62)]
 	pub type Entries = pallet_entries;
+
+	#[runtime::pallet_index(63)]
+	pub type SchemaAccounts = pallet_schema_accounts;
 
 	#[runtime::pallet_index(255)]
 	pub type Sudo = pallet_sudo;

--- a/runtimes/braid/src/lib.rs
+++ b/runtimes/braid/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("braid"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9300,
+	spec_version: 9400,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/loom/Cargo.toml
+++ b/runtimes/loom/Cargo.toml
@@ -54,6 +54,7 @@ pallet-network-score = { workspace = true }
 pallet-session-benchmarking = { workspace = true }
 pallet-registries = { workspace = true }
 pallet-entries = { workspace = true }
+pallet-schema-accounts = { workspace = true }
 
 # Internal runtime API (with default disabled)
 pallet-did-runtime-api = { workspace = true }
@@ -184,6 +185,7 @@ std = [
 	"pallet-node-authorization/std",
 	"pallet-registries/std",
 	"pallet-entries/std",
+	"pallet-schema-accounts/std",
 	"pallet-transaction-weight-runtime-api/std",
 	"sp-runtime/std",
 	"sp-staking/std",
@@ -286,6 +288,7 @@ try-runtime = [
 	"pallet-remark/try-runtime",
 	"pallet-registries/try-runtime",
 	"pallet-entries/try-runtime",
+	"pallet-schema-accounts/try-runtime",
 	"cord-runtime-common/try-runtime",
 	"authority-membership/try-runtime",
 	"identifier/try-runtime",

--- a/runtimes/loom/src/lib.rs
+++ b/runtimes/loom/src/lib.rs
@@ -873,6 +873,12 @@ impl pallet_schema::Config for Runtime {
 	type WeightInfo = weights::pallet_schema::WeightInfo<Runtime>;
 }
 
+impl pallet_schema_accounts::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type MaxEncodedSchemaLength = MaxEncodedSchemaLength;
+	type WeightInfo = ();
+}
+
 parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 10_000;
 }
@@ -1147,6 +1153,9 @@ mod runtime {
 
 	#[runtime::pallet_index(62)]
 	pub type Entries = pallet_entries;
+
+	#[runtime::pallet_index(63)]
+	pub type SchemaAccounts = pallet_schema_accounts;
 
 	#[runtime::pallet_index(254)]
 	pub type RootTesting = pallet_root_testing;

--- a/runtimes/loom/src/lib.rs
+++ b/runtimes/loom/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("loom"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9400,
+	spec_version: 9310,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/loom/src/lib.rs
+++ b/runtimes/loom/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("loom"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9300,
+	spec_version: 9400,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/weave/Cargo.toml
+++ b/runtimes/weave/Cargo.toml
@@ -54,6 +54,7 @@ pallet-network-score = { workspace = true }
 pallet-session-benchmarking = { workspace = true }
 pallet-registries = { workspace = true }
 pallet-entries = { workspace = true }
+pallet-schema-accounts = { workspace = true }
 
 # Internal runtime API (with default disabled)
 pallet-did-runtime-api = { workspace = true }
@@ -200,6 +201,7 @@ std = [
 	"sp-io/std",
 	"pallet-registries/std",
 	"pallet-entries/std",
+	"pallet-schema-accounts/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -291,6 +293,7 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 	"pallet-registries/try-runtime",
 	"pallet-entries/try-runtime",
+	"pallet-schema-accounts/try-runtime",
 ]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("weave"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9400,
+	spec_version: 9310,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("weave"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9300,
+	spec_version: 9400,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -873,6 +873,12 @@ impl pallet_schema::Config for Runtime {
 	type WeightInfo = weights::pallet_schema::WeightInfo<Runtime>;
 }
 
+impl pallet_schema_accounts::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type MaxEncodedSchemaLength = MaxEncodedSchemaLength;
+	type WeightInfo = ();
+}
+
 parameter_types! {
 	pub const MaxSpaceDelegates: u32 = 10_000;
 }
@@ -1144,6 +1150,9 @@ mod runtime {
 
 	#[runtime::pallet_index(62)]
 	pub type Entries = pallet_entries;
+
+	#[runtime::pallet_index(63)]
+	pub type SchemaAccounts = pallet_schema_accounts;
 
 	#[runtime::pallet_index(255)]
 	pub type Sudo = pallet_sudo;


### PR DESCRIPTION
This PR,
- adds a new pallet called `schema-accounts` for account based schema accounts.
- removes dependency of `chain-space`. And does not require a `authId` for creation.
- identifier updates.
- update runtime to `0.9.3-1` or `9310`.