### PR TITLE
pallet-chain_space: Added test cases for Invalid Identifier

### DIFF
--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -1250,30 +1250,30 @@ fn add_delegator_should_fail_for_space_creator_delegating_themselves() {
 }
 
 #[test]
-    fn creating_space_identifier_with_invalid_input_should_fail() {
-        new_test_ext().execute_with(|| {
-            // An empty byte slice is assumed to be invalid.
-            let bad_input: Vec<u8> = vec![];
-            let result = Ss58Identifier::create_identifier(&bad_input, IdentifierType::Space);
-            assert!(
-                result.is_err(),
-                "Expected failure when creating a space identifier with invalid input"
-            );
-        });
-    }
+fn creating_space_identifier_with_invalid_input_should_fail() {
+	new_test_ext().execute_with(|| {
+		// An empty byte slice is assumed to be invalid.
+		let bad_input: Vec<u8> = vec![];
+		let result = Ss58Identifier::create_identifier(&bad_input, IdentifierType::Space);
+		assert!(
+			result.is_err(),
+			"Expected failure when creating a space identifier with invalid input"
+		);
+	});
+}
 
-    // Test that creating an authorization identifier with an invalid input (empty slice)
-    // returns an error.
+// Test that creating an authorization identifier with an invalid input (empty slice)
+// returns an error.
 
-    #[test]
-    fn creating_authorization_identifier_with_invalid_input_should_fail() {
-        new_test_ext().execute_with(|| {
-            // Use an empty slice to simulate an invalid input.
-            let bad_input: Vec<u8> = vec![];
-            let result = Ss58Identifier::create_identifier(&bad_input, IdentifierType::Authorization);
-            assert!(
-                result.is_err(),
-                "Expected failure when creating an authorization identifier with invalid input"
-            );
-        });
-    }
+#[test]
+fn creating_authorization_identifier_with_invalid_input_should_fail() {
+	new_test_ext().execute_with(|| {
+		// Use an empty slice to simulate an invalid input.
+		let bad_input: Vec<u8> = vec![];
+		let result = Ss58Identifier::create_identifier(&bad_input, IdentifierType::Authorization);
+		assert!(
+			result.is_err(),
+			"Expected failure when creating an authorization identifier with invalid input"
+		);
+	});
+}

--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -1248,3 +1248,32 @@ fn add_delegator_should_fail_for_space_creator_delegating_themselves() {
 		);
 	});
 }
+
+#[test]
+    fn creating_space_identifier_with_invalid_input_should_fail() {
+        new_test_ext().execute_with(|| {
+            // An empty byte slice is assumed to be invalid.
+            let bad_input: Vec<u8> = vec![];
+            let result = Ss58Identifier::create_identifier(&bad_input, IdentifierType::Space);
+            assert!(
+                result.is_err(),
+                "Expected failure when creating a space identifier with invalid input"
+            );
+        });
+    }
+
+    // Test that creating an authorization identifier with an invalid input (empty slice)
+    // returns an error.
+
+    #[test]
+    fn creating_authorization_identifier_with_invalid_input_should_fail() {
+        new_test_ext().execute_with(|| {
+            // Use an empty slice to simulate an invalid input.
+            let bad_input: Vec<u8> = vec![];
+            let result = Ss58Identifier::create_identifier(&bad_input, IdentifierType::Authorization);
+            assert!(
+                result.is_err(),
+                "Expected failure when creating an authorization identifier with invalid input"
+            );
+        });
+    }


### PR DESCRIPTION
This PR fixes issue #279 

## Implementation Approach

1.
`creating_space_identifier_with_invalid_input_should_fail`

`Setup`:
It sets up the testing environment using new_test_ext().execute_with(|| { … });, which initializes the mock runtime for our pallet.
`Invalid Input`:
The test creates an empty byte vector (vec![]). In a real scenario, the identifier function expects a valid byte sequence (for example, a hash of some space data). An empty input is considered invalid.
`Action`:
The test calls Ss58Identifier::create_identifier with the empty byte vector and specifies that it is to create a Space identifier by passing IdentifierType::Space.
`Assertion`:
The test asserts that this function call returns an error. If the function correctly detects the invalid input, it will not produce a valid identifier and instead return an error, which is exactly what the test checks for.


2.
`creating_authorization_identifier_with_invalid_input_should_fail`

`Setup`:
Similarly, it initializes the testing environment with new_test_ext().execute_with(|| { … });.
`Invalid Input`:
Again, the test uses an empty byte vector as the input, which is not acceptable for a valid identifier.
`Action`:
It calls Ss58Identifier::create_identifier, this time specifying IdentifierType::Authorization to simulate creating an authorization identifier.
`Assertion`:
The test checks that the function call returns an error. This ensures that if an invalid input is given when trying to create an authorization identifier, the function correctly fails.


## Local Testing


Test 1:- 
<img width="886" alt="Screenshot 2025-03-08 at 3 08 21 PM" src="https://github.com/user-attachments/assets/73d8ca9b-97a3-4cbd-b1f3-b3ce50f7c234" />

Test 2:- 

<img width="949" alt="Screenshot 2025-03-08 at 3 09 06 PM" src="https://github.com/user-attachments/assets/e3393d5f-f3f9-4760-ad24-62e80d0b5438" />

