### PR TITLE
registry: Integrate pallet-profile into pallet-registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8536,6 +8536,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "pallet-profile",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/pallets/profile/src/lib.rs
+++ b/pallets/profile/src/lib.rs
@@ -295,6 +295,22 @@ pub mod pallet {
 
 
 impl<T: Config> Pallet<T> {
+    /// Retrieves the Profile Identifier associated with the account if exists,
+    /// Else returns appropriate errors.
+    pub fn get_profile_id(who: &CreatorOf<T>) -> Result<ProfileIdOf, Error<T>> {
+        let profile_id = AccountProfiles::<T>::get(&who).ok_or(Error::<T>::ProfileNotFound)?;
+        Profiles::<T>::get(&profile_id).ok_or(Error::<T>::ProfileNotFound)?;
+        
+        Ok(profile_id)
+    }
+
+    /// Checks if the given profile exists, else returns appropriate error of `ProfileNotFound`.
+    pub fn does_profile_exists(profile_id: &ProfileIdOf) -> Result<ProfileIdOf, Error<T>> {
+        Profiles::<T>::get(&profile_id).ok_or(Error::<T>::ProfileNotFound)?;
+        
+        Ok(profile_id.clone())
+    }
+
 	/// Records an activity using a provided event message.
 	pub fn record_activity(identifier: &Ss58Identifier, msg: &[u8]) -> DispatchResult {
 		let entry: EntryTypeOf =

--- a/pallets/registry/Cargo.toml
+++ b/pallets/registry/Cargo.toml
@@ -26,6 +26,7 @@ bitflags = { workspace = true }
 # Internal dependencies
 cord-primitives = { workspace = true }
 cord-uri = { workspace = true }
+pallet-profile = { workspace = true }
 
 # Substrate dependencies
 frame-benchmarking = { optional = true, workspace = true }
@@ -45,6 +46,7 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
+	"pallet-profile/runtime-benchmarks",
 ]
 std = [
 	"codec/std",
@@ -59,9 +61,11 @@ std = [
 	"sp-keystore/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"pallet-profile/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-profile/try-runtime",
 ]

--- a/pallets/registry/src/delegation.rs
+++ b/pallets/registry/src/delegation.rs
@@ -16,8 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
+use super::*;
 use crate::{
-	pallet::Pallet, CordAccountOf, Delegates, Error, PermissionVariant, Permissions, Ss58Identifier,
+	pallet::Pallet, Delegates, Error, PermissionVariant, Permissions, Ss58Identifier,
 };
 use frame_support::pallet_prelude::*;
 
@@ -25,8 +26,8 @@ use frame_support::pallet_prelude::*;
 /// the caller (`who`) has ADMIN or DELEGATE permissions.
 pub fn add_delegate<T: crate::Config>(
 	identifier: &Ss58Identifier,
-	who: &CordAccountOf<T>,
-	delegate: &CordAccountOf<T>,
+	who: &ProfileIdOf,
+	delegate: &ProfileIdOf,
 	roles: Vec<PermissionVariant>,
 ) -> DispatchResult {
 	ensure!(
@@ -48,8 +49,8 @@ pub fn add_delegate<T: crate::Config>(
 /// has ADMIN permission.
 pub fn remove_delegate<T: crate::Config>(
 	identifier: &Ss58Identifier,
-	who: &CordAccountOf<T>,
-	delegate: &CordAccountOf<T>,
+	who: &ProfileIdOf,
+	delegate: &ProfileIdOf,
 ) -> DispatchResult {
 	ensure!(
 		Pallet::<T>::has_permission(identifier, who, Permissions::ADMIN),

--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -32,6 +32,7 @@ use cord_uri::{EntryTypeOf, EventStamp, Identifier, RegistryIdentifierCheck, Ss5
 use frame_support::dispatch::DispatchResult;
 use frame_system::pallet_prelude::BlockNumberFor;
 use frame_system::WeightInfo;
+use pallet_profile::ProfileIdOf;
 
 #[cfg(test)]
 pub mod mock;
@@ -58,7 +59,7 @@ pub mod pallet {
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config + cord_uri::Config {
+	pub trait Config: frame_system::Config + cord_uri::Config + pallet_profile::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
@@ -77,18 +78,18 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		RegistryIdentifierOf,
-		RegistryDetails<CordAccountOf<T>, HashOf<T>, Status>,
+		RegistryDetails<HashOf<T>, Status>,
 		OptionQuery,
 	>;
 
-	/// Stores collection-level delegates (account → permissions).
+	/// Stores registry-level delegates (account → permissions).
 	#[pallet::storage]
 	pub type Delegates<T: Config> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		Ss58Identifier,
 		Blake2_128Concat,
-		CordAccountOf<T>,
+		ProfileIdOf,
 		Permissions,
 		OptionQuery,
 	>;
@@ -96,12 +97,36 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		DelegateAdded { identifier: Ss58Identifier, delegate: CordAccountOf<T> },
-		DelegateRemoved { identifier: Ss58Identifier, delegate: CordAccountOf<T> },
-		RegistryCreated { registry: RegistryIdentifierOf, creator: CordAccountOf<T> },
-		RegistryUpdated { registry: RegistryIdentifierOf, authority: CordAccountOf<T> },
-		RegistryArchived { registry: RegistryIdentifierOf, authority: CordAccountOf<T> },
-		RegistryRestored { registry: RegistryIdentifierOf, authority: CordAccountOf<T> },
+		DelegateAdded { 
+			identifier: Ss58Identifier, 
+			delegate: CordAccountOf<T>,
+			delegate_profile_id: ProfileIdOf,
+		},
+		DelegateRemoved { 
+			identifier: Ss58Identifier, 
+			delegate: CordAccountOf<T>,
+			delegate_profile_id: ProfileIdOf,
+		},
+		RegistryCreated { 
+			registry: RegistryIdentifierOf,
+			creator: CordAccountOf<T>,
+			profile_id: ProfileIdOf
+		},
+		RegistryUpdated { 
+			registry: RegistryIdentifierOf, 
+			authority: CordAccountOf<T>,
+			authority_profile_id: ProfileIdOf
+		},
+		RegistryArchived { 
+			registry: RegistryIdentifierOf, 
+			authority: CordAccountOf<T>,
+			authority_profile_id: ProfileIdOf,
+		},
+		RegistryRestored { 
+			registry: RegistryIdentifierOf, 
+			authority: CordAccountOf<T>,
+			authority_profile_id: ProfileIdOf,
+		},
 	}
 
 	#[pallet::error]
@@ -141,8 +166,26 @@ pub mod pallet {
 			roles: Vec<PermissionVariant>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			delegation::add_delegate::<T>(&identifier, &who, &delegate, roles)?;
-			Self::deposit_event(Event::DelegateAdded { identifier, delegate });
+
+			let who_profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&who
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			let delegate_profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&delegate
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			delegation::add_delegate::<T>(&identifier, &who_profile_id, &delegate_profile_id, roles)?;
+			Self::deposit_event(
+				Event::DelegateAdded { 
+					identifier, 
+					delegate, 
+					delegate_profile_id
+				}
+			);
+			
 			Ok(())
 		}
 
@@ -155,8 +198,26 @@ pub mod pallet {
 			delegate: CordAccountOf<T>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			delegation::remove_delegate::<T>(&identifier, &who, &delegate)?;
-			Self::deposit_event(Event::DelegateRemoved { identifier, delegate });
+
+			let profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&who
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			let delegate_profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&delegate
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			delegation::remove_delegate::<T>(&identifier, &profile_id, &delegate_profile_id)?;
+			Self::deposit_event(
+				Event::DelegateRemoved { 
+					identifier, 
+					delegate, 
+					delegate_profile_id,
+				}
+			);
+
 			Ok(())
 		}
 
@@ -171,34 +232,86 @@ pub mod pallet {
 			doc_node_id: Option<Vec<u8>>,
 		) -> DispatchResult {
 			let creator = ensure_signed(origin)?;
+
+			let profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&creator
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			let doc_author_profile_id = if let Some(author) = doc_author_id.clone() {
+				Some(
+					pallet_profile::Pallet::<T>::get_profile_id(&author)
+						.map_err(<pallet_profile::Error<T>>::from)?
+				)
+			} else {
+				None
+			};
+
 			let registry_id = registry::create_registry::<T>(
 				tx_hash,
 				doc_id,
-				doc_author_id,
+				doc_author_profile_id,
 				doc_node_id,
-				creator.clone(),
+				profile_id.clone(),
 			)?;
-			Self::deposit_event(Event::RegistryCreated { registry: registry_id, creator });
+
+			Self::deposit_event(
+				Event::RegistryCreated { 
+					registry: registry_id, 
+					creator, profile_id,
+				}
+			);
+
 			Ok(())
 		}
 
 		/// Archive registry
 		#[pallet::call_index(3)]
 		#[pallet::weight({10_000})]
-		pub fn archive(origin: OriginFor<T>, registry_id: RegistryIdentifierOf) -> DispatchResult {
+		pub fn archive(
+			origin: OriginFor<T>, 
+			registry_id: RegistryIdentifierOf
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			registry::archive_registry::<T>(&registry_id, who.clone())?;
-			Self::deposit_event(Event::RegistryArchived { registry: registry_id, authority: who });
+
+			let profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&who
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+			
+			registry::archive_registry::<T>(&registry_id, &profile_id)?;
+			Self::deposit_event(
+				Event::RegistryArchived { 
+					registry: registry_id, 
+					authority: who, 
+					authority_profile_id: profile_id
+				}
+			);
 			Ok(())
 		}
 
 		/// Restore registry
 		#[pallet::call_index(4)]
 		#[pallet::weight({10_000})]
-		pub fn restore(origin: OriginFor<T>, registry_id: RegistryIdentifierOf) -> DispatchResult {
+		pub fn restore(
+			origin: OriginFor<T>, 
+			registry_id: RegistryIdentifierOf
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			registry::restore_registry::<T>(&registry_id, who.clone())?;
-			Self::deposit_event(Event::RegistryRestored { registry: registry_id, authority: who });
+
+			let profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&who
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			registry::restore_registry::<T>(&registry_id, profile_id.clone())?;
+			Self::deposit_event(
+				Event::RegistryRestored { 
+					registry: registry_id, 
+					authority: who,
+					authority_profile_id: profile_id,
+				}
+			);
 			Ok(())
 		}
 
@@ -211,15 +324,29 @@ pub mod pallet {
 			new_doc_author_id: CordAccountOf<T>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
+
+			let who_profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&who
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			let new_doc_author_profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&new_doc_author_id
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
 			registry::update_registry_author::<T>(
 				&registry_id,
-				new_doc_author_id.clone(),
-				who.clone(),
+				new_doc_author_profile_id.clone(),
+				who_profile_id.clone(),
 			)?;
+
 			Self::deposit_event(Event::RegistryUpdated {
 				registry: registry_id,
 				authority: new_doc_author_id,
+				authority_profile_id: new_doc_author_profile_id
 			});
+
 			Ok(())
 		}
 
@@ -232,10 +359,27 @@ pub mod pallet {
 			new_creator: CordAccountOf<T>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			registry::update_registry_creator::<T>(&registry_id, new_creator.clone(), who.clone())?;
+
+			let who_profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&who
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			let new_creator_profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&new_creator
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			registry::update_registry_creator::<T>(
+				&registry_id, 
+				new_creator_profile_id.clone(), 
+				who_profile_id.clone()
+			)?;
+
 			Self::deposit_event(Event::RegistryUpdated {
 				registry: registry_id,
 				authority: new_creator,
+				authority_profile_id: new_creator_profile_id,
 			});
 			Ok(())
 		}
@@ -253,7 +397,7 @@ impl<T: Config> Pallet<T> {
 	/// Checks if the delegate for `who` on the given collection has any of the required permissions.
 	pub fn has_permission(
 		identifier: &Ss58Identifier,
-		who: &CordAccountOf<T>,
+		who: &ProfileIdOf,
 		required: Permissions,
 	) -> bool {
 		Delegates::<T>::get(identifier, who).unwrap_or_default().intersects(required)

--- a/pallets/registry/src/mock.rs
+++ b/pallets/registry/src/mock.rs
@@ -30,6 +30,7 @@ frame_support::construct_runtime!(
 		System: system,
 		Registry: pallet_registry,
 		Identifier: cord_uri,
+		Profile: pallet_profile,
 	}
 );
 
@@ -42,6 +43,18 @@ impl frame_system::Config for Test {
 	type Block = Block;
 	type AccountData = ();
 	type SS58Prefix = SS58Prefix;
+}
+
+parameter_types! {
+	pub const MaxDataKeyLength: u8 = 128;
+	pub const MaxDataValueLength: u32 = 1 * 1024; //1KB
+}
+
+impl pallet_profile::Config for Test {
+	type MaxDataKeyLength = MaxDataKeyLength;
+	type MaxDataValueLength = MaxDataValueLength;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
 }
 
 impl pallet_registry::Config for Test {

--- a/pallets/registry/src/registry.rs
+++ b/pallets/registry/src/registry.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
+use super::*;
 use alloc::vec::Vec;
 use codec::Encode;
 use frame_support::dispatch::DispatchResult;
@@ -23,7 +24,7 @@ use frame_support::pallet_prelude::*;
 use sp_runtime::traits::Hash;
 
 use crate::{
-	pallet::Pallet, CordAccountOf, Delegates, Error, HashOf, Identifier, Permissions, Registries,
+	pallet::Pallet, Delegates, Error, HashOf, Identifier, Permissions, Registries,
 	RegistryDetails, RegistryIdentifierOf, Status,
 };
 
@@ -40,9 +41,9 @@ pub fn push_option(buf: &mut Vec<u8>, field: Option<&[u8]>) {
 pub fn create_registry<T: crate::Config>(
 	tx_hash: HashOf<T>,
 	doc_id: Option<Vec<u8>>,
-	doc_author_id: Option<CordAccountOf<T>>,
+	doc_author_profile_id: Option<ProfileIdOf>,
 	doc_node_id: Option<Vec<u8>>,
-	creator: CordAccountOf<T>,
+	profile_id: ProfileIdOf,
 ) -> Result<RegistryIdentifierOf, sp_runtime::DispatchError> {
 	let bounded_doc_id = doc_id
 		.map(|v| v.try_into())
@@ -52,7 +53,7 @@ pub fn create_registry<T: crate::Config>(
 		.map(|v| v.try_into())
 		.transpose()
 		.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
-	let encoded_doc_author = doc_author_id.as_ref().map(|author| author.encode());
+	let encoded_doc_author = doc_author_profile_id.as_ref().map(|author| author.encode());
 
 	let mut data = Vec::with_capacity(256);
 	data.extend_from_slice(tx_hash.as_ref());
@@ -67,7 +68,7 @@ pub fn create_registry<T: crate::Config>(
 			.as_ref()
 			.map(|v: &BoundedVec<u8, ConstU32<64>>| v.as_slice()),
 	);
-	data.extend_from_slice(&creator.encode());
+	data.extend_from_slice(&profile_id.encode());
 
 	let digest = T::Hashing::hash(&data);
 	let pallet_name = <crate::pallet::Pallet<T> as frame_support::traits::PalletInfoAccess>::name();
@@ -79,19 +80,20 @@ pub fn create_registry<T: crate::Config>(
 	ensure!(!Registries::<T>::contains_key(&registry_id), Error::<T>::RegistryAlreadyExists);
 
 	let details = RegistryDetails {
-		creator: creator.clone(),
+		profile_id: profile_id.clone(),
 		tx_hash,
 		doc_id: bounded_doc_id,
-		doc_author_id: doc_author_id.clone(),
+		doc_author_profile_id: doc_author_profile_id.clone(),
 		doc_node_id: bounded_doc_node_id,
 		status: Status::Active,
 	};
 
 	Pallet::<T>::record_activity(&registry_id, b"RegistryCreated")?;
 	Registries::<T>::insert(&registry_id, details);
-	Delegates::<T>::insert(&registry_id, &creator, Permissions::all());
-	if let Some(author) = doc_author_id {
-		Delegates::<T>::insert(&registry_id, &author, Permissions::ENTRY);
+	Delegates::<T>::insert(&registry_id, &profile_id, Permissions::all());
+	
+	if let Some(author_profile_id) = doc_author_profile_id {
+		Delegates::<T>::insert(&registry_id, &author_profile_id, Permissions::ENTRY);
 	}
 	Ok(registry_id)
 }
@@ -99,7 +101,7 @@ pub fn create_registry<T: crate::Config>(
 /// Archive a registry.
 pub fn archive_registry<T: crate::Config>(
 	registry_id: &RegistryIdentifierOf,
-	who: CordAccountOf<T>,
+	who: &ProfileIdOf,
 ) -> DispatchResult {
 	Registries::<T>::try_mutate(registry_id, |maybe_registry| -> DispatchResult {
 		let registry = maybe_registry.as_mut().ok_or(Error::<T>::RegistryNotFound)?;
@@ -118,7 +120,7 @@ pub fn archive_registry<T: crate::Config>(
 /// Restore an archived registry.
 pub fn restore_registry<T: crate::Config>(
 	registry_id: &RegistryIdentifierOf,
-	who: CordAccountOf<T>,
+	who: ProfileIdOf,
 ) -> DispatchResult {
 	Registries::<T>::try_mutate(registry_id, |maybe_registry| -> DispatchResult {
 		let registry = maybe_registry.as_mut().ok_or(Error::<T>::RegistryNotFound)?;
@@ -137,8 +139,8 @@ pub fn restore_registry<T: crate::Config>(
 /// Update the document author for a registry.
 pub fn update_registry_author<T: crate::Config>(
 	registry_id: &RegistryIdentifierOf,
-	new_doc_author_id: CordAccountOf<T>,
-	who: CordAccountOf<T>,
+	new_doc_author_profile_id: ProfileIdOf,
+	who: ProfileIdOf,
 ) -> DispatchResult {
 	ensure!(
 		crate::pallet::Pallet::<T>::has_permission(registry_id, &who, Permissions::ADMIN),
@@ -148,13 +150,17 @@ pub fn update_registry_author<T: crate::Config>(
 	let mut registry = Registries::<T>::get(registry_id).ok_or(Error::<T>::RegistryNotFound)?;
 	ensure!(registry.status == Status::Active, Error::<T>::ArchivedRegistry);
 
-	let old_author = registry.doc_author_id.take();
-	registry.doc_author_id = Some(new_doc_author_id.clone());
+	let old_author = registry.doc_author_profile_id.take();
+	registry.doc_author_profile_id = Some(new_doc_author_profile_id.clone());
 
 	Pallet::<T>::record_activity(&registry_id, b"RegistryUpdated")?;
 
 	Registries::<T>::insert(registry_id, registry);
-	Delegates::<T>::insert(registry_id, &new_doc_author_id, Permissions::all());
+
+	// TODO:
+	// Why the permission here is given as Permissions::all() instead of ::ENTRY() 
+	// As it is the case during create?
+	Delegates::<T>::insert(registry_id, &new_doc_author_profile_id, Permissions::all());
 	if let Some(old) = old_author {
 		Delegates::<T>::remove(registry_id, &old);
 	}
@@ -164,8 +170,8 @@ pub fn update_registry_author<T: crate::Config>(
 /// Update registry creator
 pub fn update_registry_creator<T: crate::Config>(
 	registry_id: &RegistryIdentifierOf,
-	new_creator: CordAccountOf<T>,
-	who: CordAccountOf<T>,
+	new_profile_id: ProfileIdOf,
+	who: ProfileIdOf,
 ) -> DispatchResult {
 	Registries::<T>::try_mutate(registry_id, |maybe_registry| -> DispatchResult {
 		let registry = maybe_registry.as_mut().ok_or(Error::<T>::RegistryNotFound)?;
@@ -173,9 +179,13 @@ pub fn update_registry_creator<T: crate::Config>(
 			crate::pallet::Pallet::<T>::has_permission(registry_id, &who, Permissions::ADMIN),
 			Error::<T>::UnauthorizedOperation
 		);
-		registry.creator = new_creator;
+		registry.profile_id = new_profile_id;
 		Ok(())
 	})?;
+
+	// TODO:
+	// Would need to update the chain-state of the DELEGATES as well
+	// Is it required to remove old delegate or continue keeping him from accessing.
 
 	Pallet::<T>::record_activity(&registry_id, b"RegistryCreatorUpdated")?;
 	Ok(())

--- a/pallets/registry/src/types.rs
+++ b/pallets/registry/src/types.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
+use super::*;
 use bitflags::bitflags;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::traits::ConstU32;
@@ -88,15 +89,15 @@ pub enum Status {
 }
 
 #[derive(Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, TypeInfo)]
-pub struct RegistryDetails<Account, Hash, Status> {
-	/// The account that paid for the transaction.
-	pub creator: Account,
+pub struct RegistryDetails<Hash, Status> {
+	/// The identity of the account (profile) that paid for the transaction.
+	pub profile_id: ProfileIdOf,
 	/// The transaction hash associated with the document.
 	pub tx_hash: Hash,
 	/// Optionally, the document identifier as a bounded vector.
 	pub doc_id: Option<BoundedVec<u8, ConstU32<64>>>,
-	/// Optionally, the account that created (authored) the document.
-	pub doc_author_id: Option<Account>,
+	/// Optionally, the identity account (profile) that created (authored) the document.
+	pub doc_author_profile_id: Option<ProfileIdOf>,
 	/// Optionally, the node identifier as a bounded vector.
 	pub doc_node_id: Option<BoundedVec<u8, ConstU32<64>>>,
 	/// The status of the registry entry.


### PR DESCRIPTION
- For registry operations, profile identifier would be required and stored at storage level.  For all accounts making the transactions and also for delegates being added the `pallet-profile` is added as a dependency.