### PR TITLE
registry: Split registry creation for native and cyra

### DIFF
--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -32,6 +32,7 @@ use cord_uri::{EntryTypeOf, EventStamp, Identifier, RegistryIdentifierCheck, Ss5
 use frame_support::dispatch::DispatchResult;
 use frame_support::BoundedVec;
 use frame_system::pallet_prelude::BlockNumberFor;
+use frame_support::traits::ConstU32;
 use frame_system::WeightInfo;
 use pallet_profile::ProfileIdOf;
 
@@ -49,6 +50,9 @@ pub type CollectionIdentifierOf = Ss58Identifier;
 pub type RegistryIdentifierOf = Ss58Identifier;
 pub type HashOf<T> = <T as frame_system::Config>::Hash;
 pub(crate) type CordAccountOf<T> = <T as frame_system::Config>::AccountId;
+
+pub type DocIdOf = BoundedVec<u8, ConstU32<64>>;
+pub type DocNodeIdOf = BoundedVec<u8, ConstU32<64>>;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -90,7 +94,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		RegistryIdentifierOf,
-		RegistryDetails<HashOf<T>, Status>,
+		RegistryDetails<HashOf<T>, Status, DocIdOf, DocNodeIdOf>,
 		OptionQuery,
 	>;
 
@@ -120,6 +124,11 @@ pub mod pallet {
 			delegate_profile_id: ProfileIdOf,
 		},
 		RegistryCreated { 
+			registry: RegistryIdentifierOf,
+			creator: CordAccountOf<T>,
+			profile_id: ProfileIdOf
+		},
+		RegistryStoreCreated { 
 			registry: RegistryIdentifierOf,
 			creator: CordAccountOf<T>,
 			profile_id: ProfileIdOf
@@ -274,18 +283,14 @@ pub mod pallet {
 
 		/// Creates a new registry.
 		///
-		/// Initializes a new registry with the provided transaction hash and optional metadata
-		/// (document ID, author, node ID). The creator must have a valid profile. The registry is
-		/// created via the `registry::create_registry` function, assigned a unique SS58 identifier,
-		/// and marked as active.
+		/// Initializes a new registry with the provided transaction hash and a optional blob.
+		/// The creator must have a valid profile. The registry is created via the `registry::create_registry` 
+		/// function, assigned a unique SS58 identifier, and marked as active.
 		///
 		/// # Arguments
 		/// * `origin` - The signed account creating the registry.
 		/// * `tx_hash` - The hash of the registry’s content.
 		/// * `_blob` - Optional data associated with the registry.
-		/// * `doc_id` - Optional document identifier.
-		/// * `doc_author_id` - Optional account ID of the document author.
-		/// * `doc_node_id` - Optional document node identifier.
 		///
 		/// # Errors
 		/// * `InvalidIdentifierLength` - If the generated registry ID is invalid.
@@ -302,9 +307,6 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			tx_hash: HashOf<T>,
 			_blob: Option<RegistryBlobOf<T>>,
-			doc_id: Option<Vec<u8>>,
-			doc_author_id: Option<CordAccountOf<T>>,
-			doc_node_id: Option<Vec<u8>>,
 		) -> DispatchResult {
 			let creator = ensure_signed(origin)?;
 
@@ -313,16 +315,69 @@ pub mod pallet {
 			)
 			.map_err(<pallet_profile::Error<T>>::from)?;
 
-			let doc_author_profile_id = if let Some(author) = doc_author_id.clone() {
-				Some(
-					pallet_profile::Pallet::<T>::get_profile_id(&author)
-						.map_err(<pallet_profile::Error<T>>::from)?
-				)
-			} else {
-				None
-			};
-
 			let registry_id = registry::create_registry::<T>(
+				tx_hash,
+				profile_id.clone(),
+			)?;
+
+			Self::deposit_event(
+				Event::RegistryCreated { 
+					registry: registry_id, 
+					creator, profile_id,
+				}
+			);
+
+			Ok(())
+		}
+
+
+		/// Creates a new registry store with cyra based credentials.
+		///
+		/// Initializes a new registry store with the provided transaction hash and optional metadata
+		/// (document ID, author, node ID). The creator must have a valid profile. The registry is
+		/// created via the `registry::create_registry_store` function, assigned a unique SS58 identifier,
+		/// and marked as active.
+		///
+		/// The key difference between create and create-store is that create-store is to map the registry
+		/// data present in Cyra into Cord.
+		///
+		/// # Arguments
+		/// * `origin` - The signed account creating the registry.
+		/// * `tx_hash` - The hash of the registry’s content.
+		/// * `_blob` - Data associated with the registry.
+		/// * `doc_id` - Document identifier.
+		/// * `doc_author_id` - Account ID of the document author.
+		/// * `doc_node_id` - Document node identifier.
+		///
+		/// # Errors
+		/// * `InvalidIdentifierLength` - If the generated registry ID is invalid.
+		/// * `RegistryAlreadyExists` - If a registry with the same ID exists.
+		/// * `pallet_profile::Error` - If the creator’s or author’s profile is invalid.
+		///
+		/// # Events
+		/// * `RegistryStoreCreated` - Emitted with `registry`, `creator`, `profile_id`.
+		///
+		/// ```
+		#[pallet::call_index(3)]
+		#[pallet::weight({10_000})]
+		pub fn create_store(
+			origin: OriginFor<T>,
+			tx_hash: HashOf<T>,
+			doc_id: Vec<u8>,
+			doc_author_id: CordAccountOf<T>,
+			doc_node_id: Vec<u8>,
+		) -> DispatchResult {
+			let creator = ensure_signed(origin)?;
+
+			let profile_id = pallet_profile::Pallet::<T>::get_profile_id(
+				&creator
+			)
+			.map_err(<pallet_profile::Error<T>>::from)?;
+
+			let doc_author_profile_id = pallet_profile::Pallet::<T>::get_profile_id(&doc_author_id)
+				.map_err(<pallet_profile::Error<T>>::from)?;
+
+			let registry_id = registry::create_registry_store::<T>(
 				tx_hash,
 				doc_id,
 				doc_author_profile_id,
@@ -331,7 +386,7 @@ pub mod pallet {
 			)?;
 
 			Self::deposit_event(
-				Event::RegistryCreated { 
+				Event::RegistryStoreCreated { 
 					registry: registry_id, 
 					creator, profile_id,
 				}
@@ -360,7 +415,7 @@ pub mod pallet {
 		/// * `RegistryArchived` - Emitted with `registry`, `authority`, `authority_profile_id`.
 		///
 		/// ```
-		#[pallet::call_index(3)]
+		#[pallet::call_index(4)]
 		#[pallet::weight({10_000})]
 		pub fn archive(
 			origin: OriginFor<T>, 
@@ -404,7 +459,7 @@ pub mod pallet {
 		/// * `RegistryRestored` - Emitted with `registry`, `authority`, `authority_profile_id`.
 		///
 		/// ```
-		#[pallet::call_index(4)]
+		#[pallet::call_index(5)]
 		#[pallet::weight({10_000})]
 		pub fn restore(
 			origin: OriginFor<T>, 
@@ -448,7 +503,7 @@ pub mod pallet {
 		/// * `RegistryUpdated` - Emitted with `registry`, `authority` (new author), `authority_profile_id`.
 		///
 		/// ```
-		#[pallet::call_index(5)]
+		#[pallet::call_index(6)]
 		#[pallet::weight({10_000})]
 		pub fn update_author(
 			origin: OriginFor<T>,
@@ -502,7 +557,7 @@ pub mod pallet {
 		/// * `RegistryUpdated` - Emitted with `registry`, `authority` (new creator), `authority_profile_id`.
 		///
 		/// ```
-		#[pallet::call_index(6)]
+		#[pallet::call_index(7)]
 		#[pallet::weight({10_000})]
 		pub fn update_creator(
 			origin: OriginFor<T>,
@@ -556,7 +611,7 @@ pub mod pallet {
 		/// * `RegistryUpdated` - Emitted with `registry`, `authority`, `authority_profile_id`.
 		///
 		/// ```
-		#[pallet::call_index(7)]
+		#[pallet::call_index(8)]
 		#[pallet::weight({10_000})]
 		pub fn update_registry_hash(
 			origin: OriginFor<T>, 

--- a/pallets/registry/src/registry.rs
+++ b/pallets/registry/src/registry.rs
@@ -28,46 +28,15 @@ use crate::{
 	RegistryDetails, RegistryIdentifierOf, Status,
 };
 
-pub fn push_option(buf: &mut Vec<u8>, field: Option<&[u8]>) {
-	if let Some(bytes) = field {
-		buf.push(1u8);
-		buf.extend_from_slice(bytes);
-	} else {
-		buf.push(0u8);
-	}
-}
 
 /// Create a new registry.
 pub fn create_registry<T: crate::Config>(
 	tx_hash: HashOf<T>,
-	doc_id: Option<Vec<u8>>,
-	doc_author_profile_id: Option<ProfileIdOf>,
-	doc_node_id: Option<Vec<u8>>,
 	profile_id: ProfileIdOf,
 ) -> Result<RegistryIdentifierOf, sp_runtime::DispatchError> {
-	let bounded_doc_id = doc_id
-		.map(|v| v.try_into())
-		.transpose()
-		.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
-	let bounded_doc_node_id = doc_node_id
-		.map(|v| v.try_into())
-		.transpose()
-		.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
-	let encoded_doc_author = doc_author_profile_id.as_ref().map(|author| author.encode());
 
 	let mut data = Vec::with_capacity(256);
 	data.extend_from_slice(tx_hash.as_ref());
-	push_option(
-		&mut data,
-		bounded_doc_id.as_ref().map(|v: &BoundedVec<u8, ConstU32<64>>| v.as_slice()),
-	);
-	push_option(&mut data, encoded_doc_author.as_ref().map(|v| v.as_slice()));
-	push_option(
-		&mut data,
-		bounded_doc_node_id
-			.as_ref()
-			.map(|v: &BoundedVec<u8, ConstU32<64>>| v.as_slice()),
-	);
 	data.extend_from_slice(&profile_id.encode());
 
 	let digest = T::Hashing::hash(&data);
@@ -82,22 +51,72 @@ pub fn create_registry<T: crate::Config>(
 	let details = RegistryDetails {
 		creator: profile_id.clone(),
 		tx_hash,
-		doc_id: bounded_doc_id,
-		doc_author_profile_id: doc_author_profile_id.clone(),
-		doc_node_id: bounded_doc_node_id,
+		doc_id: None,
+		doc_author_profile_id: None,
+		doc_node_id: None,
 		status: Status::Active,
 	};
 
 	Pallet::<T>::record_activity(&registry_id, b"RegistryCreated")?;
 	Registries::<T>::insert(&registry_id, details);
 	Delegates::<T>::insert(&registry_id, &profile_id, Permissions::all());
-
-	if let Some(author_profile_id) = doc_author_profile_id {
-		Delegates::<T>::insert(&registry_id, &author_profile_id, Permissions::ENTRY);
-	}
 	
 	Ok(registry_id)
 }
+
+
+/// Create a new registry store.
+pub fn create_registry_store<T: crate::Config>(
+	tx_hash: HashOf<T>,
+	doc_id: Vec<u8>,
+	doc_author_profile_id: ProfileIdOf,
+	doc_node_id: Vec<u8>,
+	profile_id: ProfileIdOf,
+) -> Result<RegistryIdentifierOf, sp_runtime::DispatchError> {
+	let bounded_doc_id: DocIdOf = doc_id
+        .try_into()
+        .map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+    let bounded_doc_node_id: DocNodeIdOf = doc_node_id
+        .try_into()
+        .map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+
+	let mut data = Vec::with_capacity(256);
+	data.extend_from_slice(tx_hash.as_ref());
+
+	data.extend_from_slice(&bounded_doc_id.encode());
+	data.extend_from_slice(&bounded_doc_node_id.encode());
+
+	data.extend_from_slice(&doc_author_profile_id.encode());
+	data.extend_from_slice(&profile_id.encode());
+
+	let digest = T::Hashing::hash(&data);
+	let pallet_name = <crate::pallet::Pallet<T> as frame_support::traits::PalletInfoAccess>::name();
+
+	let registry_id =
+		<cord_uri::Pallet<T> as Identifier>::build(&(digest).encode()[..], pallet_name)
+			.map_err(|_| Error::<T>::InvalidIdentifierLength)?;
+
+	ensure!(!Registries::<T>::contains_key(&registry_id), Error::<T>::RegistryAlreadyExists);
+
+	let details = RegistryDetails {
+		creator: profile_id.clone(),
+		tx_hash,
+		doc_id: Some(bounded_doc_id),
+		doc_author_profile_id: Some(doc_author_profile_id.clone()),
+		doc_node_id: Some(bounded_doc_node_id),
+		status: Status::Active,
+	};
+
+	Pallet::<T>::record_activity(&registry_id, b"RegistryStoreCreated")?;
+	Registries::<T>::insert(&registry_id, details);
+	Delegates::<T>::insert(&registry_id, &profile_id, Permissions::all());
+
+	/* Add the doc_author as a delegate for having permission to create entry */
+	Delegates::<T>::insert(&registry_id, &doc_author_profile_id, Permissions::ENTRY);
+	
+	Ok(registry_id)
+}
+
 
 /// Update a existing registry.
 pub fn update_registry_hash<T: crate::Config>(
@@ -162,6 +181,7 @@ pub fn restore_registry<T: crate::Config>(
 	Ok(())
 }
 
+
 /// Update the document author for a registry.
 pub fn update_registry_author<T: crate::Config>(
 	registry_id: &RegistryIdentifierOf,
@@ -191,6 +211,7 @@ pub fn update_registry_author<T: crate::Config>(
 	}
 	Ok(())
 }
+
 
 /// Update registry creator
 pub fn update_registry_creator<T: crate::Config>(

--- a/pallets/registry/src/types.rs
+++ b/pallets/registry/src/types.rs
@@ -19,8 +19,6 @@
 use super::*;
 use bitflags::bitflags;
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::traits::ConstU32;
-use frame_support::BoundedVec;
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 
@@ -89,17 +87,17 @@ pub enum Status {
 }
 
 #[derive(Encode, Decode, Clone, MaxEncodedLen, RuntimeDebug, PartialEq, Eq, TypeInfo)]
-pub struct RegistryDetails<Hash, Status> {
+pub struct RegistryDetails<Hash, Status, DocIdOf, DocNodeIdOf> {
 	/// The identity of the account (profile) that created/ owns the registry.
 	pub creator: ProfileIdOf,
 	/// The transaction hash associated with the document.
 	pub tx_hash: Hash,
 	/// Optionally, the document identifier as a bounded vector.
-	pub doc_id: Option<BoundedVec<u8, ConstU32<64>>>,
+	pub doc_id: Option<DocIdOf>,
 	/// Optionally, the identity account (profile) that created (authored) the document.
 	pub doc_author_profile_id: Option<ProfileIdOf>,
 	/// Optionally, the node identifier as a bounded vector.
-	pub doc_node_id: Option<BoundedVec<u8, ConstU32<64>>>,
+	pub doc_node_id: Option<DocNodeIdOf>,
 	/// The status of the registry entry.
 	pub status: Status,
 }


### PR DESCRIPTION
Splitting the current union of creation of a registry into 

- create: For creating registry natively on-chain.
- create-store: For anchoring creation of registry made on `cyra` onto `cord`

^ @amarts @smohan-dw 