### PR TITLE
schema: Add tests for SchemaNotFound

### DIFF
--- a/pallets/schema/src/lib.rs
+++ b/pallets/schema/src/lib.rs
@@ -131,6 +131,7 @@ pub mod pallet {
 	}
 
 	#[pallet::error]
+	#[derive(PartialEq)]
 	pub enum Error<T> {
 		/// Schema identifier is not unique.
 		SchemaAlreadyAnchored,


### PR DESCRIPTION
Fixes #310 
### Description
Added tests for the `SchemaNotFound` error in the `pallet/schema` module.

### Goals
- Assert that `SchemaNotFound` is returned correctly in all applicable cases.
- Validate all functions that could potentially return this error code.
