### PR TITLE
entry: Add Hash to Identifier Lookup

### DIFF
--- a/pallets/entry/src/lib.rs
+++ b/pallets/entry/src/lib.rs
@@ -127,7 +127,28 @@ pub mod pallet {
 	/// It maps Registry Entry Identifier to Registry Entry Details.
 	#[pallet::storage]
 	pub type RegistryEntries<T: Config> =
-		StorageMap<_, Blake2_128Concat, RegistryEntryIdOf, RegistryEntryDetailsOf<T>, OptionQuery>;
+		StorageMap<
+			_, 
+			Blake2_128Concat, 
+			RegistryEntryIdOf, 
+			RegistryEntryDetailsOf<T>, 
+			OptionQuery
+		>;
+
+	/// Storage to map for Entry hashes to corresponding Registry Identifiers.
+	/// It being a storage double-map will have the Registry Entry Hash and the Registry ID
+	/// as the key, whereas the value resulted is the Registry Entry Identifier.
+    #[pallet::storage]
+    pub type HashToIdentifier<T> = 
+        StorageDoubleMap<
+            _,
+            Blake2_128Concat,
+            RegistryEntryHashOf<T>,
+            Blake2_128Concat,
+            RegistryIdentifierOf,
+			RegistryEntryIdOf,
+            OptionQuery
+        >;
 
 	#[pallet::error]
 	pub enum Error<T> {
@@ -271,6 +292,8 @@ pub mod pallet {
 
 			RegistryEntries::<T>::insert(&registry_entry_id, registry_entry);
 
+			HashToIdentifier::<T>::insert(&tx_hash, &registry_id, &registry_entry_id);
+
             Self::record_activity(&registry_entry_id, b"RegistryEntryCreated")?;
 
 			Self::deposit_event(Event::RegistryEntryCreated {
@@ -342,6 +365,8 @@ pub mod pallet {
 			entry.tx_hash = tx_hash;
 
 			RegistryEntries::<T>::insert(&registry_entry_id, entry);
+
+			HashToIdentifier::<T>::insert(&tx_hash, &registry_id, &registry_entry_id);
 
             Self::record_activity(&registry_entry_id, b"RegistryEntryUpdated")?;
 


### PR DESCRIPTION
As the current identifiers are generated dynamically and considered as a token guaranteed to be on the chain, 
the apps/sdks would need to get the identifier generated from the content (digest) they sent which was ultimately used in part for creation of the identifier.

So create a new storage to have a lookup of identifier of registry entry based out of RegistryEntryHash and RegistryIdentifier.

In `Rust` we can iterate using `iter_prefix` for getting the identifier with registry-id being unknown.

But in `typescript` we need to fetch the entire storage and check for existence.
Example usage:
```
    const entries = await api.query.entry.hashToIdentifier.entries();
    const matches = entries
      .filter(([key]) => {
        const [key1] = key.args; 
        return key1.toHex() === tx_hash; 
      })
      .map(([key, value]) => {
        const [, registry_id] = key.args; 
        return {
          registry_id: registry_id.toHuman(), 
          registry_entry_id: value.isNone ? null : value.unwrap().toHuman(), 
        };
      });
 ```
 The above will be integrated with the demo script at SDK CORD.js
