### PR TITLE
Integrate `schema-accounts` with `registries` & `entries`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "authority-membership"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1234,7 +1234,7 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cord-braid-runtime"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "authority-membership",
  "cord-braid-runtime-constants",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "cord-braid-runtime-constants"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "cord-identifier"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "blake2-rfc",
  "bs58 0.5.1",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "cord-loom-runtime"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "authority-membership",
  "cord-identifier",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "cord-loom-runtime-constants"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-cli"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "array-bytes",
  "assert_cmd",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-inspect"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "cord-node-rpc"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "jsonrpsee",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "cord-primitives"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "cord-runtime-common"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "frame-benchmarking",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "cord-utilities"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "cord-weave-runtime"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "authority-membership",
  "cord-identifier",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "cord-weave-runtime-constants"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "cord-runtime-common",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "network-membership"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-runtime-api"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-chain-space"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "bitflags 1.3.2",
  "cord-identifier",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-config"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-primitives",
  "frame-benchmarking",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-utilities",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-name"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-utilities",
  "frame-benchmarking",
@@ -6331,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-runtime-api"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-entries"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6355,6 +6355,7 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-registries",
+ "pallet-schema-accounts",
  "parity-scale-codec",
  "scale-info",
  "serde_json",
@@ -6389,7 +6390,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6454,7 +6455,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6484,7 +6485,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-network-membership"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6502,7 +6503,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-network-score"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6523,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-node-authorization"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "bs58 0.5.1",
  "cord-primitives",
@@ -6540,7 +6541,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6571,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-registries"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "bitflags 1.3.2",
  "cord-identifier",
@@ -6623,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-runtime-upgrade"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6651,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schema"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6672,7 +6673,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-schema-accounts"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6713,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -6725,7 +6726,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-statement"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "cord-identifier",
  "cord-primitives",
@@ -6823,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-weight-runtime-api"
-version = "0.9.3-1"
+version = "0.9.4"
 dependencies = [
  "frame-support",
  "pallet-network-membership",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6581,6 +6581,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
+ "pallet-schema-accounts",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 
 [workspace.package]
-version = "0.9.3-1"
+version = "0.9.4"
 authors = ['Dhiway Networks <info@dhiway.com>']
 edition = "2021"
 homepage = "https://cord.network"

--- a/pallets/entries/Cargo.toml
+++ b/pallets/entries/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true }
 
 frame-benchmarking = { optional = true, workspace = true }
 pallet-registries = { workspace = true }
+pallet-schema-accounts = { workspace = true }
 
 [dev-dependencies]
 sp-core = { workspace = true }
@@ -41,6 +42,7 @@ cord-utilities = { workspace = true }
 sp-keystore = { workspace = true }
 serde_json = { workspace = true }
 pallet-registries = { workspace = true }
+pallet-schema-accounts = { workspace = true }
 
 cord-primitives = { workspace = true }
 identifier = { workspace = true }
@@ -65,6 +67,7 @@ std = [
 	"identifier/std",
 	"cord-utilities/std",
 	"pallet-registries/std",
+	"pallet-schema-accounts/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -73,6 +76,7 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"cord-utilities/runtime-benchmarks",
 	"pallet-registries/runtime-benchmarks",
+	"pallet-schema-accounts/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/entries/src/mock.rs
+++ b/pallets/entries/src/mock.rs
@@ -37,6 +37,7 @@ frame_support::construct_runtime!(
 		System: frame_system,
 		Identifier: identifier,
 		MockOrigin: mock_origin,
+		SchemaAccounts: pallet_schema_accounts,
 		Registries: pallet_registries,
 		Entries: pallet_entries,
 	}
@@ -60,6 +61,16 @@ impl mock_origin::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type AccountId = AccountId;
 	type SubjectId = SubjectId;
+}
+
+parameter_types! {
+	pub const MaxEncodedSchemaLength: u32 = 15_360;
+}
+
+impl pallet_schema_accounts::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type MaxEncodedSchemaLength = MaxEncodedSchemaLength;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/pallets/entries/src/tests.rs
+++ b/pallets/entries/src/tests.rs
@@ -25,6 +25,7 @@ use sp_runtime::traits::Hash;
 use sp_std::prelude::*;
 
 use pallet_registries::{RegistryBlobOf, RegistryHashOf};
+use pallet_schema_accounts::{InputSchemaOf, SchemaHashOf, SchemaIdOf};
 
 /// Generates a Registry ID
 pub fn generate_registry_id<T: Config>(id_digest: &RegistryHashOf<T>) -> RegistryIdOf {
@@ -50,13 +51,13 @@ pub fn generate_authorization_id<T: Config>(digest: &RegistryHashOf<T>) -> Autho
 		.unwrap()
 }
 
