### PR TITLE
gen_key: Add beefy into session keys

### DIFF
--- a/node/cli/src/command/gen_key.rs
+++ b/node/cli/src/command/gen_key.rs
@@ -62,11 +62,12 @@ pub struct GenSessionKeysCmd {
 	pub keystore_params: KeystoreParams,
 }
 
-const KEY_TYPES: [(KeyTypeId, CryptoScheme); 4] = [
+const KEY_TYPES: [(KeyTypeId, CryptoScheme); 5] = [
 	(KeyTypeId(*b"gran"), CryptoScheme::Ed25519),
 	(KeyTypeId(*b"babe"), CryptoScheme::Sr25519),
 	(KeyTypeId(*b"imon"), CryptoScheme::Sr25519),
 	(KeyTypeId(*b"audi"), CryptoScheme::Sr25519),
+	(KeyTypeId(*b"beef"), CryptoScheme::Ecdsa),
 ];
 
 impl GenSessionKeysCmd {
@@ -81,7 +82,7 @@ impl GenSessionKeysCmd {
 		let chain_spec = cli.load_spec(&chain_id)?;
 		let config_dir = base_path.config_dir(chain_spec.id());
 
-		let mut public_keys_bytes = Vec::with_capacity(128);
+		let mut public_keys_bytes = Vec::with_capacity(161);
 		for (key_type_id, crypto_scheme) in KEY_TYPES {
 			let (keystore, public) = match self.keystore_params.keystore_config(&config_dir)? {
 				KeystoreConfig::Path { path, password } => {
@@ -100,6 +101,7 @@ impl GenSessionKeysCmd {
 		}
 
 		let mut buffer = [0; 32];
+		let mut beefy_buffer = [0; 33];
 		// grandpa
 		buffer.copy_from_slice(&public_keys_bytes[..32]);
 		println!("grandpa: {}", AccountId32::new(buffer));
@@ -110,8 +112,13 @@ impl GenSessionKeysCmd {
 		buffer.copy_from_slice(&public_keys_bytes[64..96]);
 		println!("im_online: {}", AccountId32::new(buffer));
 		// authority discovery
-		buffer.copy_from_slice(&public_keys_bytes[96..]);
+		buffer.copy_from_slice(&public_keys_bytes[96..128]);
 		println!("authority_discovery: {}", AccountId32::new(buffer));
+		// beefy 
+		beefy_buffer.copy_from_slice(&public_keys_bytes[128..]);
+		// println!("beefy (without prefix): {:?}", beefy_buffer);
+		buffer.copy_from_slice(&beefy_buffer[1..]);
+		println!("beefy: {}", AccountId32::new(buffer));
 
 		println!("Session Keys: 0x{}", hex::encode(public_keys_bytes));
 		Ok(())


### PR DESCRIPTION
Added `beefy` into session generation keys list:

```
sudo ./target/release/cord key generate-session-keys --chain=./test2/test2.raw.spec.json --suri "0x76cbc87d2f25181955c9e6cf931e8f46f4e44af70de634c908679624794bd6d6" -d ./test2/node1    
grandpa: 5DqcaXuXXPvsXxgW9JWvxmLH1uU7LHPvuA4stMxf3ZpvogpV
babe: 5EZsi5jN7C9FPzPSNQUWUccNZ34PFrKvMxLBGTYZwKCMpzdf
im_online: 5EZsi5jN7C9FPzPSNQUWUccNZ34PFrKvMxLBGTYZwKCMpzdf
authority_discovery: 5EZsi5jN7C9FPzPSNQUWUccNZ34PFrKvMxLBGTYZwKCMpzdf
beefy: 5HcCFtMLpEGZLukCCiyRFswdQu4NjMaPY92X39Ra4hD5xq5E
Session Keys: 0x4e7c82387c824ff1d27d0777cbc69b83b28a048bf819ac0fdf36963085e31e7c6eb7bf8f776d783494d773e72d947059dce8204cf5e5af2f6cda030e2b9557536eb7bf8f776d783494d773e72d947059dce8204cf5e5af2f6cda030e2b9557536eb7bf8f776d783494d773e72d947059dce8204cf5e5af2f6cda030e2b95575302f53160f4ac702d037463f1e57762e24049c070de101d6ae79b5a05139a4f19d2
```


From the explorer: session.nextKeys(). This one already had `beefy` before this PR.
```
{
  babe: 0x6eb7bf8f776d783494d773e72d947059dce8204cf5e5af2f6cda030e2b955753
  grandpa: 0x30df2104cf015443aad30ac07c21c2b29da4b9bea7c11c026a2138a6140b556d
  imOnline: 0x6eb7bf8f776d783494d773e72d947059dce8204cf5e5af2f6cda030e2b955753
  authorityDiscovery: 0x6eb7bf8f776d783494d773e72d947059dce8204cf5e5af2f6cda030e2b955753
  beefy: 0x036b11c0302b9e0e709365fdb04ed56772b9098118d920212434c4a45c1a067b8d
}
```

@amarts ^