### PR TITLE
registries: Add benchmarking for pallet-registry

### DIFF
--- a/pallets/registries/src/benchmarking.rs
+++ b/pallets/registries/src/benchmarking.rs
@@ -1,0 +1,617 @@
+#![cfg(feature = "runtime-benchmarks")]
+
+use super::*;
+use codec::Encode;
+use frame_benchmarking::{account, benchmarks};
+use frame_support::sp_runtime::traits::Hash;
+use frame_system::RawOrigin;
+use identifier::{IdentifierType, Ss58Identifier};
+use pallet_schema_accounts::{InputSchemaOf, SchemaHashOf};
+use sp_std::prelude::*;
+
+fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
+}
+
+pub fn generate_registry_id<T: Config>(digest: &RegistryHashOf<T>) -> RegistryIdOf {
+	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Registries).unwrap()
+}
+
+pub fn generate_authorization_id<T: Config>(digest: &RegistryHashOf<T>) -> AuthorizationIdOf {
+	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::RegistryAuthorization)
+		.unwrap()
+}
+
+pub fn generate_schema_id<T: Config>(digest: &SchemaHashOf<T>) -> SchemaIdOf {
+	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::SchemaAccounts)
+		.unwrap()
+}
+
+const SEED: u32 = 0;
+
+benchmarks! {
+		where_clause {
+			where
+				T: pallet_schema_accounts::Config,
+				T: frame_system::Config,
+		}
+
+
+		add_delegate {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let delegate: T::AccountId = account("delegate", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let delegate_auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &delegate.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let delegate_authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&delegate_auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+		}: _<T::RuntimeOrigin>(
+			RawOrigin::Signed(creator.clone()).into(),
+			registry_id.clone(),
+			delegate.clone(),
+			authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Authorization {
+					registry_id: registry_id,
+					authorization: delegate_authorization_id,
+					delegate: delegate,
+				}
+				.into()
+			);
+		}
+
+
+		add_admin_delegate {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let delegate: T::AccountId = account("delegate", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let delegate_auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &delegate.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let delegate_authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&delegate_auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+			let origin = RawOrigin::Signed(creator.clone()).into();
+
+		}: _<T::RuntimeOrigin>(origin, registry_id.clone(), delegate.clone(), authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Authorization {
+					registry_id: registry_id,
+					authorization: delegate_authorization_id,
+					delegate: delegate,
+				}
+				.into()
+			);
+		}
+
+
+		add_delegator {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let delegate: T::AccountId = account("delegate", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let delegate_auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &delegate.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let delegate_authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&delegate_auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+		}: _<T::RuntimeOrigin>(
+			RawOrigin::Signed(creator.clone()).into(),
+			registry_id.clone(),
+			delegate.clone(),
+			authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Authorization {
+					registry_id: registry_id,
+					authorization: delegate_authorization_id,
+					delegate: delegate,
+				}
+				.into()
+			);
+		}
+
+
+		remove_delegate {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let delegate: T::AccountId = account("delegate", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let delegate_auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &delegate.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let delegate_authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&delegate_auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+			Pallet::<T>::add_delegate(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				delegate.clone(),
+				authorization_id.clone()
+			)?;
+
+		}: _<T::RuntimeOrigin>(
+			RawOrigin::Signed(creator.clone()).into(),
+			registry_id.clone(),
+			delegate_authorization_id.clone(),
+			authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Deauthorization {
+					registry_id: registry_id,
+					authorization: delegate_authorization_id
+				}
+				.into()
+			);
+		}
+
+
+		create {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+		}: _<T::RuntimeOrigin>(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob)
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Create {
+					registry_id: registry_id,
+					creator: creator,
+					authorization: authorization_id,
+				}
+				.into(),
+			);
+		}
+
+
+		update {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let new_digest =
+				<T as frame_system::Config>::Hashing::hash(&[3u8; 256].to_vec().encode()[..]);
+
+			let new_raw_blob = [4u8; 256].to_vec();
+			let new_blob: RegistryBlobOf<T> = BoundedVec::try_from(new_raw_blob.clone())
+				.expect("New Test Blob should fit into the expected input length of for the test runtime.");
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+		}: _<T::RuntimeOrigin>(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				new_digest,
+				Some(new_blob.clone()),
+				authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Update {
+					registry_id: registry_id,
+					updater: creator,
+					authorization: authorization_id
+				}
+				.into(),
+			);
+		}
+
+
+		revoke {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+		}: _<T::RuntimeOrigin>(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Revoke {
+					registry_id: registry_id,
+					authority: creator,
+				}
+				.into(),
+			);
+		}
+
+
+		reinstate {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+			Pallet::<T>::revoke(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				authorization_id.clone()
+			)?;
+
+		}: _<T::RuntimeOrigin>(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Reinstate {
+					registry_id: registry_id,
+					authority: creator,
+				}
+				.into(),
+			);
+		}
+
+
+		archive {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+		}: _<T::RuntimeOrigin>(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Archive {
+					registry_id: registry_id,
+					authority: creator,
+				}
+				.into(),
+			);
+		}
+
+
+		restore {
+			let creator: T::AccountId = account("creator", 0, SEED);
+			let registry = [2u8; 256].to_vec();
+
+			let raw_blob = [2u8; 256].to_vec();
+			let blob: RegistryBlobOf<T> = BoundedVec::try_from(raw_blob)
+				.expect("Test blob should fit into the expected input length for the test runtime.");
+
+			let registry_digest = <T as frame_system::Config>::Hashing::hash(&registry.encode()[..]);
+
+			let id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_digest.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let registry_id: RegistryIdOf = generate_registry_id::<T>(&id_digest);
+
+			let auth_id_digest = <T as frame_system::Config>::Hashing::hash(
+				&[&registry_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+			);
+
+			let authorization_id: AuthorizationIdOf = generate_authorization_id::<T>(&auth_id_digest);
+
+			let raw_schema = [2u8; 256].to_vec();
+			let schema: InputSchemaOf<T> = BoundedVec::try_from(raw_schema)
+				.expect("Test schema should fit into the expected input length for the test runtime.");
+			let schema_id_digest = <T as frame_system::Config>::Hashing::hash(&schema.encode()[..]);
+			let schema_id: SchemaIdOf = generate_schema_id::<T>(&schema_id_digest);
+
+			Pallet::<T>::create(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				registry_digest,
+				Some(schema_id.clone()),
+				Some(blob),
+			)?;
+
+			Pallet::<T>::archive(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				authorization_id.clone(),
+			)?;
+
+		}: _<T::RuntimeOrigin>(
+				RawOrigin::Signed(creator.clone()).into(),
+				registry_id.clone(),
+				authorization_id.clone()
+		)
+		verify {
+			assert_last_event::<T>(
+				Event::Restore {
+					registry_id: registry_id,
+					authority: creator,
+				}
+				.into(),
+			);
+		}
+
+		impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
+}