-pub(crate) const ACCOUNT_00: AccountId = AccountId::new([1u8; 32]);
+/// Generates a Schema ID
+pub fn generate_schema_id<T: Config>(digest: &SchemaHashOf<T>) -> SchemaIdOf {
+	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::SchemaAccounts)
+		.unwrap()
+}
 
-// TODO:
-// Add tests for SchemaId.
-// Right now None is being pased.
-// Fix: Remove pallet-chain-space dependency from pallet-schema &
-// make it account based.
+pub(crate) const ACCOUNT_00: AccountId = AccountId::new([1u8; 32]);
 
 #[test]
 fn create_registry_entry_should_work() {
@@ -80,13 +81,21 @@ fn create_registry_entry_should_work() {
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+
+	let raw_schema = [2u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		/* Test creation of a Registry */
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob),
 		));
 
@@ -183,14 +192,21 @@ fn update_registry_entry_should_work() {
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+
+	let raw_schema = [2u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		/* Test creation of a Registry */
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			// Disable Schema ID for now
-			None,
+			Some(schema_id),
 			Some(blob),
 		));
 
@@ -328,14 +344,21 @@ fn revoke_registry_entry_should_work() {
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+
+	let raw_schema = [2u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		/* Test creation of a Registry */
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			// Disable Schema ID for now
-			None,
+			Some(schema_id),
 			Some(blob),
 		));
 
@@ -434,14 +457,21 @@ fn reinstating_revoked_registry_entry_should_work() {
 	);
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
+
+	let raw_schema = [2u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		/* Test creation of a Registry */
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			// Disable Schema ID for now
-			None,
+			Some(schema_id),
 			Some(blob),
 		));
 

