### PR TITLE
node, scripts: Update the bootstrap scripts and Bootstrap builder subcommand.

### DIFF
--- a/node/cli/src/chain_spec/bootstrap.rs
+++ b/node/cli/src/chain_spec/bootstrap.rs
@@ -46,6 +46,12 @@ pub use cord_weave_runtime_constants::currency::UNITS;
 
 use crate::chain_spec::{get_properties, Extensions, CORD_TELEMETRY_URL, DEFAULT_PROTOCOL_ID};
 
+use array_bytes::hex2array;
+use sp_core::{
+	crypto::{AccountId32, Ss58Codec},
+	ed25519, sr25519,
+};
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct ChainParams {
 	pub chain_name: String,
@@ -217,21 +223,130 @@ fn cord_weave_custom_config_genesis(config: ChainParams) -> serde_json::Value {
 	)> = config
 		.authorities
 		.iter()
-		.map(|auth| {
-			(
-				array_bytes::hex_n_into_unchecked(&auth[0]),
-				array_bytes::hex2array_unchecked(&auth[0]).unchecked_into(),
-				array_bytes::hex2array_unchecked(&auth[1]).unchecked_into(),
-				array_bytes::hex2array_unchecked(&auth[0]).unchecked_into(),
-				array_bytes::hex2array_unchecked(&auth[0]).unchecked_into(),
-				array_bytes::hex2array_unchecked(&auth[0]).unchecked_into(),
-			)
+		.enumerate()
+		.filter_map(|(i, auth)| {
+			if auth.len() != 6 {
+				eprintln!(
+					"Authority {} has invalid length: expected 6 keys, got {}",
+					i,
+					auth.len()
+				);
+				return None;
+			}
+
+			let account_id: AccountId = match AccountId32::from_ss58check(&auth[0]) {
+				Ok(acc) => acc,
+				Err(e) => {
+					eprintln!("Failed to decode SS58 AccountId {}: {:?}", auth[0], e);
+					return None;
+				},
+			};
+
+			let babe_id: BabeId = match array_bytes::hex2array::<_, 32>(&auth[1]) {
+				Ok(bytes) => match sp_core::sr25519::Public::try_from(&bytes[..]) {
+					Ok(pubkey) => pubkey.into(),
+					Err(_) => {
+						eprintln!(
+							"Invalid sr25519 public key for BabeId {}: not a valid key",
+							auth[1]
+						);
+						return None;
+					},
+				},
+				Err(e) => {
+					eprintln!("Failed to decode BabeId {}: {:?}", auth[1], e);
+					return None;
+				},
+			};
+
+			let grandpa_id: GrandpaId = match array_bytes::hex2array::<_, 32>(&auth[2]) {
+				Ok(bytes) => match sp_core::ed25519::Public::try_from(&bytes[..]) {
+					Ok(pubkey) => pubkey.into(),
+					Err(_) => {
+						eprintln!(
+							"Invalid ed25519 public key for GrandpaId {}: not a valid key",
+							auth[2]
+						);
+						return None;
+					},
+				},
+				Err(e) => {
+					eprintln!("Failed to decode GrandpaId {}: {:?}", auth[2], e);
+					return None;
+				},
+			};
+
+			let im_online_id: ImOnlineId = match array_bytes::hex2array::<_, 32>(&auth[3]) {
+				Ok(bytes) => match sp_core::sr25519::Public::try_from(&bytes[..]) {
+					Ok(pubkey) => pubkey.into(),
+					Err(_) => {
+						eprintln!(
+							"Invalid sr25519 public key for ImOnlineId {}: not a valid key",
+							auth[3]
+						);
+						return None;
+					},
+				},
+				Err(e) => {
+					eprintln!("Failed to decode ImOnlineId {}: {:?}", auth[3], e);
+					return None;
+				},
+			};
+
+			let authority_discovery_id: AuthorityDiscoveryId = match array_bytes::hex2array::<_, 32>(
+				&auth[4],
+			) {
+				Ok(bytes) => match sp_core::sr25519::Public::try_from(&bytes[..]) {
+					Ok(pubkey) => pubkey.into(),
+					Err(_) => {
+						eprintln!("Invalid sr25519 public key for AuthorityDiscoveryId {}: not a valid key", auth[4]);
+						return None;
+					},
+				},
+				Err(e) => {
+					eprintln!("Failed to decode AuthorityDiscoveryId {}: {:?}", auth[4], e);
+					return None;
+				},
+			};
+
+			let beefy_id: BeefyId = match array_bytes::hex2array::<_, 33>(&auth[5]) {
+				Ok(bytes) => {
+					if bytes[0] != 0x02 && bytes[0] != 0x03 {
+						eprintln!(
+							"Invalid BeefyId ECDSA key {}: must start with 0x02 or 0x03",
+							auth[5]
+						);
+						return None;
+					}
+					match sp_consensus_beefy::ecdsa_crypto::Public::try_from(&bytes[..]) {
+						Ok(pubkey) => pubkey.into(),
+						Err(e) => {
+							eprintln!("Invalid BeefyId ECDSA key format {}: {:?}", auth[5], e);
+							return None;
+						},
+					}
+				},
+				Err(e) => {
+					eprintln!("Failed to decode BeefyId {}: {:?}", auth[5], e);
+					return None;
+				},
+			};
+
+			Some((account_id, babe_id, grandpa_id, im_online_id, authority_discovery_id, beefy_id))
 		})
 		.collect();
 
-	let initial_sudo_key: AccountId = array_bytes::hex_n_into_unchecked(&config.sudo_key);
+	let initial_sudo_key: AccountId = match AccountId32::from_ss58check(&config.sudo_key) {
+		Ok(acc) => acc,
+		Err(e) => {
+			eprintln!("Failed to decode sudo key {}: {:?}", config.sudo_key, e);
+			panic!("Invalid sudo key");
+		},
+	};
+
 	cord_weave_custom_genesis(initial_authorities, initial_sudo_key)
 }
+
 pub fn cord_custom_config(config: ChainParams) -> Result<CordChainSpec, String> {
 	let chain_name = String::from(config.chain_name());
 	let chain_type = config.chain_type();

--- a/node/cli/src/chain_spec/bootstrap.rs
+++ b/node/cli/src/chain_spec/bootstrap.rs
@@ -225,9 +225,9 @@ fn cord_weave_custom_config_genesis(config: ChainParams) -> serde_json::Value {
 		.iter()
 		.enumerate()
 		.filter_map(|(i, auth)| {
-			if auth.len() != 6 {
+			if auth.len() != 4 {
 				eprintln!(
-					"Authority {} has invalid length: expected 6 keys, got {}",
+					"Authority {} has invalid length: expected 4 keys, got {}",
 					i,
 					auth.len()
 				);
@@ -276,7 +276,7 @@ fn cord_weave_custom_config_genesis(config: ChainParams) -> serde_json::Value {
 				},
 			};
 
-			let im_online_id: ImOnlineId = match array_bytes::hex2array::<_, 32>(&auth[3]) {
+			let im_online_id: ImOnlineId = match array_bytes::hex2array::<_, 32>(&auth[1]) {
 				Ok(bytes) => match sp_core::sr25519::Public::try_from(&bytes[..]) {
 					Ok(pubkey) => pubkey.into(),
 					Err(_) => {
@@ -288,28 +288,28 @@ fn cord_weave_custom_config_genesis(config: ChainParams) -> serde_json::Value {
 					},
 				},
 				Err(e) => {
-					eprintln!("Failed to decode ImOnlineId {}: {:?}", auth[3], e);
+					eprintln!("Failed to decode ImOnlineId {}: {:?}", auth[1], e);
 					return None;
 				},
 			};
 
 			let authority_discovery_id: AuthorityDiscoveryId = match array_bytes::hex2array::<_, 32>(
-				&auth[4],
+				&auth[1],
 			) {
 				Ok(bytes) => match sp_core::sr25519::Public::try_from(&bytes[..]) {
 					Ok(pubkey) => pubkey.into(),
 					Err(_) => {
-						eprintln!("Invalid sr25519 public key for AuthorityDiscoveryId {}: not a valid key", auth[4]);
+						eprintln!("Invalid sr25519 public key for AuthorityDiscoveryId {}: not a valid key", auth[1]);
 						return None;
 					},
 				},
 				Err(e) => {
-					eprintln!("Failed to decode AuthorityDiscoveryId {}: {:?}", auth[4], e);
+					eprintln!("Failed to decode AuthorityDiscoveryId {}: {:?}", auth[1], e);
 					return None;
 				},
 			};
 
-			let beefy_id: BeefyId = match array_bytes::hex2array::<_, 33>(&auth[5]) {
+			let beefy_id: BeefyId = match array_bytes::hex2array::<_, 33>(&auth[3]) {
 				Ok(bytes) => {
 					if bytes[0] != 0x02 && bytes[0] != 0x03 {
 						eprintln!(
@@ -321,13 +321,13 @@ fn cord_weave_custom_config_genesis(config: ChainParams) -> serde_json::Value {
 					match sp_consensus_beefy::ecdsa_crypto::Public::try_from(&bytes[..]) {
 						Ok(pubkey) => pubkey.into(),
 						Err(e) => {
-							eprintln!("Invalid BeefyId ECDSA key format {}: {:?}", auth[5], e);
+							eprintln!("Invalid BeefyId ECDSA key format {}: {:?}", auth[3], e);
 							return None;
 						},
 					}
 				},
 				Err(e) => {
-					eprintln!("Failed to decode BeefyId {}: {:?}", auth[5], e);
+					eprintln!("Failed to decode BeefyId {}: {:?}", auth[3], e);
 					return None;
 				},
 			};

--- a/node/cli/src/command/chain_setup.rs
+++ b/node/cli/src/command/chain_setup.rs
@@ -62,6 +62,18 @@ impl BootstrapChainCmd {
 			std::process::exit(1);
 		}
 
+		// Validate that each authority has exactly 6 keys
+		for (i, auth) in config.authorities.iter().enumerate() {
+			if auth.len() != 6 {
+				eprintln!(
+					"Error: Authority {} has invalid length: expected 6 keys, got {}",
+					i,
+					auth.len()
+				);
+				std::process::exit(1);
+			}
+		}
+
 		let chain_name = if config.chain_name.len() <= 64 {
 			config.chain_name.clone()
 		} else {
@@ -103,7 +115,16 @@ impl BootstrapChainCmd {
 		let initial_authorities: Vec<Vec<String>> = config
 			.authorities
 			.iter()
-			.map(|auth| vec![auth[1].clone(), auth[2].clone()])
+			.map(|auth| {
+				vec![
+					auth[0].clone(), // SS58 AccountId
+					auth[1].clone(), // BabeId (sr25519)
+					auth[2].clone(), // GrandpaId (ed25519)
+					auth[3].clone(), // ImOnlineId (sr25519)
+					auth[4].clone(), // AuthorityDiscoveryId (sr25519)
+					auth[5].clone(), // BeefyId (ecdsa)
+				]
+			})
 			.collect();
 
 		let initial_council_members: Vec<String> =
@@ -124,7 +145,7 @@ impl BootstrapChainCmd {
 			config
 				.authorities
 				.get(0)
-				.map(|auth| auth[1].clone())
+				.map(|auth| auth[0].clone())
 				.expect("No authorities provided; cannot set sudo_key")
 		});
 

--- a/node/cli/src/command/chain_setup.rs
+++ b/node/cli/src/command/chain_setup.rs
@@ -62,11 +62,11 @@ impl BootstrapChainCmd {
 			std::process::exit(1);
 		}
 
-		// Validate that each authority has exactly 6 keys
+		// Validate that each authority has exactly 4 keys
 		for (i, auth) in config.authorities.iter().enumerate() {
-			if auth.len() != 6 {
+			if auth.len() != 4 {
 				eprintln!(
-					"Error: Authority {} has invalid length: expected 6 keys, got {}",
+					"Error: Authority {} has invalid length: expected 4 keys, got {}",
 					i,
 					auth.len()
 				);
@@ -118,11 +118,9 @@ impl BootstrapChainCmd {
 			.map(|auth| {
 				vec![
 					auth[0].clone(), // SS58 AccountId
-					auth[1].clone(), // BabeId (sr25519)
+					auth[1].clone(), // BabeId, ImOnlineId, AuthorityDiscoveryId (sr25519)
 					auth[2].clone(), // GrandpaId (ed25519)
-					auth[3].clone(), // ImOnlineId (sr25519)
-					auth[4].clone(), // AuthorityDiscoveryId (sr25519)
-					auth[5].clone(), // BeefyId (ecdsa)
+					auth[3].clone(), // BeefyId (ecdsa)
 				]
 			})
 			.collect();

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -162,11 +162,10 @@ echo "authorities = [" >>$CONFIG_FILE
 for i in $(seq 1 $NUM_AUTHORITIES); do
   echo "[" >>$CONFIG_FILE
   get_ss58_address $i '--scheme Sr25519'         # auth[0]: SS58 AccountId
-  get_public_key $i '--scheme Sr25519'           # auth[1]: BabeId (sr25519) 
+
+  get_public_key $i '--scheme Sr25519'           # auth[1]: BabeId, ImOnlineId, AuthorityDiscoveryId (sr25519) 
   get_public_key $i '--scheme Ed25519'           # auth[2]: GrandpaId (ed25519)
-  get_public_key $i '--scheme Sr25519'           # auth[3]: ImOnlineId (sr25519)
-  get_public_key $i '--scheme Sr25519'           # auth[4]: AuthorityDiscoveryId (sr25519)
-  get_public_key $i '--scheme Ecdsa'             # auth[5]: BeefyId (ecdsa)
+  get_public_key $i '--scheme Ecdsa'             # auth[3]: BeefyId (ecdsa)
   echo "]," >>$CONFIG_FILE
 done
 echo "]" >>$CONFIG_FILE

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -20,6 +20,7 @@ function usage() {
   echo ""
   echo "  The generated configuration is written to 'config.toml' and account details to 'accounts.txt'."
 }
+
 # Defaults
 NUM_MEMBERS=6
 NUM_NODES=5
@@ -123,16 +124,19 @@ get_ss58_address() {
 }
 
 generate_account_details() {
-
   ACCOUNT_DETAILS=$($cord key inspect -n cord ${2:-} ${3:-} "$SECRET//$1")
-
   echo "Account $i" >>$ACCOUNTS_FILE
   echo "${ACCOUNT_DETAILS}" >>$ACCOUNTS_FILE
   echo "" >>$ACCOUNTS_FILE
 }
 
-echo "network_members = [" >>$CONFIG_FILE
+# Function to get public key (hex) for a given scheme
+get_public_key() {
+  PUBLIC_KEY=$($cord key inspect -n cord ${2:-} ${3:-} "$SECRET//$1" | grep "Public key (hex)" | awk '{ print $4 }')
+  echo "\"${PUBLIC_KEY#'0x'}\"," >>$CONFIG_FILE
+}
 
+echo "network_members = [" >>$CONFIG_FILE
 for i in $(seq 1 $NUM_MEMBERS); do
   generate_account_details $i '--scheme Sr25519'
   echo "[" >>$CONFIG_FILE
@@ -140,12 +144,10 @@ for i in $(seq 1 $NUM_MEMBERS); do
   get_account_id $i '--scheme Sr25519'
   echo "  ]," >>$CONFIG_FILE
 done
-
 echo "]" >>$CONFIG_FILE
 echo "" >>$CONFIG_FILE
 
 echo "well_known_nodes = [" >>$CONFIG_FILE
-
 for i in $(seq 1 $NUM_NODES); do
   echo "[" >>$CONFIG_FILE
   get_ss58_address $i '--scheme Sr25519'
@@ -153,22 +155,21 @@ for i in $(seq 1 $NUM_NODES); do
   get_account_id $i '--scheme Sr25519'
   echo "  ]," >>$CONFIG_FILE
 done
-
 echo "]" >>$CONFIG_FILE
 echo "" >>$CONFIG_FILE
 
 echo "authorities = [" >>$CONFIG_FILE
-
 for i in $(seq 1 $NUM_AUTHORITIES); do
   echo "[" >>$CONFIG_FILE
-  get_ss58_address $i '--scheme Sr25519'
-  get_account_id $i '--scheme Sr25519'
-  get_ed_account_id $i '--scheme Ed25519'
+  get_ss58_address $i '--scheme Sr25519'         # auth[0]: SS58 AccountId
+  get_public_key $i '--scheme Sr25519'           # auth[1]: BabeId (sr25519) 
+  get_public_key $i '--scheme Ed25519'           # auth[2]: GrandpaId (ed25519)
+  get_public_key $i '--scheme Sr25519'           # auth[3]: ImOnlineId (sr25519)
+  get_public_key $i '--scheme Sr25519'           # auth[4]: AuthorityDiscoveryId (sr25519)
+  get_public_key $i '--scheme Ecdsa'             # auth[5]: BeefyId (ecdsa)
   echo "]," >>$CONFIG_FILE
 done
-
 echo "]" >>$CONFIG_FILE
-
 echo "" >>$CONFIG_FILE
 
 echo "☃️ Chain configuration has been generated!"


### PR DESCRIPTION
node changes:

- Change Bootstrap Subcommand to accept 6 keys, with validation.
- In Bootstrap move away using from `hex2array_unchecked` and use `hex2array` with correct keys matching for it, example BeefyId requires `EcDsa` earlier we used account-id which was incorrect.

bootstrap script:
- Correctly output the config.toml file with correct changes on `authorities` section. So there will be 6 keys. For `AccountId,
		BabeId,
		GrandpaId,
		ImOnlineId,
		AuthorityDiscoveryId,
		BeefyId`.

Fixes: #625 