### PR TITLE
pallet-asset: Added new test-case for DistributionLimitExceeded.

### DIFF
--- a/pallets/asset/src/mock.rs
+++ b/pallets/asset/src/mock.rs
@@ -65,7 +65,7 @@ impl mock_origin::Config for Test {
 
 parameter_types! {
 	pub const MaxEncodedValueLength: u32 = 1_024;
-	pub const MaxAssetDistribution: u32 = u32::MAX;
+	pub const MaxAssetDistribution: u32 = 25;
 }
 
 impl Config for Test {

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -227,6 +227,84 @@ fn asset_issue_should_succeed() {
 }
 
 #[test]
+fn asset_issue_should_succeed_until_limit() {
+    let creator = DID_00;
+    let author = ACCOUNT_00;
+    let capacity = 5u64;
+
+    let raw_space = [2u8; 256].to_vec();
+    let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+    let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+    let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+    let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_qty = 10;
+    let asset_value = 10;
+    let asset_type = AssetTypeOf::MF;
+
+    let entry = AssetInputEntryOf::<Test> {
+        asset_desc,
+        asset_qty,
+        asset_type,
+        asset_value,
+        asset_tag,
+        asset_meta,
+    };
+
+    let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+    new_test_ext().execute_with(|| {
+        
+        assert_ok!(Space::create(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            space_digest,
+        ));
+
+       
+        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+        
+        assert_ok!(Asset::create(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            entry.clone(),
+            digest,
+            authorization_id
+        ));
+
+        
+        for i in 1..=25 {
+            let recipient = SubjectId(AccountId32::new([i as u8; 32])); 
+            assert_ok!(Asset::issue(
+                DoubleOrigin(author.clone(), creator.clone()).into(),
+                recipient.clone(),
+                asset_qty
+            ));
+        }
+
+        
+        let exceeding_recipient = SubjectId(AccountId32::new([26u8; 32]));
+        assert_noop!(
+            Asset::issue(
+                DoubleOrigin(author.clone(), creator.clone()).into(),
+                exceeding_recipient,
+                asset_qty
+            ),
+            Error::<Test>::DistributionLimitExceeded
+        );
+    });
+}
+
+
+#[test]
 fn asset_overissuance_should_fail() {
 	let creator = DID_00;
 	let author = ACCOUNT_00;

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{mock::*, types::AssetIssuanceEntry, Error};
 use codec::Encode;
 use cord_utilities::mock::{mock_origin::DoubleOrigin, SubjectId};
-use frame_support::{assert_err, assert_noop, assert_ok, BoundedVec};
+use frame_support::{assert_err, assert_ok, BoundedVec};
 use frame_system::RawOrigin;
 use pallet_chain_space::{SpaceCodeOf, SpaceIdOf};
 use sp_runtime::{traits::Hash, AccountId32};
@@ -2923,7 +2923,7 @@ fn asset_issue_should_fail_when_distribution_limit_exceeds() {
 		let exceeding_digest =
 			<Test as frame_system::Config>::Hashing::hash(&exceeding_entry.encode()[..]);
 
-		assert_noop!(
+		assert_err!(
 			Asset::issue(
 				DoubleOrigin(author.clone(), creator.clone()).into(),
 				exceeding_entry,

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
-use crate::mock::*;
-use crate::{types::AssetIssuanceEntry, Error};
+use crate::{mock::*, types::AssetIssuanceEntry, Error};
 use codec::Encode;
 use cord_utilities::mock::{mock_origin::DoubleOrigin, SubjectId};
 use frame_support::{assert_err, assert_noop, assert_ok, BoundedVec};

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{mock::*, types::AssetIssuanceEntry, Error};
 use codec::Encode;
 use cord_utilities::mock::{mock_origin::DoubleOrigin, SubjectId};
-use frame_support::{assert_err, assert_noop, assert_ok, BoundedVec};
+use frame_support::{assert_err, assert_ok, BoundedVec};
 use frame_system::RawOrigin;
 use pallet_chain_space::{SpaceCodeOf, SpaceIdOf};
 use sp_runtime::{traits::Hash, AccountId32};

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{mock::*, types::AssetIssuanceEntry, Error};
 use codec::Encode;
 use cord_utilities::mock::{mock_origin::DoubleOrigin, SubjectId};
-use frame_support::{assert_err, assert_ok, BoundedVec};
+use frame_support::{assert_err, assert_ok, assert_noop, BoundedVec};
 use frame_system::RawOrigin;
 use pallet_chain_space::{SpaceCodeOf, SpaceIdOf};
 use sp_runtime::{traits::Hash, AccountId32};
@@ -223,112 +223,6 @@ fn asset_issue_should_succeed() {
 			issue_entry_digest,
 			authorization_id
 		));
-	});
-}
-
-#[test]
-fn asset_issue_should_fail_when_distribution_limit_exceeds() {
-	let creator = DID_00;
-	let author = ACCOUNT_00;
-	let capacity = 25u64;
-
-	let raw_space = [2u8; 256].to_vec();
-	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
-	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
-	);
-	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
-
-	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
-	);
-	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
-
-	let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
-	let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
-	let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
-	let asset_qty = 1;
-	let asset_value = 10;
-	let asset_type = AssetTypeOf::MF;
-
-	let entry = AssetInputEntryOf::<Test> {
-		asset_desc,
-		asset_qty,
-		asset_type,
-		asset_value,
-		asset_tag,
-		asset_meta,
-	};
-
-	let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
-
-	let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
-		&[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
-	);
-
-	new_test_ext().execute_with(|| {
-		let space_id_clone = space_id.clone();
-		let _authorization_id_clone = authorization_id.clone();
-
-		assert_ok!(Space::create(
-			DoubleOrigin(author.clone(), creator.clone()).into(),
-			space_digest,
-		));
-
-		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id_clone, capacity));
-
-		assert_ok!(Asset::create(
-			DoubleOrigin(author.clone(), creator.clone()).into(),
-			entry.clone(),
-			digest,
-			authorization_id.clone()
-		));
-
-		let _recipient = SubjectId(AccountId32::new([1u8; 32]));
-		let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
-		let asset_owner = creator.clone();
-		let asset_issuance_qty = asset_qty;
-
-		for _ in 1..=capacity {
-			let issuance_entry = AssetIssuanceEntry {
-				asset_id: asset_id.clone(),
-				asset_owner: asset_owner.clone(),
-				asset_issuance_qty: Some(asset_issuance_qty),
-			};
-
-			let issuance_digest =
-				<Test as frame_system::Config>::Hashing::hash(&issuance_entry.encode()[..]);
-
-			assert_ok!(Asset::issue(
-				DoubleOrigin(author.clone(), creator.clone()).into(),
-				issuance_entry.clone(),
-				issuance_digest,
-				authorization_id.clone()
-			));
-		}
-
-		let exceeding_asset_id = space_id.clone();
-		let exceeding_asset_owner = creator.clone();
-		let exceeding_asset_issuance_qty = asset_qty;
-
-		let exceeding_entry = AssetIssuanceEntry {
-			asset_id: exceeding_asset_id,
-			asset_owner: exceeding_asset_owner,
-			asset_issuance_qty: Some(exceeding_asset_issuance_qty),
-		};
-
-		let exceeding_digest =
-			<Test as frame_system::Config>::Hashing::hash(&exceeding_entry.encode()[..]);
-
-		assert_err!(
-			Asset::issue(
-				DoubleOrigin(author.clone(), creator.clone()).into(),
-				exceeding_entry,
-				exceeding_digest,
-				authorization_id.clone()
-			),
-			Error::<Test>::DistributionLimitExceeded
-		);
 	});
 }
 