--- a/pallets/registries/Cargo.toml
+++ b/pallets/registries/Cargo.toml
@@ -24,6 +24,7 @@ codec = { features = ["derive"], workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 bitflags = { workspace = true }
 log = { workspace = true }
+pallet-schema-accounts = { workspace = true }
 
 # Internal dependencies
 cord-primitives = { workspace = true }
@@ -63,6 +64,7 @@ std = [
 	"sp-keystore/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"pallet-schema-accounts/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -70,6 +72,7 @@ try-runtime = [
 	"identifier/try-runtime",
 	"cord-utilities/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-schema-accounts/std",
 ]
 
 # Disable doctest when running `cargo test` 

--- a/pallets/registries/src/lib.rs
+++ b/pallets/registries/src/lib.rs
@@ -125,7 +125,8 @@ pub type RegistryBlobOf<T> = BoundedVec<u8, MaxRegistryBlobSizeOf<T>>;
 pub type RegistryAuthorizationOf<T> =
 	RegistryAuthorization<RegistryIdOf, RegistryCreatorOf<T>, Permissions>;
 /// Type of Registry Details
-pub type RegistryDetailsOf<T> = RegistryDetails<RegistryCreatorOf<T>, StatusOf, RegistryHashOf<T>, SchemaIdOf>;
+pub type RegistryDetailsOf<T> =
+	RegistryDetails<RegistryCreatorOf<T>, StatusOf, RegistryHashOf<T>, SchemaIdOf>;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/registries/src/lib.rs
+++ b/pallets/registries/src/lib.rs
@@ -116,7 +116,7 @@ pub type RegistryCreatorOf<T> = <T as frame_system::Config>::AccountId;
 /// Type of the Registry Template Id
 pub type TemplateIdOf<T> = BoundedVec<u8, <T as Config>::MaxEncodedInputLength>;
 /// Type of the Schema Id
-pub type SchemaIdOf<T> = BoundedVec<u8, <T as Config>::MaxEncodedInputLength>;
+pub type SchemaIdOf = Ss58Identifier;
 /// Type of Maximum allowed size of the Registry Blob
 pub type MaxRegistryBlobSizeOf<T> = <T as crate::Config>::MaxRegistryBlobSize;
 /// Type of Registry Blob
@@ -125,7 +125,7 @@ pub type RegistryBlobOf<T> = BoundedVec<u8, MaxRegistryBlobSizeOf<T>>;
 pub type RegistryAuthorizationOf<T> =
 	RegistryAuthorization<RegistryIdOf, RegistryCreatorOf<T>, Permissions>;
 /// Type of Registry Details
-pub type RegistryDetailsOf<T> = RegistryDetails<RegistryCreatorOf<T>, StatusOf, RegistryHashOf<T>>;
+pub type RegistryDetailsOf<T> = RegistryDetails<RegistryCreatorOf<T>, StatusOf, RegistryHashOf<T>, SchemaIdOf>;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -512,7 +512,8 @@ pub mod pallet {
 		/// - `origin`: The origin of the transaction, signed by the creator.
 		/// - `registry_id`: A unique code created to identify the registry.
 		/// - `digest`: The digest representing the registry data to be created.
-		/// - `blob`: Optional metadata or data associated with the registry.
+		/// - `schema_id`: (Optional) A unique code represnting the Schema.
+		/// - `blob`: (Optional) Metadata or data associated with the registry.
 		///
 		/// # Returns
 		/// - `DispatchResult`: Returns `Ok(())` if the registry is successfully created, or an
@@ -537,7 +538,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			_registry_id: RegistryIdOf,
 			digest: RegistryHashOf<T>,
-			_schema_id: Option<SchemaIdOf<T>>,
+			schema_id: Option<SchemaIdOf>,
 			_blob: Option<RegistryBlobOf<T>>,
 		) -> DispatchResult {
 			let creator = ensure_signed(origin)?;
@@ -607,6 +608,7 @@ pub mod pallet {
 					revoked: false,
 					archived: false,
 					digest,
+					schema_id,
 				},
 			);
 

--- a/pallets/registries/src/mock.rs
+++ b/pallets/registries/src/mock.rs
@@ -33,6 +33,7 @@ pub(crate) type Block = frame_system::mocking::MockBlock<Test>;
 frame_support::construct_runtime!(
 	pub enum Test {
 		System: frame_system,
+		SchemaAccounts: pallet_schema_accounts,
 		Registries: pallet_registries,
 		Identifier: identifier,
 		MockOrigin: mock_origin,
@@ -57,6 +58,16 @@ impl mock_origin::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type AccountId = AccountId;
 	type SubjectId = SubjectId;
+}
+
+parameter_types! {
+	pub const MaxEncodedSchemaLength: u32 = 15_360;
+}
+
+impl pallet_schema_accounts::Config for Test{
+	type RuntimeEvent = RuntimeEvent;
+	type MaxEncodedSchemaLength = MaxEncodedSchemaLength;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/pallets/registries/src/mock.rs
+++ b/pallets/registries/src/mock.rs
@@ -64,7 +64,7 @@ parameter_types! {
 	pub const MaxEncodedSchemaLength: u32 = 15_360;
 }
 
-impl pallet_schema_accounts::Config for Test{
+impl pallet_schema_accounts::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type MaxEncodedSchemaLength = MaxEncodedSchemaLength;
 	type WeightInfo = ();

--- a/pallets/registries/src/tests.rs
+++ b/pallets/registries/src/tests.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::mock::*;
 use codec::Encode;
 use frame_support::{assert_err, assert_ok};
-use sp_runtime::traits::Hash;
 use pallet_schema_accounts::{InputSchemaOf, SchemaHashOf};
+use sp_runtime::traits::Hash;
 use sp_std::prelude::*;
 
 pub fn generate_registry_id<T: Config>(digest: &RegistryHashOf<T>) -> RegistryIdOf {

--- a/pallets/registries/src/tests.rs
+++ b/pallets/registries/src/tests.rs
@@ -48,12 +48,11 @@ fn add_delegate_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -99,12 +98,11 @@ fn add_admin_delegate_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -150,12 +148,11 @@ fn add_admin_delegate_should_fail_if_admin_delegate_already_exists() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -211,12 +208,11 @@ fn add_delegator_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -261,12 +257,11 @@ fn add_delegator_should_fail_if_delegator_already_exists() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -420,12 +415,11 @@ fn add_delegate_should_fail_if_the_regisrty_is_revoked() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -480,12 +474,11 @@ fn add_delegate_should_fail_if_a_non_delegate_tries_to_add() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -533,12 +526,11 @@ fn add_delegate_should_fail_if_delegate_already_exists() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -586,12 +578,11 @@ fn creating_a_new_registries_should_succeed() {
 
 	let registry_id: RegistryIdOf = generate_registry_id::<Test>(&id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -622,12 +613,11 @@ fn creating_a_duplicate_registries_should_fail() {
 
 	let registry_id: RegistryIdOf = generate_registry_id::<Test>(&id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -675,12 +665,11 @@ fn revoking_a_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -724,12 +713,11 @@ fn reinstating_an_revoked_a_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -785,12 +773,11 @@ fn reinstating_an_non_revoked_a_registry_should_fail() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -836,12 +823,11 @@ fn archiving_a_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -885,12 +871,11 @@ fn restoring_an_archived_a_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -946,12 +931,11 @@ fn restoring_an_non_archived_a_registry_should_fail() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -991,12 +975,11 @@ fn add_delegate_should_fail_if_registry_delegates_limit_exceeded() {
 
 	let registry_id: RegistryIdOf = generate_registry_id::<Test>(&id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -1064,12 +1047,11 @@ fn remove_delegate_should_succeed() {
 	let delegate_authorization_id: AuthorizationIdOf =
 		generate_authorization_id::<Test>(&delegate_auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -1121,12 +1103,11 @@ fn remove_delegate_should_fail_for_creator_removing_themselves() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {
@@ -1186,12 +1167,11 @@ fn update_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
-	let raw_schema = [11u8; 256].to_vec();
+	let raw_schema = [2u8; 256].to_vec();
 	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
 		.expect("Test Schema should fit into the expected input length of for the test runtime.");
-	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
-	);
+	let _digest: SchemaHashOf<Test> = <Test as frame_system::Config>::Hashing::hash(&schema[..]);
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
 	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
 
 	new_test_ext().execute_with(|| {

--- a/pallets/registries/src/tests.rs
+++ b/pallets/registries/src/tests.rs
@@ -3,6 +3,7 @@ use crate::mock::*;
 use codec::Encode;
 use frame_support::{assert_err, assert_ok};
 use sp_runtime::traits::Hash;
+use pallet_schema_accounts::{InputSchemaOf, SchemaHashOf};
 use sp_std::prelude::*;
 
 pub fn generate_registry_id<T: Config>(digest: &RegistryHashOf<T>) -> RegistryIdOf {
@@ -14,15 +15,14 @@ pub fn generate_authorization_id<T: Config>(digest: &RegistryHashOf<T>) -> Autho
 		.unwrap()
 }
 
+pub fn generate_schema_id<T: Config>(digest: &SchemaHashOf<T>) -> SchemaIdOf {
+	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::SchemaAccounts)
+		.unwrap()
+}
+
 pub(crate) const ACCOUNT_00: AccountId = AccountId::new([1u8; 32]);
 pub(crate) const ACCOUNT_01: AccountId = AccountId::new([2u8; 32]);
 pub(crate) const ACCOUNT_02: AccountId = AccountId::new([3u8; 32]);
-
-// TODO:
-// Add tests for SchemaId.
-// Right now None is being pased.
-// Fix: Remove pallet-chain-space dependency from pallet-schema &
-// make it account based.
 
 #[test]
 fn add_delegate_should_succeed() {
@@ -48,12 +48,20 @@ fn add_delegate_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob)
 		));
 
@@ -91,12 +99,20 @@ fn add_admin_delegate_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob)
 		));
 
@@ -134,12 +150,20 @@ fn add_admin_delegate_should_fail_if_admin_delegate_already_exists() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob)
 		));
 
@@ -187,12 +211,20 @@ fn add_delegator_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob)
 		));
 
@@ -229,12 +261,20 @@ fn add_delegator_should_fail_if_delegator_already_exists() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob)
 		));
 
@@ -380,12 +420,20 @@ fn add_delegate_should_fail_if_the_regisrty_is_revoked() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob)
 		));
 
