### PR TITLE
network-score: Add tests for UnauthorizedOperation

### DIFF
--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -1032,3 +1032,101 @@ fn revise_rating_with_space_mismatch_should_fail() {
 		);
 	});
 }
+#[test]
+fn unauthorized_operation_test() {
+	let creator = DID_00.clone();
+	let author = ACCOUNT_00.clone();
+	let message_id = BoundedVec::try_from([82u8; 10].to_vec()).unwrap();
+	let message_id_revoke = BoundedVec::try_from([84u8; 10].to_vec()).unwrap();
+	let entity_id = BoundedVec::try_from([73u8; 10].to_vec()).unwrap();
+	let provider_id = BoundedVec::try_from([74u8; 10].to_vec()).unwrap();
+
+	let entry = RatingInputEntryOf::<Test> {
+		entity_id: entity_id.clone(),
+		provider_id: provider_id.clone(),
+		total_encoded_rating: 250u64,
+		count_of_txn: 7u64,
+		rating_type: RatingTypeOf::Overall,
+		provider_did: creator.clone(),
+	};
+
+	let entry_digest =
+		<Test as frame_system::Config>::Hashing::hash(&[&entry.encode()[..]].concat()[..]);
+
+	let raw_space = [2u8; 256].to_vec();
+	let space_digest = <Test as frame_system::Config>::Hashing::hash(&raw_space.encode()[..]);
+	let space_id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id: SpaceIdOf = generate_space_id::<Test>(&space_id_digest);
+	let auth_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id: AuthorizationIdOf =
+		Ss58Identifier::create_identifier(&auth_digest.encode()[..], IdentifierType::Authorization)
+			.unwrap();
+
+	let raw_space_2 = [3u8; 256].to_vec();
+	let space_digest_2 = <Test as frame_system::Config>::Hashing::hash(&raw_space_2.encode()[..]);
+	let space_id_digest_2 = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_digest_2.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let space_id_2: SpaceIdOf = generate_space_id::<Test>(&space_id_digest_2);
+	let auth_digest_2 = <Test as frame_system::Config>::Hashing::hash(
+		&[&space_id_2.encode()[..], &creator.encode()[..], &creator.encode()[..]].concat()[..],
+	);
+	let authorization_id_2: AuthorizationIdOf = Ss58Identifier::create_identifier(
+		&auth_digest_2.encode()[..],
+		IdentifierType::Authorization,
+	)
+	.unwrap();
+
+	let id_digest = <Test as frame_system::Config>::Hashing::hash(
+		&[
+			&entry_digest.encode()[..],
+			&entry.entity_id.encode()[..],
+			&message_id.encode()[..],
+			&space_id.encode()[..],
+			&creator.encode()[..],
+		]
+		.concat()[..],
+	);
+	let identifier =
+		Ss58Identifier::create_identifier(&(id_digest).encode()[..], IdentifierType::Rating)
+			.unwrap();
+
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest
+		));
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id, 5u64));
+
+		assert_ok!(Space::create(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			space_digest_2
+		));
+		assert_ok!(Space::approve(RawOrigin::Root.into(), space_id_2, 5u64));
+
+		assert_ok!(Score::register_rating(
+			DoubleOrigin(author.clone(), creator.clone()).into(),
+			entry.clone(),
+			entry_digest,
+			message_id.clone(),
+			authorization_id.clone(),
+		));
+
+		assert_err!(
+			Score::revoke_rating(
+				DoubleOrigin(author.clone(), creator.clone()).into(),
+				identifier.clone(),
+				message_id_revoke.clone(),
+				entry_digest,
+				authorization_id_2,
+			),
+			Error::<Test>::UnauthorizedOperation
+		);
+	});
+}


### PR DESCRIPTION
Fixes #294 
## Description
This PR adds a test case to verify that rating revocations are properly authorized. The test ensures that a rating can only be revoked using the authorization ID that was used to create it, preventing unauthorized operations.

## Implementation

- Creates two spaces with different authorization IDs
- Registers a rating using the first authorization ID
- Attempts to revoke the rating using the second authorization ID
- Verifies that the operation fails with an UnauthorizedOperation error

## Testing

- All new tests can be executed using cargo test -p pallet-asset
- Test cases validate proper error handling

Below is the attached screenshot of the test case passing in the local environment:-
<img width="941" alt="Screenshot 2025-03-14 at 2 36 53 PM" src="https://github.com/user-attachments/assets/169e5442-dcbe-4f34-93b2-c722627efb68" />