@@ -2944,4 +2838,101 @@ fn asset_vc_status_change_with_wrong_asset_id_should_fail() {
 			Error::<Test>::AssetIdNotFound
 		);
 	});
+}
+
+
+
+#[test]
+fn asset_issue_should_fail_when_distribution_limit_exceeds() {
+    let creator = DID_00;
+    let author = ACCOUNT_00;
+    let capacity = 200u64;  
+
+    let raw_space = [2u8; 256].to_vec();
+    let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+    let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+    let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+    let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+    let asset_desc = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_tag = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_meta = BoundedVec::try_from([72u8; 10].to_vec()).unwrap();
+    let asset_qty = 1000; 
+    let asset_value = 10;
+    let asset_type = AssetTypeOf::MF;
+
+    let entry = AssetInputEntryOf::<Test> {
+        asset_desc,
+        asset_qty,
+        asset_type,
+        asset_value,
+        asset_tag,
+        asset_meta,
+    };
+
+    let digest = <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+    let issue_id_digest = <Test as frame_system::Config>::Hashing::hash(
+        &[&digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+    );
+
+    let asset_id: Ss58Identifier = generate_asset_id::<Test>(&issue_id_digest);
+
+    new_test_ext().execute_with(|| {
+        // Create and approve space
+        assert_ok!(Space::create(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            space_digest,
+        ));
+        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id.clone(), capacity));
+        assert_ok!(Asset::create(
+            DoubleOrigin(author.clone(), creator.clone()).into(),
+            entry.clone(),
+            digest,
+            authorization_id.clone()
+        ));
+
+        let max_distribution = <Test as Config>::MaxAssetDistribution::get();
+        
+		for _ in 0..max_distribution {
+            let issuance_entry = AssetIssuanceEntry {
+                asset_id: asset_id.clone(),
+                asset_owner: creator.clone(),
+                asset_issuance_qty: Some(1), 
+            };
+
+            let issuance_digest = 
+                <Test as frame_system::Config>::Hashing::hash(&issuance_entry.encode()[..]);
+
+            assert_ok!(Asset::issue(
+                DoubleOrigin(author.clone(), creator.clone()).into(),
+                issuance_entry,
+                issuance_digest,
+                authorization_id.clone()
+            ));
+        }
+        let exceeding_entry = AssetIssuanceEntry {
+            asset_id: asset_id.clone(),
+            asset_owner: creator.clone(),
+            asset_issuance_qty: Some(1),
+        };
+        
+        let exceeding_digest = 
+            <Test as frame_system::Config>::Hashing::hash(&exceeding_entry.encode()[..]);
+
+        assert_noop!(
+            Asset::issue(
+                DoubleOrigin(author.clone(), creator.clone()).into(),
+                exceeding_entry,
+                exceeding_digest,
+                authorization_id.clone()
+            ),
+            Error::<Test>::DistributionLimitExceeded
+        );
+    });
 }


### PR DESCRIPTION
This PR fixes issue #379 .

This issue has been structured  similarly to the `asset_create_should_succeed` test.
This test will ensure that an asset can be issued successfully and will include coverage for reaching and exceeding the `MaxAssetDistribution` limit.


- Test Initialization:
The test sets up a space, approves it, and creates an asset similarly to the `asset_create_should_succeed` test.
- Asset Issuance:
The loop issues the asset up to the `MaxAssetDistribution` limit (set to 25 for testing). Each iteration simulates issuing the asset to a different recipient.
- Error Handling:
After the limit is reached, the test tries to issue the asset to one more recipient, which should trigger the `DistributionLimitExceeded` error. This ensures that the pallet's logic correctly handles and enforces the distribution limit.

This implementation checks that the asset issuance process is valid up to the `MaxAssetDistribution`  limit and correctly throws an error when the `limit` is exceeded. 