### PR TITLE
pallet-asset: Add tests for UnauthorizedOperation

### DIFF
--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -31,8 +31,9 @@ pub fn generate_asset_instance_id<T: Config>(digest: &SpaceCodeOf<T>) -> AssetIn
 }
 
 pub(crate) const DID_00: SubjectId = SubjectId(AccountId32::new([1u8; 32]));
-pub(crate) const DID_01: SubjectId = SubjectId(AccountId32::new([1u8; 32]));
+pub(crate) const DID_01: SubjectId = SubjectId(AccountId32::new([2u8; 32]));
 pub(crate) const ACCOUNT_00: AccountId = AccountId::new([1u8; 32]);
+pub(crate) const ACCOUNT_01: AccountId = AccountId::new([2u8; 32]);
 
 #[test]
 fn asset_create_should_succeed() {
@@ -147,6 +148,223 @@ fn asset_create_duplicate_should_fail() {
 			),
 			Error::<Test>::AssetIdAlreadyExists
 		);
+	});
+}
+
+#[test]
+fn asset_unauthorized_operation_should_fail() {
+	let creator = DID_00;
+	let unauthorized_creator = DID_01;
+	let unauthorized_author = ACCOUNT_01;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let unauthorized_space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &unauthorized_creator.encode()[..]].concat()[..],
+	);
+	let unauthorized_space_id: SpaceIdOf = generate_space_id::<Test>(&unauthorized_space_id_digest);
+
+	let unauthorized_auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&unauthorized_space_id.encode()[..],
+			&unauthorized_creator.encode()[..],
+			&unauthorized_creator.encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let unauthorized_authorization_id: Ss58Identifier =
+		generate_authorization_id::<Test>(&unauthorized_auth_digest);
+
+	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+	let asset_qty = 10;
+	let asset_value = 10;
+	let asset_type = AssetTypeOf::MF;
+
+	let entry = AssetInputEntryOf::<Test> {
+		asset_desc,
+		asset_qty,
+		asset_type,
+		asset_value,
+		asset_tag,
+		asset_meta,
+	};
+
+	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+
+	let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+	let issue_entry = AssetIssuanceEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_owner: creator.clone(),
+		asset_issuance_qty: Some(10),
+	};
+
+	let issue_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&issue_entry.encode()[..]].concat()[..]);
+
+	let instance_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&asset_id.encode()[..],
+			&creator.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+			&issue_entry_digest.encode()[..],
+		]
+		.concat()[..],
+	);
+
+	let instance_id = generate_asset_instance_id::<Test>(&instance_id_digest);
+
+	let transfer_entry = AssetTransferEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_instance_id: instance_id.clone(),
+		asset_owner: creator.clone(),
+		new_asset_owner: unauthorized_creator.clone(),
+	};
+
+	let unauthorized_transfer_entry = AssetTransferEntryOf::<Test> {
+		asset_id: asset_id.clone(),
+		asset_instance_id: instance_id.clone(),
+		asset_owner: unauthorized_creator.clone(),
+		new_asset_owner: unauthorized_creator.clone(),
+	};
+
+	let unauthorized_entry_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&unauthorized_transfer_entry.encode()[..]].concat()[..],
+	);
+
+	let transfer_entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&transfer_entry.encode()[..]].concat()[..]);
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::create(
+			DoubleOrigin(unauthorized_author.clone(), unauthorized_creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), unauthorized_space_id, capacity));
+
+		assert_ok!(Asset::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_err!(Asset::issue(
+			DoubleOrigin(unauthorized_author.clone(), unauthorized_creator.clone()).into(), // Unauthorized author attempting the action
+			issue_entry.clone(),
+			issue_entry_digest,
+			unauthorized_authorization_id.clone()
+		), Error::<Test>::UnauthorizedOperation);
+
+		assert_ok!(Asset::issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			authorization_id.clone()
+		));
+
+		assert_err!(Asset::transfer(
+			DoubleOrigin(unauthorized_author.clone(), unauthorized_creator.clone()).into(),
+			transfer_entry.clone(),
+			transfer_entry_digest,
+		),
+		Error::<Test>::UnauthorizedOperation
+		);
+
+		assert_err!(Asset::transfer(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			unauthorized_transfer_entry.clone(),
+			unauthorized_entry_digest,
+		),
+		Error::<Test>::UnauthorizedOperation
+		);
+
+		assert_err!(Asset::status_change(
+			DoubleOrigin(unauthorized_author.clone(), unauthorized_creator.clone()).into(),
+			asset_id.clone(),
+			Some(instance_id.clone()),
+			AssetStatusOf::INACTIVE
+		),
+		Error::<Test>::UnauthorizedOperation
+		);
+
+		assert_ok!(Asset::vc_create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			asset_qty,
+			digest,
+			authorization_id.clone()
+		));
+
+		assert_err!(Asset::vc_issue(
+			DoubleOrigin(unauthorized_author.clone(), unauthorized_creator.clone()).into(),
+			issue_entry.clone(),
+			issue_entry_digest,
+			unauthorized_authorization_id
+		),
+		Error::<Test>::UnauthorizedOperation
+		);
+
+		assert_ok!(Asset::vc_issue(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			issue_entry,
+			issue_entry_digest,
+			authorization_id
+		));
+
+		assert_err!(Asset::vc_transfer(
+			DoubleOrigin(unauthorized_author.clone(), unauthorized_creator.clone()).into(),
+			transfer_entry.clone(),
+			transfer_entry_digest,
+		),
+		Error::<Test>::UnauthorizedOperation
+		);
+
+		assert_err!(Asset::vc_transfer(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			unauthorized_transfer_entry.clone(),
+			unauthorized_entry_digest,
+		),
+		Error::<Test>::UnauthorizedOperation
+		);
+
+		assert_err!(Asset::vc_status_change(
+			DoubleOrigin(unauthorized_author.clone(), unauthorized_creator.clone()).into(),
+			asset_id.clone(),
+			Some(instance_id.clone()),
+			AssetStatusOf::INACTIVE
+		),
+		Error::<Test>::UnauthorizedOperation
+		);
+
 	});
 }
 


### PR DESCRIPTION
Fixes: #368 

`UnauthorizedOperation` was returned by issue, transfer, status_change and their vc counter parts.

hence the lots of assert statements since it also requires creating the issue before operating on it like transfer and status_change. 

The change to `DID_01` is needed since the SubjectID's are compared to throw out `UnauthorizedOperation` else since they had the same SubjectIDs before it wouldn't work. Similar need for `ACCOUNT_01`.