### PR TITLE
Add `pallet-profile` for new Identity management.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,6 +2569,7 @@ dependencies = [
  "pallet-offences-benchmarking",
  "pallet-paged-list",
  "pallet-preimage",
+ "pallet-profile",
  "pallet-registry",
  "pallet-remark",
  "pallet-revive",
@@ -8469,6 +8470,27 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+]
+
+[[package]]
+name = "pallet-profile"
+version = "0.9.5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cord-primitives",
+ "cord-uri",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 	"test-utils/runtime/client",
 	"test-utils/runtime/transaction-pool",
 	"test-utils/service",
-
+	"pallets/profile",
 ]
 default-members = ["node/cli"]
 
@@ -905,7 +905,7 @@ pallet-entries = { path = "pallets/entries", default-features = false }
 pallet-schema-accounts = { path = "pallets/schema-accounts", default-features = false }
 pallet-meta-tx = { path = "pallets/meta-tx", default-features = false }
 pallet-namespace = { path = 'pallets/namespace', default-features = false }
-
+pallet-profile = { path = "pallets/profile", default-features = false }
 
 [profile.release]
 panic = 'unwind'

--- a/pallets/profile/Cargo.toml
+++ b/pallets/profile/Cargo.toml
@@ -1,0 +1,72 @@
+[package]
+name = 'pallet-profile'
+description = 'Manage CORD Profiles'
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dev-dependencies]
+sp-core = { features = ["std"], workspace = true }
+sp-keystore = { features = ["std"], workspace = true }
+cord-utilities = { features = ["mock"], workspace = true }
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+scale-info = { features = ["derive"], workspace = true }
+bitflags = { workspace = true }
+log = { workspace = true }
+
+# Internal dependencies
+cord-primitives = { workspace = true }
+cord-uri = { workspace = true }
+
+# Substrate dependencies
+frame-benchmarking = { optional = true, workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { optional = true, workspace = true }
+sp-io = { optional = true, workspace = true }
+sp-keystore = { optional = true, workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+[features]
+default = ['std']
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+]
+std = [
+	"codec/std",
+	"frame-benchmarking/std",
+	"frame-support/std",
+	"frame-system/std",
+	"cord-uri/std",
+	"cord-primitives/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-keystore/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"sp-runtime/try-runtime",
+]
+
+# Disable doctest when running `cargo test` 
+[lib]
+doctest = false

--- a/pallets/profile/src/lib.rs
+++ b/pallets/profile/src/lib.rs
@@ -1,0 +1,277 @@
+// This file is part of CORD – https://cord.network
+
+// Copyright (C) Dhiway Networks Pvt. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// CORD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CORD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CORD. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod types;
+
+use frame_support::{ensure, storage::types::StorageMap, BoundedVec};
+pub use crate::{pallet::*, types::*};
+use codec::Encode;
+use sp_runtime::traits::Hash;
+use cord_uri::{EntryTypeOf, EventStamp, Identifier, Ss58Identifier};
+use frame_support::pallet_prelude::DispatchResult;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	pub use cord_primitives::{IsPermissioned, StatusOf};
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	pub use frame_system::WeightInfo;
+
+    use sp_runtime::Vec;
+
+    /// DataKeyOf is the type of Profile Data Key.
+    pub type DataKeyOf<T> = BoundedVec<u8, <T as Config>::MaxDataKeyLength>;
+
+    /// DataValueOf is the type of the Profile Data Value.
+    pub type DataValueOf<T> = BoundedVec<u8, <T as Config>::MaxDataValueLength>;
+
+    /// Type of the Profile Identifier is a Ss58.
+    pub type ProfileIdOf = Ss58Identifier;
+
+    /// CreatorOf is the creator/holder of the Profile/
+    pub type CreatorOf<T> = <T as frame_system::Config>::AccountId;
+
+    /// Profile Metadata Of is the type wrapper for Profile Metadata struct.
+    /// Currently only holds latest-key.
+    pub type ProfileMetadataOf<T> = ProfileMetadata<CreatorOf<T>>;
+
+    #[pallet::config]
+    // TODO: Check workaround of not having TypeInfo here
+    pub trait Config: frame_system::Config + scale_info::TypeInfo + cord_uri::Config{
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        
+        #[pallet::constant]
+        type MaxDataKeyLength: Get<u32>;
+
+        #[pallet::constant]
+        type MaxDataValueLength: Get<u32>;
+
+        type WeightInfo: frame_system::WeightInfo;
+    }
+
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
+    #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
+    pub struct Pallet<T>(_);
+
+    #[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+    /// Storage to map Profile Identifier and 
+    /// its associated metadata.
+    #[pallet::storage]
+    pub type Profiles<T: Config> = 
+        StorageMap<
+            _,
+            Blake2_128Concat,
+            ProfileIdOf, 
+            ProfileMetadataOf<T>,
+            OptionQuery
+        >;
+
+    /// Storage to map the latest CORD account and
+    /// its associated Profile Identifier.
+    #[pallet::storage]
+    pub type AccountProfiles<T> = 
+        StorageMap<
+            _,
+            Blake2_128Concat,
+            CreatorOf<T>,
+            ProfileIdOf,
+            OptionQuery
+        >;
+    
+    /// Storage to map Profile Identifier and 
+    /// the actual Profile Data HashMap.
+    #[pallet::storage]
+    pub type ProfileData<T> = 
+        StorageDoubleMap<
+            _,
+            Blake2_128Concat,
+            ProfileIdOf,
+            Blake2_128Concat,
+            DataKeyOf<T>,
+            DataValueOf<T>,
+            OptionQuery
+        >;
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// The length of the identifier exceeds capacity limit.
+        InvalidIdentifierLength,
+        /// The Profile data key must start with 'pub_'
+        InvalidKeyPrefix,
+        /// The Profile already exists with a identifier.
+        ProfileAlreadyExists,
+        /// The Profile Identifier does not exist.
+        ProfileNotFound,
+        /// The event activity update has failed.
+        ActivityUpdateFailed,
+        /// The entry type for the activity is not valid.
+        InvalidEntryTypeInput,
+        /// Rotation must be to new key, not to existing tied account.
+        CannotRotateToSameAccount,
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// A new profile has been created.
+		/// \[Creator, Profile Identifier\]
+        ProfileSet { 
+            who: CreatorOf<T>, 
+            identifier: ProfileIdOf
+        },
+
+        /// Existing Profile's Key has been rotated.
+        /// \[Old Profile Holder, Profile Identifier, New public of the Holder]
+        KeyRotated {
+            who: CreatorOf<T>,
+            identifier: ProfileIdOf,
+            new_key: CreatorOf<T>,
+        }
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Creates a new Profile with associated details.
+		///
+        /// This extrinsic creates a new Profile to be mapped to a CORD account.
+		/// Also it expects a vector of Data Keys and its values. 
+        /// This HashMap is tied to the generated Profile Identifier.
+        /// But currently expects the user given Data Keys to start with `pub_` prefix only.
+        ///
+		/// # Parameters
+		/// - `origin`: The origin of the call, which must be signed by the creator of the profile.
+		/// - `data`: The data is a vector of a HashMap of the Data Key and associated Data Values.
+		///
+		/// # Returns
+		/// Returns `Ok(())` if the Profile is succesfully been created.
+		/// or an `Err` if the operation fails due to a same profile already existing.
+		///
+		/// # Errors
+        /// - `InvalidIdentifierLength`: If the newly creted Profile Identifier exceeds limit.
+		/// - `ProfileAlreadyExists`: If the newly created Profile already exists. 
+        ///   This happens if a user creates a duplicate profile with the same account key-pair.
+        /// - `InvalidKeyPrefix`: If the Profile Data Key starts with anything other than `pub_`.
+        #[pallet::call_index(0)]
+        #[pallet::weight({10_000})]
+        pub fn set_profile(
+            origin: OriginFor<T>,
+            data: Vec<(DataKeyOf<T>, DataValueOf<T>)>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+            let digest = T::Hashing::hash(&who.encode());
+            let pallet_name = <Self as frame_support::traits::PalletInfoAccess>::name();
+            let profile_id = <cord_uri::Pallet<T> as Identifier>::build(&(digest).encode()[..], pallet_name)
+                .map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+
+            ensure!(
+                !Profiles::<T>::contains_key(&profile_id),
+                Error::<T>::ProfileAlreadyExists
+            );
+
+            let profile = ProfileMetadataOf::<T> { latest_key: who.clone() }; 
+            Profiles::<T>::insert(&profile_id, profile);
+            AccountProfiles::<T>::insert(&who, &profile_id);
+
+            for (key, value) in data {
+                let key_str = sp_std::str::from_utf8(key.as_slice())
+                    .map_err(|_| Error::<T>::InvalidKeyPrefix)?;
+                ensure!(key_str.starts_with("pub_"), Error::<T>::InvalidKeyPrefix);
+                ProfileData::<T>::insert(&profile_id, &key, value);
+            }
+
+            Self::record_activity(&profile_id, b"ProfileSet")?;
+            Self::deposit_event(Event::ProfileSet { who: who.clone(), identifier: profile_id }); 
+            Ok(())
+        }
+
+        /// Rotates the key of an existing Profile.
+		///
+        /// This extrinsic rotates the key of an existing Profile, identified through its
+        /// Profile Identifier. 
+        /// This must be signed by the account tied to the Profile only. 
+        /// The `new-key` will be the public-key of the CORD/Substarte account tied to the Profile
+        /// from here on. So all new operations will require `new-key` based acconut only.
+        ///
+		/// # Parameters
+		/// - `origin`: The origin of the call, which must be signed by the owner of the profile.
+		/// - `new_key`: The new_key represnts the public key of the CORD/Substrate account for which 
+        ///   The existing Profile Identifier will be tied to from here on. Make Sure this public key 
+        ///   exists and accessible before making this call. 
+        ///   This is irreversible and will tie all existing Profile Data to new-key based account.
+		///
+		/// # Returns
+		/// Returns `Ok(())` if the Profile is succesfully rotated to new-key.
+		/// or an `Err` if the operation fails due to issues regarding Profile existence.
+		///
+		/// # Errors
+        /// - `ProfileNotFound`: If the Profile does not exist for the signed origin account.
+        #[pallet::call_index(1)]
+        #[pallet::weight({10_000})]
+        pub fn rotate_key(
+            origin: OriginFor<T>,
+            new_key: CreatorOf<T>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+            let profile_id = AccountProfiles::<T>::get(&who).ok_or(Error::<T>::ProfileNotFound)?;
+            
+            let mut profile = Profiles::<T>::get(&profile_id).ok_or(Error::<T>::ProfileNotFound)?;
+            let old_key = profile.latest_key;
+
+            ensure!(
+                old_key != new_key, 
+                Error::<T>::CannotRotateToSameAccount
+            );
+
+            profile.latest_key = new_key.clone();
+            Profiles::<T>::insert(&profile_id, profile);
+
+            AccountProfiles::<T>::insert(&new_key, &profile_id);
+            AccountProfiles::<T>::remove(&who);
+
+            Self::record_activity(&profile_id, b"KeyRotated")?;
+            Self::deposit_event(Event::KeyRotated { who, identifier: profile_id, new_key });
+
+            Ok(())
+        }
+    }
+}
+
+
+impl<T: Config> Pallet<T> {
+	/// Records an activity using a provided event message.
+	pub fn record_activity(identifier: &Ss58Identifier, msg: &[u8]) -> DispatchResult {
+		let entry: EntryTypeOf =
+			msg.to_vec().try_into().map_err(|_| Error::<T>::InvalidEntryTypeInput)?;
+		let stamp = EventStamp::current::<T>();
+		<cord_uri::Pallet<T> as Identifier>::record_activity(identifier, entry, stamp)
+			.map_err(|_| Error::<T>::ActivityUpdateFailed)?;
+		Ok(())
+	}
+}
+
+// TODO:
+// 1. Use with_transactional! for ensuring atomicity between connected stroages.
+// 2. Have a way through runtime constants where we would be able to configure deposits for ops.