@@ -432,12 +480,20 @@ fn add_delegate_should_fail_if_a_non_delegate_tries_to_add() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob)
 		));
 
@@ -477,12 +533,20 @@ fn add_delegate_should_fail_if_delegate_already_exists() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob)
 		));
 
@@ -522,12 +586,20 @@ fn creating_a_new_registries_should_succeed() {
 
 	let registry_id: RegistryIdOf = generate_registry_id::<Test>(&id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob),
 		));
 	});
@@ -550,12 +622,20 @@ fn creating_a_duplicate_registries_should_fail() {
 
 	let registry_id: RegistryIdOf = generate_registry_id::<Test>(&id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -595,12 +675,20 @@ fn revoking_a_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -636,12 +724,20 @@ fn reinstating_an_revoked_a_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -689,12 +785,20 @@ fn reinstating_an_non_revoked_a_registry_should_fail() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -732,12 +836,20 @@ fn archiving_a_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -773,12 +885,20 @@ fn restoring_an_archived_a_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -826,12 +946,20 @@ fn restoring_an_non_archived_a_registry_should_fail() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -863,13 +991,21 @@ fn add_delegate_should_fail_if_registry_delegates_limit_exceeded() {
 
 	let registry_id: RegistryIdOf = generate_registry_id::<Test>(&id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		// Create the Registries
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -928,12 +1064,20 @@ fn remove_delegate_should_succeed() {
 	let delegate_authorization_id: AuthorizationIdOf =
 		generate_authorization_id::<Test>(&delegate_auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -977,12 +1121,20 @@ fn remove_delegate_should_fail_for_creator_removing_themselves() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(blob.clone()),
 		));
 
@@ -1034,12 +1186,20 @@ fn update_registry_should_succeed() {
 
 	let authorization_id: AuthorizationIdOf = generate_authorization_id::<Test>(&auth_id_digest);
 
+	let raw_schema = [11u8; 256].to_vec();
+	let schema: InputSchemaOf<Test> = BoundedVec::try_from(raw_schema)
+		.expect("Test Schema should fit into the expected input length of for the test runtime.");
+	let schema_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&schema.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let schema_id: SchemaIdOf = generate_schema_id::<Test>(&schema_id_digest);
+
 	new_test_ext().execute_with(|| {
 		assert_ok!(Registries::create(
 			frame_system::RawOrigin::Signed(creator.clone()).into(),
 			registry_id.clone(),
 			registry_digest,
-			None,
+			Some(schema_id),
 			Some(initial_blob),
 		));
 

--- a/pallets/registries/src/types.rs
+++ b/pallets/registries/src/types.rs
@@ -62,7 +62,6 @@ impl Default for Permissions {
 	}
 }
 
-
 /// Details of an on-chain registry.
 ///
 /// This struct stores metadata about a registry, including information about
@@ -79,11 +78,10 @@ impl Default for Permissions {
 pub struct RegistryDetails<RegistryCreatorOf, StatusOf, RegistryHashOf, SchemaIdOf> {
 	pub creator: RegistryCreatorOf,
 	pub revoked: StatusOf,
-	pub archived: StatusOf, 
+	pub archived: StatusOf,
 	pub digest: RegistryHashOf,
 	pub schema_id: Option<SchemaIdOf>,
 }
-
 
 /// Authorization details for a registry delegate.
 ///

--- a/pallets/registries/src/types.rs
+++ b/pallets/registries/src/types.rs
@@ -62,30 +62,28 @@ impl Default for Permissions {
 	}
 }
 
+
 /// Details of an on-chain registry.
 ///
-/// This structure holds metadata about a registry, including its identifier,
-/// creator, capacity, and current usage. It also tracks the revoke and
-/// archival status of the registry.
+/// This struct stores metadata about a registry, including information about
+/// its creator, status, and linkage to a schema. It helps in tracking the
+/// governance and operational state of the registry.
 ///
-/// ## Fields
-///
-/// - `code`: The unique code or identifier for the registry.
-/// - `creator`: The account or entity that created the registry.
-/// - `txn_capacity`: The maximum allowed transactions within the registry. A value of zero denotes
-///   unlimited capacity.
-/// - `txn_count`: The current usage of the registry's capacity.
-/// - `approved`: Indicates whether the registry has been approved by the appropriate governance
-///   body.
-/// - `archive`: Indicates whether the registry is currently archived.
+/// # Fields
+/// - `creator`: The account or entity responsible for creating the registry.
+/// - `revoked`: Status indicating if the registry has been revoked.
+/// - `archived`: Flag showing whether the registry is archived.
+/// - `digest`: A hash representing unique content or metadata of the registry.
+/// - `schema_id`: (Optional) Identifier linking the registry to a specific schema.
 #[derive(Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, TypeInfo)]
-pub struct RegistryDetails<RegistryCreatorOf, StatusOf, RegistryHashOf> {
+pub struct RegistryDetails<RegistryCreatorOf, StatusOf, RegistryHashOf, SchemaIdOf> {
 	pub creator: RegistryCreatorOf,
 	pub revoked: StatusOf,
-	pub archived: StatusOf, /* Only at the registry level. (If it is archived, revoked dont
-	                         * allow entry creation) */
+	pub archived: StatusOf, 
 	pub digest: RegistryHashOf,
+	pub schema_id: Option<SchemaIdOf>,
 }
+
 
 /// Authorization details for a registry delegate.
 ///

--- a/runtimes/braid/src/lib.rs
+++ b/runtimes/braid/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("braid"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9310,
+	spec_version: 9400,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/loom/src/lib.rs
+++ b/runtimes/loom/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("loom"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9310,
+	spec_version: 9400,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("weave"),
 	impl_name: create_runtime_str!("dhiway-cord"),
 	authoring_version: 0,
-	spec_version: 9310,
+	spec_version: 9400,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
This PR,
- Integrates the account based schema-management pallet `schema-accounts` into `registries` & `entries`.
- Updates the runtime spec to `9400` or cord package to `0.9.4`.
