### PR TITLE
Fixes: #318 Add test cases for PresentationDigestAlreadyAnchored error

### DIFF
--- a/pallets/statement/src/tests.rs
+++ b/pallets/statement/src/tests.rs
@@ -1296,3 +1296,66 @@ fn nonexistent_presentation_should_fail() {
 		);
 	});
 }
+
+#[test]
+fn adding_duplicate_presentation_should_fail() {
+	let creator = DID_00;
+	let author = ACCOUNT_00;
+	let capacity = 5u64;
+	let statement = [77u8; 32];
+	let statement_digest = <Test as frame_system::Config>::Hashing::hash(&statement[..]);
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: Ss58Identifier = generate_authorization_id::<Test>(&auth_digest);
+
+	let statement_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&statement_digest.encode()[..], &space_id.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let statement_id: StatementIdOf = generate_statement_id::<Test>(&statement_id_digest);
+	let presentation = [88u8; 32];
+	let presentation_digest = <Test as frame_system::Config>::Hashing::hash(&presentation[..]);
+	let presentation_type = PresentationTypeOf::Other;
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest,
+		));
+
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, capacity));
+
+		assert_ok!(Statement::register(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			statement_digest,
+			authorization_id.clone(),
+			None
+		));
+		assert_ok!(Statement::add_presentation(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			statement_id.clone(), // Use the generated statement_id
+			presentation_digest,
+			presentation_type,
+			authorization_id.clone(),
+		));
+
+		assert_err!(
+			Statement::add_presentation(
+				DoubleOrigin(author, creator).into(),
+				statement_id, // Use the generated statement_id
+				presentation_digest,
+				presentation_type,
+				authorization_id,
+			),
+			Error::<Test>::PresentationDigestAlreadyAnchored
+		);
+	});
+}


### PR DESCRIPTION
Fix for- #318 .

This PR adds a new unit test to the pallet-statement module to verify that attempting to add a presentation with the same digest to a statement that already has a presentation with that digest results in the expected error:
 Error::< Test >::PresentationDigestAlreadyAnchored.

The test covers the following scenarios:

Creates a statement.
Adds a presentation to the statement.
Attempts to add the same presentation (with the same digest) to the same statement again.
Asserts that the second add_presentation call fails with the expected error.
This test enhances the test coverage of the pallet-statement module and improves its overall quality.