### PR TITLE
pallet-asset: Added new test cases for invalid asset value Fixes #372

### DIFF
--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -3152,3 +3152,54 @@ fn asset_issue_should_fail_when_distribution_limit_exceeds() {
 		);
 	});
 }
+
+#[test]
+fn should_fail_for_invalid_asset_values() {
+	let (creator, author) = (DID_00, ACCOUNT_00);
+	let space_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[2u8; 256].to_vec().encode()[..]);
+	let space_id = generate_space_id::<Test>(&<Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	));
+
+	let authorization_id =
+		generate_authorization_id::<Test>(&<Test as frame_system::Config>::Hashing::hash(
+			&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+		));
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 5u64));
+		let entry = AssetInputEntryOf::<Test> {
+			asset_desc: BoundedVec::try_from([72u8; 10].to_vec()).unwrap(),
+			asset_qty: 0,
+			asset_type: AssetTypeOf::MF,
+			asset_value: 0,
+			asset_tag: BoundedVec::try_from([72u8; 10].to_vec()).unwrap(),
+			asset_meta: BoundedVec::try_from([72u8; 10].to_vec()).unwrap(),
+		};
+
+		let digest =
+			<Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+		assert_err!(
+			Asset::create(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				entry,
+				digest,
+				authorization_id.clone()
+			),
+			Error::<Test>::InvalidAssetValue
+		);
+		let vc_digest =
+			<Test as frame_system::Config>::Hashing::hash(&[&0u64.encode()[..]].concat()[..]);
+
+		assert_err!(
+			Asset::vc_create(DoubleOrigin(author, creator).into(), 0, vc_digest, authorization_id),
+			Error::<Test>::InvalidAssetQty
+		);
+	});
+}


### PR DESCRIPTION
This PR fixes the issue #372 

### Implementation Approach
1. Analyzed existing test cases (particularly `asset_create_should_succeed`) as referenced in the issue
2. Identified all functions that could return `InvalidAssetValue` error
3. Wrote test cases for efficiency while maintaining comprehensive coverage
4. Implemented test validating:
   - Regular asset creation with invalid value
   - VC asset creation with invalid quantity

### Testing
- All new tests can be executed using `cargo test -p pallet-asset`
- Test cases validate proper error handling

Below is the attached screenshot of the test case passing in the local environment:- 

<img width="751" alt="Screenshot 2025-01-06 at 1 05 26 PM" src="https://github.com/user-attachments/assets/e4be1490-5b85-4b3b-b667-3facd0c7afd2" />
