### PR TITLE
registry: Add registry hash update method

### DIFF
--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -164,6 +164,7 @@ pub mod pallet {
 		InvalidEntryTypeInput,
 		/// The activity update operation failed.
 		ActivityUpdateFailed,
+		
 	}
 
 	#[pallet::call]
@@ -394,6 +395,39 @@ pub mod pallet {
 				authority: new_creator,
 				authority_profile_id: new_creator_profile_id,
 			});
+			Ok(())
+		}
+
+		/// Updates the registry hash, optionally accepts a blob.
+		#[pallet::call_index(7)]
+		#[pallet::weight({10_000})]
+		pub fn update_registry_hash(
+			origin: OriginFor<T>, 
+			registry_id: RegistryIdentifierOf,
+			tx_hash: HashOf<T>,
+			_blob: Option<RegistryBlobOf<T>>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			let profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&who
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+			
+			registry::update_registry_hash::<T>(
+				&registry_id,
+				&profile_id,
+				&tx_hash,
+			)?;
+
+			Self::deposit_event(
+				Event::RegistryUpdated { 
+					registry: registry_id, 
+					authority: who, 
+					authority_profile_id: profile_id
+				}
+			);
+
 			Ok(())
 		}
 	}

--- a/pallets/registry/src/registry.rs
+++ b/pallets/registry/src/registry.rs
@@ -99,6 +99,31 @@ pub fn create_registry<T: crate::Config>(
 	Ok(registry_id)
 }
 
+/// Update a existing registry.
+pub fn update_registry_hash<T: crate::Config>(
+	registry_id: &RegistryIdentifierOf,
+	who: &ProfileIdOf,
+	tx_hash: &HashOf<T>,
+) -> DispatchResult {
+	Registries::<T>::try_mutate(registry_id, |maybe_registry| -> DispatchResult {
+		let registry = maybe_registry.as_mut().ok_or(Error::<T>::RegistryNotFound)?;
+
+		ensure!(
+			Pallet::<T>::has_permission(registry_id, &who, Permissions::ADMIN),
+			Error::<T>::UnauthorizedOperation
+		);
+
+		ensure!(registry.status == Status::Active, Error::<T>::ArchivedRegistry);
+
+		registry.tx_hash = *tx_hash;
+
+		Ok(())
+	})?;
+	Pallet::<T>::record_activity(registry_id, b"RegistryHashUpdated")?;
+
+	Ok(())
+}
+
 /// Archive a registry.
 pub fn archive_registry<T: crate::Config>(
 	registry_id: &RegistryIdentifierOf,
@@ -154,7 +179,7 @@ pub fn update_registry_author<T: crate::Config>(
 	let old_author = registry.doc_author_profile_id.take();
 	registry.doc_author_profile_id = Some(new_doc_author_profile_id.clone());
 
-	Pallet::<T>::record_activity(&registry_id, b"RegistryUpdated")?;
+	Pallet::<T>::record_activity(&registry_id, b"RegistryAuthorUpdated")?;
 
 	Registries::<T>::insert(registry_id, registry);
 


### PR DESCRIPTION
Adds capability to update the `tx_hash` and a optional `blob` of the Registry.