### PR TITLE
registry: Fix has_permission method 

### DIFF
--- a/pallets/entry/src/types.rs
+++ b/pallets/entry/src/types.rs
@@ -35,12 +35,4 @@ pub struct RegistryEntryDetails<RegistryEntryHashOf, StatusOf, ProfileIdOf, Regi
 	pub creator: ProfileIdOf,
 	/// Type of Reistry Entry Identifier.
 	pub registry_id: RegistryIdentifierOf,
-	// /// Optionally, the document identifier as a bounded vector.
-	// pub doc_id: Option<BoundedVec<u8, ConstU32<64>>>,
-	// /// Optionally, the identity account (profile) that created (authored) the document.
-	// pub doc_author_profile_id: Option<ProfileIdOf>,
-	// /// Optionally, the node identifier as a bounded vector.
-	// pub doc_node_id: Option<BoundedVec<u8, ConstU32<64>>>,
-	// /// Optionally, the document entry identifier as a bounded vector.
-	// pub doc_entry_id: Option<BoundedVec<u8, ConstU32<64>>>,
 }

--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -400,8 +400,7 @@ impl<T: Config> Pallet<T> {
 		who: &ProfileIdOf,
 		required: Permissions,
 	) -> bool {
-		// TODO: Bug unwrap_or_default() will return true always, since default is ENTRY.
-		Delegates::<T>::get(identifier, who).unwrap_or_default().intersects(required)
+		Delegates::<T>::get(identifier, who).unwrap_or(Permissions::empty()).intersects(required)
 	}
 
 	/// Helper function to encode an optional field into a byte buffer.


### PR DESCRIPTION
The `has_permission` method at registry had a bug, which gave positive outputs even if the `delegate` was not present.
This was due to `unwrap_or_default()` if there are no delegate present. The default was at `Permissions::Empty` allowing non existent delegate to be shown present with Entry permission.

Made the default value as `empty()` to avoid errors.