### PR TITLE
Increase endowment balances across all specs

### DIFF
--- a/node/cli/src/chain_spec/bootstrap.rs
+++ b/node/cli/src/chain_spec/bootstrap.rs
@@ -82,8 +82,9 @@ pub type CordChainSpec = sc_service::GenericChainSpec<Extensions>;
 
 // pub const BRAID_ENDOWMENT: Balance = 10_000_000 * BRAID_UNITS;
 // pub const LOOOM_ENDOWMENT: Balance = 10_000_000 * LOOM_UNITS;
-pub const ENDOWMENT: Balance = 10_000_000 * UNITS;
-const STASH: u128 = 100_000 * UNITS;
+
+const ENDOWMENT: u128 = 500_000_000_000 * UNITS;
+const STASH: u128 = 100_000_000 * UNITS;
 
 fn braid_session_keys(
 	babe: BabeId,

--- a/runtimes/braid/src/genesis_config_presets.rs
+++ b/runtimes/braid/src/genesis_config_presets.rs
@@ -85,8 +85,8 @@ fn cord_braid_testnet_genesis(
 	endowed_accounts: Option<Vec<AccountId>>,
 ) -> serde_json::Value {
 	let endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(testnet_accounts);
-	const ENDOWMENT: u128 = 500_000_000 * UNITS;
-
+	const ENDOWMENT: u128 = 500_000_000_000 * UNITS;
+	                
 	serde_json::json!( {
 		"balances": {
 			"balances": endowed_accounts.iter().map(|k| (k.clone(), ENDOWMENT)).collect::<Vec<_>>(),

--- a/runtimes/loom/src/genesis_config_presets.rs
+++ b/runtimes/loom/src/genesis_config_presets.rs
@@ -85,7 +85,8 @@ fn cord_loom_testnet_genesis(
 	endowed_accounts: Option<Vec<AccountId>>,
 ) -> serde_json::Value {
 	let endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(testnet_accounts);
-	const ENDOWMENT: u128 = 500_000_000 * UNITS;
+	
+	const ENDOWMENT: u128 = 500_000_000_000 * UNITS;
 
 	serde_json::json!( {
 		"balances": {

--- a/runtimes/weave/src/genesis_config_presets.rs
+++ b/runtimes/weave/src/genesis_config_presets.rs
@@ -84,8 +84,9 @@ fn cord_weave_testnet_genesis(
 	endowed_accounts: Option<Vec<AccountId>>,
 ) -> serde_json::Value {
 	let endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(testnet_accounts);
-	const ENDOWMENT: u128 = 500_000_000 * UNITS;
-	const STASH: u128 = 100_000 * UNITS;
+	
+	const ENDOWMENT: u128 = 500_000_000_000 * UNITS;
+	const STASH: u128 = 100_000_000 * UNITS;
 
 	serde_json::json!({
 	"balances": {


### PR DESCRIPTION
Currently set initial endowment balance is not enough for bulk transactions. Increase to 5 BN.