### PR TITLE
Fixes: #294 Added test cases for UnauthorizedOperation error

### DIFF
--- a/pallets/network-membership/src/tests.rs
+++ b/pallets/network-membership/src/tests.rs
@@ -363,25 +363,22 @@ fn test_auto_expire_non_existent_membership() {
 }
 #[test]
 fn test_unauthorized_operation() {
-    new_test_ext().execute_with(|| {
-        run_to_block(1);
+	new_test_ext().execute_with(|| {
+		run_to_block(1);
 
-        let non_member = AccountId::new([14u8; 32]);
-        
-        assert_err!(
-            NetworkMembership::nominate(
-                RuntimeOrigin::signed(non_member),
-                AccountId::new([13u8; 32]),
-                true
-            ),
-            BadOrigin
-        );
+		let non_member = AccountId::new([14u8; 32]);
 
-        assert_eq!(NetworkMembership::members_count(), 1);
-        
-        assert_eq!(
-            Members::<Test>::get(AccountId::new([13u8; 32])),
-            None
-        );
-    });
+		assert_err!(
+			NetworkMembership::nominate(
+				RuntimeOrigin::signed(non_member),
+				AccountId::new([13u8; 32]),
+				true
+			),
+			BadOrigin
+		);
+
+		assert_eq!(NetworkMembership::members_count(), 1);
+
+		assert_eq!(Members::<Test>::get(AccountId::new([13u8; 32])), None);
+	});
 }

--- a/pallets/network-membership/src/tests.rs
+++ b/pallets/network-membership/src/tests.rs
@@ -361,24 +361,3 @@ fn test_auto_expire_non_existent_membership() {
 		assert_eq!(NetworkMembership::is_member(&AccountId::new([99u8; 32])), false);
 	});
 }
-#[test]
-fn test_unauthorized_operation() {
-	new_test_ext().execute_with(|| {
-		run_to_block(1);
-
-		let non_member = AccountId::new([14u8; 32]);
-
-		assert_err!(
-			NetworkMembership::nominate(
-				RuntimeOrigin::signed(non_member),
-				AccountId::new([13u8; 32]),
-				true
-			),
-			BadOrigin
-		);
-
-		assert_eq!(NetworkMembership::members_count(), 1);
-
-		assert_eq!(Members::<Test>::get(AccountId::new([13u8; 32])), None);
-	});
-}

--- a/pallets/network-membership/src/tests.rs
+++ b/pallets/network-membership/src/tests.rs
@@ -361,3 +361,27 @@ fn test_auto_expire_non_existent_membership() {
 		assert_eq!(NetworkMembership::is_member(&AccountId::new([99u8; 32])), false);
 	});
 }
