### PR TITLE
statement: Add statement existence verification

### DIFF
--- a/pallets/statement/src/lib.rs
+++ b/pallets/statement/src/lib.rs
@@ -261,6 +261,13 @@ pub mod pallet {
 			indices: Vec<u16>,
 			author: StatementCreatorOf<T>,
 		},
+		/// Statement existence has been verified.
+		/// \[statement identifier, digest, controller\]
+		StatementEntryExistenceVerified {
+			verifier: StatementCreatorOf<T>,
+			identifier: StatementIdOf,
+			digest: StatementDigestOf<T>,
+		},
 	}
 
 	#[pallet::error]
@@ -1115,6 +1122,58 @@ pub mod pallet {
 				identifier: statement_id,
 				digest: presentation_digest,
 				author: remover,
+			});
+
+			Ok(())
+		}
+
+		/// Verifies the existence of a Statement Entry.
+		///
+		/// This function allows an account to verify the existence of a specific Statement Entry.
+		/// If the entry exists and is not revoked, the latest identifier and digest are returned.
+		///
+		/// # Arguments
+		/// * `origin` - The origin of the call, which must be a signed account (verifier).
+		/// * `statement_id` - The unique identifier of the Statement to be verified.
+		///
+		/// # Conditions
+		/// - The Statement Entry must exist.
+		/// - The Statement Entry must not be revoked.
+		///
+		/// # Errors
+		/// This function returns an error in the following cases:
+		/// * `StatementNotFound` - If the specified `statement_id` does not exist.
+		/// * `StatementRevoked` - If the specified `statement_id` has been revoked.
+		///
+		/// # Events
+		/// Emits the `Event::StatementEntryExistenceVerified` event upon successful verification.
+		/// This event includes the `verifier`, the `statement_id`, and the
+		/// `statement_digest`.
+		///
+		/// # Example
+		/// ```rust
+		/// verify_existence(origin, statement_id)?;
+		/// ```
+		#[pallet::call_index(8)]
+		#[pallet::weight({0})]
+		pub fn verify_existence(
+			origin: OriginFor<T>,
+			statement_id: StatementIdOf,
+		) -> DispatchResult {
+			let verifier = ensure_signed(origin)?;
+
+			let statement =
+				<Statements<T>>::get(&statement_id).ok_or(Error::<T>::StatementNotFound)?;
+
+			ensure!(
+				!<RevocationList<T>>::contains_key(&statement_id, statement.digest),
+				Error::<T>::StatementRevoked
+			);
+
+			Self::deposit_event(Event::StatementEntryExistenceVerified {
+				verifier,
+				identifier: statement_id.clone(),
+				digest: statement.digest,
 			});
 
 			Ok(())


### PR DESCRIPTION
Adds a new extrinsic to statement for verification of existence of a specific `statement-id`.