### PR TITLE
toolchain: Update rust-toolchain to 1.86.0 for linux build issue fix

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.86.0"
 components = [
 	"cargo",
 	"clippy",


### PR DESCRIPTION
The previous version of rust-toolchain was not compiling on `linux` OS & hence our docker build was failing.
Updated the tool-chain to `1.86.0` for docker-hub image publish.