### PR TITLE
pallet - node-authorization : Adding Tests for Node_ID_Too_Long

### DIFF
--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -24,6 +24,7 @@ use super::*;
 use crate::mock::*;
 use frame_support::{assert_err, assert_noop, assert_ok};
 use sp_runtime::traits::BadOrigin;
+use frame_support::traits::Get;
 
 #[test]
 fn check_genesis_well_known_nodes() {
@@ -461,13 +462,31 @@ fn test_generate_peer_id_invalid_utf8() {
 }
 
 #[test]
-fn peer_id_too_long_test() {
-	new_test_ext().execute_with(|| {
-		let node_id: &str = &"nodeid".repeat(32);
+fn node_id_too_long_checks() {
+    new_test_ext().execute_with(|| {
+        let max_len: u32 = <Test as Config>::MaxNodeIdLength::get();
+        let long_string = "a".repeat((max_len + 1) as usize);
+        let oversized_node = test_node(&long_string);
 
-		let node_identity = test_node(&node_id);
-		let testing = NodeAuthorization::generate_peer_id(&node_identity).unwrap();
+        // println!("Testing with NodeId of length: {}", long_string.len());
+        // println!("MaxNodeIdLength is: {}", max_len);
 
-		assert_eq!(test_peer_id_length(testing), Err(Error::<Test>::PeerIdTooLong));
-	})
+        assert_err!(
+            NodeAuthorization::add_well_known_node(
+                RuntimeOrigin::signed(1),
+                oversized_node.clone(),
+                15
+            ),
+            Error::<Test>::NodeIdTooLong
+        );
+        assert_err!(
+            NodeAuthorization::add_connection(
+                RuntimeOrigin::signed(10),
+                oversized_node.clone(),
+                test_node(TEST_NODE_1)
+            ),
+            Error::<Test>::NodeIdTooLong
+        );
+    });
 }
+

--- a/pallets/node-authorization/src/tests.rs
+++ b/pallets/node-authorization/src/tests.rs
@@ -22,9 +22,8 @@
 
 use super::*;
 use crate::mock::*;
-use frame_support::{assert_err, assert_noop, assert_ok};
+use frame_support::{assert_err, assert_noop, assert_ok, traits::Get};
 use sp_runtime::traits::BadOrigin;
-use frame_support::traits::Get;
 
 #[test]
 fn check_genesis_well_known_nodes() {
@@ -460,33 +459,43 @@ fn test_generate_peer_id_invalid_utf8() {
 	let invalid_node_id: NodeId = vec![0xFF, 0xFE, 0xFD];
 	assert_err!(NodeAuthorization::generate_peer_id(&invalid_node_id), Error::<Test>::InvalidUtf8);
 }
+#[test]
+fn peer_id_too_long_test() {
+	new_test_ext().execute_with(|| {
+		let node_id: &str = &"nodeid".repeat(32);
+
+		let node_identity = test_node(&node_id);
+		let testing = NodeAuthorization::generate_peer_id(&node_identity).unwrap();
+
+		assert_eq!(test_peer_id_length(testing), Err(Error::<Test>::PeerIdTooLong));
+	})
+}
 
 #[test]
 fn node_id_too_long_checks() {
-    new_test_ext().execute_with(|| {
-        let max_len: u32 = <Test as Config>::MaxNodeIdLength::get();
-        let long_string = "a".repeat((max_len + 1) as usize);
-        let oversized_node = test_node(&long_string);
+	new_test_ext().execute_with(|| {
+		let max_len: u32 = <Test as Config>::MaxNodeIdLength::get();
+		let long_string = "a".repeat((max_len + 1) as usize);
+		let oversized_node = test_node(&long_string);
 
-        // println!("Testing with NodeId of length: {}", long_string.len());
-        // println!("MaxNodeIdLength is: {}", max_len);
+		// println!("Testing with NodeId of length: {}", long_string.len());
+		// println!("MaxNodeIdLength is: {}", max_len);
 
-        assert_err!(
-            NodeAuthorization::add_well_known_node(
-                RuntimeOrigin::signed(1),
-                oversized_node.clone(),
-                15
-            ),
-            Error::<Test>::NodeIdTooLong
-        );
-        assert_err!(
-            NodeAuthorization::add_connection(
-                RuntimeOrigin::signed(10),
-                oversized_node.clone(),
-                test_node(TEST_NODE_1)
-            ),
-            Error::<Test>::NodeIdTooLong
-        );
-    });
+		assert_err!(
+			NodeAuthorization::add_well_known_node(
+				RuntimeOrigin::signed(1),
+				oversized_node.clone(),
+				15
+			),
+			Error::<Test>::NodeIdTooLong
+		);
+		assert_err!(
+			NodeAuthorization::add_connection(
+				RuntimeOrigin::signed(10),
+				oversized_node.clone(),
+				test_node(TEST_NODE_1)
+			),
+			Error::<Test>::NodeIdTooLong
+		);
+	});
 }
-


### PR DESCRIPTION
This PR fixes the issue #592 


## Description 

This test is designed to verify that the system correctly enforces the `MaxNodeIdLength` constraint in `NodeAuthorization`. Here's a breakdown of how it works:

 - Fetches the Maximum Allowed NodeId Length:

 - Retrieves the `MaxNodeIdLength` from the runtime configuration `(<Test as Config>::MaxNodeIdLength::get())`.
 - Creates an Oversized NodeId:

 - Generates a string that exceeds the allowed length by one character `("a".repeat((max_len + 1) as usize))`.
 - Uses `test_node(&long_string)`to create a node with this oversized identifier.
 - Executes `Two Assertions` to Validate Enforcement:

 - Test `add_well_known_node`:
 - Calls `NodeAuthorization::add_well_known_node` with the oversized node.
 - Expects it to fail with `Error::<Test>::NodeIdTooLong`.
 - Test `add_connection`:
 - Calls `NodeAuthorization::add_connection`, attempting to establish a connection using the oversized node.
 - Expects it to fail with the same error.


## Testing 

The tests are passed in my local environment as well
Below is the attached screenshot for the same

<img width="940" alt="Screenshot 2025-03-09 at 5 13 19 PM" src="https://github.com/user-attachments/assets/825c36e0-96b0-4844-bff4-8d260afd1b62" />




@amarts @vatsa287 would you please take a look at the issue #592 and the PR to check if they are in compliance with the present requirements? 