--- a/pallets/registries/src/lib.rs
+++ b/pallets/registries/src/lib.rs
@@ -92,6 +92,9 @@
 #[cfg(any(feature = "mock", test))]
 pub mod mock;
 
+#[cfg(feature = "runtime-benchmarks")]
+pub mod benchmarking;
+
 #[cfg(test)]
 mod tests;
 

--- a/runtimes/braid/Cargo.toml
+++ b/runtimes/braid/Cargo.toml
@@ -230,7 +230,8 @@ runtime-benchmarks = [
 	"cord-runtime-common/runtime-benchmarks",
 	"pallet-asset-conversion/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
-	"pallet-config/runtime-benchmarks"
+	"pallet-config/runtime-benchmarks",
+	"pallet-registries/runtime-benchmarks",
 ]
 
 try-runtime = [

--- a/runtimes/loom/Cargo.toml
+++ b/runtimes/loom/Cargo.toml
@@ -244,6 +244,7 @@ runtime-benchmarks = [
 	"pallet-assets/runtime-benchmarks",
 	"pallet-config/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
+	"pallet-registries/runtime-benchmarks",
 ]
 
 try-runtime = [

--- a/runtimes/weave/Cargo.toml
+++ b/runtimes/weave/Cargo.toml
@@ -243,6 +243,7 @@ runtime-benchmarks = [
 	"pallet-assets/runtime-benchmarks",
 	"pallet-config/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
+	"pallet-registries/runtime-benchmarks",
 ]
 
 try-runtime = [


### PR DESCRIPTION
Add `registries` benchmarks using which we can get the `weights.rs ` file generated on a remote server.