### PR TITLE
runtime: Update existential deposit

### DIFF
--- a/runtimes/braid/constants/src/lib.rs
+++ b/runtimes/braid/constants/src/lib.rs
@@ -25,13 +25,14 @@ pub mod weights;
 pub mod currency {
 	use cord_primitives::Balance;
 
-	/// The existential deposit.
-	pub const EXISTENTIAL_DEPOSIT: Balance = 100 * MILLI_UNITS;
 	pub const UNITS: Balance = 1_000_000_000_000; // 10^12 precision
 
 	pub const MILLI_UNITS: Balance = UNITS / 1_000; // 10^9 precision
 	pub const MICRO_UNITS: Balance = UNITS / 1_000_000; // 10^6 precision
 	pub const NANO_UNITS: Balance = UNITS / 1_000_000_000; // 10^3 precision
+
+	/// The existential deposit.
+	pub const EXISTENTIAL_DEPOSIT: Balance = 100 * MILLI_UNITS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 100 * UNITS + (bytes as Balance) * 100 * MILLI_UNITS

--- a/runtimes/loom/constants/src/lib.rs
+++ b/runtimes/loom/constants/src/lib.rs
@@ -25,13 +25,14 @@ pub mod weights;
 pub mod currency {
 	use cord_primitives::Balance;
 
-	/// The existential deposit.
-	pub const EXISTENTIAL_DEPOSIT: Balance = 100 * MILLI_UNITS;
 	pub const UNITS: Balance = 1_000_000_000_000; // 10^12 precision
 
 	pub const MILLI_UNITS: Balance = UNITS / 1_000; // 10^9 precision
 	pub const MICRO_UNITS: Balance = UNITS / 1_000_000; // 10^6 precision
 	pub const NANO_UNITS: Balance = UNITS / 1_000_000_000; // 10^3 precision
+
+	/// The existential deposit.
+	pub const EXISTENTIAL_DEPOSIT: Balance = 100 * MILLI_UNITS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 100 * UNITS + (bytes as Balance) * 100 * MILLI_UNITS

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -368,7 +368,8 @@ pub mod currency {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: Balance = currency::UNITS;
+	pub const ExistentialDeposit: Balance = 100 * currency::MILLI_UNITS;
+
 	// For weight estimation, we assume that the most locks on an individual account will be 50.
 	// This number may need to be adjusted in the future if this assumption no longer holds true.
 	pub const MaxLocks: u32 = 50;


### PR DESCRIPTION
Update the `Existential_Deposit` for `test-utils`.

Even though it already updated for `braid` & `loom` configurations. I feel it is good to have arrange the constants in the order they have been declared even though rust has `lasy evaluation`.

btw, 
This does not require any updates on `augment-api` on CORD.JS side as well.