+#[test]
+fn test_unauthorized_operation() {
+    new_test_ext().execute_with(|| {
+        run_to_block(1);
+
+        let non_member = AccountId::new([14u8; 32]);
+        
+        assert_err!(
+            NetworkMembership::nominate(
+                RuntimeOrigin::signed(non_member),
+                AccountId::new([13u8; 32]),
+                true
+            ),
+            BadOrigin
+        );
+
+        assert_eq!(NetworkMembership::members_count(), 1);
+        
+        assert_eq!(
+            Members::<Test>::get(AccountId::new([13u8; 32])),
+            None
+        );
+    });
+}

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -917,97 +917,99 @@ fn reference_identifier_not_found_test() {
 }
 #[test]
 fn unauthorized_operation_test() {
-    let creator = DID_00.clone();
-    let author = ACCOUNT_00.clone();
-    let message_id = BoundedVec::try_from([82u8; 10].to_vec()).unwrap();
-    let message_id_revoke = BoundedVec::try_from([84u8; 10].to_vec()).unwrap();
-    let entity_id = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
-    let provider_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+	let creator = DID_00.clone();
+	let author = ACCOUNT_00.clone();
+	let message_id = BoundedVec::try_from([82u8; 10].to_vec()).unwrap();
+	let message_id_revoke = BoundedVec::try_from([84u8; 10].to_vec()).unwrap();
+	let entity_id = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
+	let provider_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
 
-    let entry = RatingInputEntryOf::<Test> {
-        entity_id: entity_id.clone(),
-        provider_id: provider_id.clone(),
-        total_encoded_rating: 250u64,
-        count_of_txn: 7u64,
-        rating_type: RatingTypeOf::Overall,
-        provider_did: creator.clone(),
-    };
+	let entry = RatingInputEntryOf::<Test> {
+		entity_id: entity_id.clone(),
+		provider_id: provider_id.clone(),
+		total_encoded_rating: 250u64,
+		count_of_txn: 7u64,
+		rating_type: RatingTypeOf::Overall,
+		provider_did: creator.clone(),
+	};
 
-    let entry_digest = 
-        <Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+	let entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
 
-    let raw_space = [2u8; 256].to_vec();
-    let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
-    let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
-        &[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
-    );
-    let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
-    let auth_digest = <Test as frame_system::Config>::Hashing::hash(
-        &[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
-    );
-    let authorization_id: AuthorizationIdOf =
-        Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
-            .unwrap();
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: AuthorizationIdOf =
+		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
+			.unwrap();
 
-    let raw_space_2 = [3u8; 256].to_vec();
-    let space_digest_2 = <Test as frame_system::Config>::Hashing::hash(&raw_space_2.encode()[..]);
-    let space_id_digest_2 = <Test as frame_system::Config>::Hashing::hash(
-        &[&space_digest_2.encode()[..], &creator.encode()[..]].concat()[..],
-    );
-    let space_id_2: SpaceIdOf = generate_space_id::<Test>(&space_id_digest_2);
-    let auth_digest_2 = <Test as frame_system::Config>::Hashing::hash(
-        &[&space_id_2.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
-    );
-    let authorization_id_2: AuthorizationIdOf =
-        Ss58Identifier::create_identifier(&auth_digest_2.encode()[..], IdentifierType::Authorization)
-            .unwrap();
+	let raw_space_2 = [3u8; 256].to_vec();
+	let space_digest_2 = <Test as frame_system::Config>::Hashing::hash(&raw_space_2.encode()[..]);
+	let space_id_digest_2 = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest_2.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id_2: SpaceIdOf = generate_space_id::<Test>(&space_id_digest_2);
+	let auth_digest_2 = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id_2.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id_2: AuthorizationIdOf = Ss58Identifier::create_identifier(
+		&auth_digest_2.encode()[..],
+		IdentifierType::Authorization,
+	)
+	.unwrap();
 
-    let id_digest = <Test as frame_system::Config>::Hashing::hash(
-        &[
-            &entry_digest.encode()[..],
-            &entry.entity_id.encode()[..],
-            &message_id.encode()[..],
-            &space_id.encode()[..],
-            &creator.encode()[..],
-        ]
-        .concat()[..],
-    );
-    let identifier =
-        Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
-            .unwrap();
+	let id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&entry_digest.encode()[..],
+			&entry.entity_id.encode()[..],
+			&message_id.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+		]
+		.concat()[..],
+	);
+	let identifier =
+		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
+			.unwrap();
 
-    new_test_ext().execute_with(|| {
-        System::set_block_number(1);
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
 
-        assert_ok!(Space::create(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            space_digest
-        ));
-        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 5u64));
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 5u64));
 
-        assert_ok!(Space::create(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            space_digest_2
-        ));
-        assert_ok!(Space::approve(RawOrigin::Root.into(), space_id_2, 5u64));
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest_2
+		));
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id_2, 5u64));
 
-        assert_ok!(Score::register_rating(
-            DoubleOrigin(author.clone(), creator.clone()).into(),
-            entry.clone(),
-            entry_digest,
-            message_id.clone(),
-            authorization_id.clone(),
-        ));
+		assert_ok!(Score::register_rating(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry.clone(),
+			entry_digest,
+			message_id.clone(),
+			authorization_id.clone(),
+		));
 
-        assert_err!(
-            Score::revoke_rating(
-                DoubleOrigin(author.clone(), creator.clone()).into(),
-                identifier.clone(),
-                message_id_revoke.clone(),
-                entry_digest,
-                authorization_id_2,
-            ),
-            Error::<Test>::UnauthorizedOperation
-        );
-    });
+		assert_err!(
+			Score::revoke_rating(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				identifier.clone(),
+				message_id_revoke.clone(),
+				entry_digest,
+				authorization_id_2,
+			),
+			Error::<Test>::UnauthorizedOperation
+		);
+	});
 }


### PR DESCRIPTION
Fixes #294 
### Description
Added tests for the `UnauthorizedOperation` error in the `pallet/network-score` module.

### Goals
- Validate that `UnauthorizedOperation` is returned correctly in all applicable scenarios.
- Cover all functions that may return this error.