--- a/pallets/profile/src/lib.rs
+++ b/pallets/profile/src/lib.rs
@@ -17,11 +17,26 @@
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 //
 
+//! # Pallet Profile
+//!
+//! The Profle pallet provides a framework for creating and managing
+//! identities within the CORD blockchain that can be persisted and not tied
+//! for a specific account. 
+//! Pallet Profile allows to create identities tied to a unique CORD URI which 
+//! can be watched/subscribed on its activities.
+//! Pallet Profile allows for rotation of keys without losing the data tied with 
+//! account created. 
+//! 
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod types;
 
-use frame_support::{ensure, storage::types::StorageMap, BoundedVec};
+use frame_support::{
+    ensure,
+    storage::types::StorageMap,
+    BoundedVec
+};
 pub use crate::{pallet::*, types::*};
 use codec::Encode;
 use sp_runtime::traits::Hash;
@@ -131,6 +146,8 @@ pub mod pallet {
         InvalidEntryTypeInput,
         /// Rotation must be to new key, not to existing tied account.
         CannotRotateToSameAccount,
+        /// Storage transaction has failed abrubtly.
+        TransactionFailed,
     }
 
     #[pallet::event]
@@ -155,23 +172,23 @@ pub mod pallet {
     #[pallet::call]
     impl<T: Config> Pallet<T> {
         /// Creates a new Profile with associated details.
-		///
+        ///
         /// This extrinsic creates a new Profile to be mapped to a CORD account.
-		/// Also it expects a vector of Data Keys and its values. 
+        /// Also it expects a vector of Data Keys and its values. 
         /// This HashMap is tied to the generated Profile Identifier.
         /// But currently expects the user given Data Keys to start with `pub_` prefix only.
         ///
-		/// # Parameters
-		/// - `origin`: The origin of the call, which must be signed by the creator of the profile.
-		/// - `data`: The data is a vector of a HashMap of the Data Key and associated Data Values.
-		///
-		/// # Returns
-		/// Returns `Ok(())` if the Profile is succesfully been created.
-		/// or an `Err` if the operation fails due to a same profile already existing.
-		///
-		/// # Errors
+        /// # Parameters
+        /// - `origin`: The origin of the call, which must be signed by the creator of the profile.
+        /// - `data`: The data is a vector of a HashMap of the Data Key and associated Data Values.
+        ///
+        /// # Returns
+        /// Returns `Ok(())` if the Profile is succesfully been created.
+        /// or an `Err` if the operation fails due to a same profile already existing.
+        ///
+        /// # Errors
         /// - `InvalidIdentifierLength`: If the newly creted Profile Identifier exceeds limit.
-		/// - `ProfileAlreadyExists`: If the newly created Profile already exists. 
+        /// - `ProfileAlreadyExists`: If the newly created Profile already exists. 
         ///   This happens if a user creates a duplicate profile with the same account key-pair.
         /// - `InvalidKeyPrefix`: If the Profile Data Key starts with anything other than `pub_`.
         #[pallet::call_index(0)]
@@ -181,6 +198,7 @@ pub mod pallet {
             data: Vec<(DataKeyOf<T>, DataValueOf<T>)>,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
+
             let digest = T::Hashing::hash(&who.encode());
             let pallet_name = <Self as frame_support::traits::PalletInfoAccess>::name();
             let profile_id = <cord_uri::Pallet<T> as Identifier>::build(&(digest).encode()[..], pallet_name)
@@ -191,42 +209,51 @@ pub mod pallet {
                 Error::<T>::ProfileAlreadyExists
             );
 
-            let profile = ProfileMetadataOf::<T> { latest_key: who.clone() }; 
+            for (key, _) in &data {
+                let key_str = sp_std::str::from_utf8(key.as_slice())
+                    .map_err(|_| Error::<T>::InvalidKeyPrefix)?;
+                ensure!(key_str.starts_with("pub_"), Error::<T>::InvalidKeyPrefix);
+            }
+
+            let profile = ProfileMetadataOf::<T> { latest_key: who.clone() };
             Profiles::<T>::insert(&profile_id, profile);
             AccountProfiles::<T>::insert(&who, &profile_id);
 
             for (key, value) in data {
-                let key_str = sp_std::str::from_utf8(key.as_slice())
-                    .map_err(|_| Error::<T>::InvalidKeyPrefix)?;
-                ensure!(key_str.starts_with("pub_"), Error::<T>::InvalidKeyPrefix);
                 ProfileData::<T>::insert(&profile_id, &key, value);
             }
 
             Self::record_activity(&profile_id, b"ProfileSet")?;
-            Self::deposit_event(Event::ProfileSet { who: who.clone(), identifier: profile_id }); 
+            Self::deposit_event(
+                Event::ProfileSet { 
+                    who: who.clone(), 
+                    identifier: profile_id
+            });
+
             Ok(())
         }
 
+
         /// Rotates the key of an existing Profile.
-		///
+        ///
         /// This extrinsic rotates the key of an existing Profile, identified through its
         /// Profile Identifier. 
         /// This must be signed by the account tied to the Profile only. 
         /// The `new-key` will be the public-key of the CORD/Substarte account tied to the Profile
         /// from here on. So all new operations will require `new-key` based acconut only.
         ///
-		/// # Parameters
-		/// - `origin`: The origin of the call, which must be signed by the owner of the profile.
-		/// - `new_key`: The new_key represnts the public key of the CORD/Substrate account for which 
+        /// # Parameters
+        /// - `origin`: The origin of the call, which must be signed by the owner of the profile.
+        /// - `new_key`: The new_key represnts the public key of the CORD/Substrate account for which 
         ///   The existing Profile Identifier will be tied to from here on. Make Sure this public key 
         ///   exists and accessible before making this call. 
         ///   This is irreversible and will tie all existing Profile Data to new-key based account.
-		///
-		/// # Returns
-		/// Returns `Ok(())` if the Profile is succesfully rotated to new-key.
-		/// or an `Err` if the operation fails due to issues regarding Profile existence.
-		///
-		/// # Errors
+        ///
+        /// # Returns
+        /// Returns `Ok(())` if the Profile is succesfully rotated to new-key.
+        /// or an `Err` if the operation fails due to issues regarding Profile existence.
+        ///
+        /// # Errors
         /// - `ProfileNotFound`: If the Profile does not exist for the signed origin account.
         #[pallet::call_index(1)]
         #[pallet::weight({10_000})]
@@ -246,13 +273,20 @@ pub mod pallet {
             );
 
             profile.latest_key = new_key.clone();
+
             Profiles::<T>::insert(&profile_id, profile);
 
             AccountProfiles::<T>::insert(&new_key, &profile_id);
             AccountProfiles::<T>::remove(&who);
 
             Self::record_activity(&profile_id, b"KeyRotated")?;
-            Self::deposit_event(Event::KeyRotated { who, identifier: profile_id, new_key });
+
+            Self::deposit_event(
+                Event::KeyRotated {
+                    who, 
+                    identifier: profile_id,
+                    new_key
+            });
 
             Ok(())
         }
@@ -273,5 +307,4 @@ impl<T: Config> Pallet<T> {
 }
 
 // TODO:
-// 1. Use with_transactional! for ensuring atomicity between connected stroages.
-// 2. Have a way through runtime constants where we would be able to configure deposits for ops.
+// 1. Have a way through runtime constants where we would be able to configure deposits for ops.

--- a/pallets/profile/src/types.rs
+++ b/pallets/profile/src/types.rs
@@ -1,0 +1,29 @@
+// This file is part of CORD – https://cord.network
+
+// Copyright (C) Dhiway Networks Pvt. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// CORD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CORD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CORD. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_runtime::RuntimeDebug;
+use sp_std::prelude::*;
+
+/// Struture to hold the Metadata of the associated Profile
+#[derive(Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, TypeInfo)]
+pub struct ProfileMetadata<CreatorOf> {
+    pub latest_key: CreatorOf,
+}

--- a/runtimes/weave/Cargo.toml
+++ b/runtimes/weave/Cargo.toml
@@ -43,7 +43,7 @@ pallet-collection = { workspace = true }
 pallet-registry = { workspace = true }
 pallet-config = { workspace = true }
 cord-uri = { workspace = true }
-
+pallet-profile = { workspace = true }
 
 # Substrate
 sp-api = { workspace = true }
@@ -289,6 +289,7 @@ std = [
 	"sp-trie/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
+	"pallet-profile/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -402,6 +403,7 @@ try-runtime = [
 	"pallet-utility/try-runtime",
 	"pallet-verify-signature/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-profile/try-runtime",
 ]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -1551,6 +1551,18 @@ impl TryFrom<RuntimeCall> for pallet_revive::Call<Runtime> {
 }
 
 parameter_types! {
+	pub const MaxDataKeyLength: u8 = 128;
+	pub const MaxDataValueLength: u32 = 1 * 1024; //1KB
+}
+
+impl pallet_profile::Config for Runtime {
+	type MaxDataKeyLength = MaxDataKeyLength;
+	type MaxDataValueLength = MaxDataValueLength;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+}
+
+parameter_types! {
 	pub MbmServiceWeight: Weight = Perbill::from_percent(80) * BlockWeights::get().max_block;
 }
 
@@ -1760,6 +1772,9 @@ mod runtime {
 	// Experimental EVM Pallet
 	#[runtime::pallet_index(108)]
 	pub type Revive = pallet_revive::Pallet<Runtime>;
+
+	#[runtime::pallet_index(109)]
+	pub type Profile = pallet_profile::Pallet<Runtime>;
 
 	#[runtime::pallet_index(255)]
 	pub type Sudo = pallet_sudo::Pallet<Runtime>;


### PR DESCRIPTION
### Pallet Profile

The current **Identity** pallet which is used for Identity management is tied up with an account and is therefore stateless. 
Watch cannot be established on the events associated to the Identity later. 
Also on the `rotation` of keys, the entire identity would be lost or have to be migrated to new key again to keep it stateful.

The new `pallet-identity` focuses on solving these issues entirely so it is much in line with our stack's needs. 
- Allows users or organisational accounts of CORD to create their identity on chain tied to a particular `CORD URI` based identifier. ( More on this later ) 
- Ownership transfer is made possible easily by just providing the new-public key which they want this Profile to be managed by here on.
- Activity or Event watching and broadcasting is made possible with the inclusion of the the Identifier based approach.
- Historical Keys can be provided for showing provenance from an external off-chain workers.

CORD URI:
This pallet uses new CORD URI based identifier which allows to extract the exact Network ID, Pallet the identifier belongs, helping to identify the route of the identifier in a multi-chain setup.

We can integrate this with our Registries, Entries, Collections and even for `myn.social` use cases to have persistent identities.

@amarts @smohan-dw 

