### PR TITLE
CORD: Remove `sp-std` dependency 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,6 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std",
 ]
 
 [[package]]
@@ -2153,9 +2152,220 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std",
  "sp-weights",
  "static_assertions",
+]
+
+[[package]]
+name = "cord-service-test"
+version = "0.9.3-dev"
+dependencies = [
+ "array-bytes",
+ "async-channel 1.9.0",
+ "cord-test-runtime",
+ "cord-test-runtime-client",
+ "fdlimit",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus",
+ "sc-executor",
+ "sc-network",
+ "sc-network-sync",
+ "sc-service",
+ "sc-transaction-pool-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-storage 19.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
+ "sp-tracing 16.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
+ "sp-trie",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "cord-test-client"
+version = "0.9.3-dev"
+dependencies = [
+ "array-bytes",
+ "async-trait",
+ "futures",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus",
+ "sc-executor",
+ "sc-offchain",
+ "sc-service",
+ "serde",
+ "serde_json",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+ "tokio",
+]
+
+[[package]]
+name = "cord-test-runtime"
+version = "0.9.3-dev"
+dependencies = [
+ "array-bytes",
+ "cord-test-runtime-client",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "futures",
+ "hex-literal",
+ "log",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "sc-block-builder",
+ "sc-chain-spec",
+ "sc-executor",
+ "sc-executor-common",
+ "sc-service",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/dhiway/sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/dhiway/sdk?branch=master)",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-state-machine",
+ "sp-tracing 16.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
+ "sp-transaction-pool",
+ "sp-trie",
+ "sp-version",
+ "substrate-wasm-builder",
+ "trie-db",
+]
+
+[[package]]
+name = "cord-test-runtime-client"
+version = "0.9.3-dev"
+dependencies = [
+ "cord-test-client",
+ "cord-test-runtime",
+ "futures",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
+name = "cord-test-runtime-transaction-pool"
+version = "0.9.3-dev"
+dependencies = [
+ "cord-test-runtime-client",
+ "futures",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "sp-blockchain",
+ "sp-runtime",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cord-test-utils"
+version = "0.9.3-dev"
+dependencies = [
+ "assert_cmd",
+ "cord-primitives",
+ "futures",
+ "nix 0.29.0",
+ "regex",
+ "sc-service",
+ "substrate-rpc-client",
+ "tokio",
+ "trybuild",
+]
+
+[[package]]
+name = "cord-uri"
+version = "0.9.5"
+dependencies = [
+ "blake2 0.10.6",
+ "bs58",
+ "cord-primitives",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "hex",
+ "impl-serde",
+ "log",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/dhiway/sdk?branch=master)",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
+]
+
+[[package]]
+name = "cord-uri-runtime-api"
+version = "0.9.5"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+]
+
+[[package]]
+name = "cord-utilities"
+version = "0.9.5"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -7022,6 +7232,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pallet-asset"
+version = "0.9.3-dev"
+dependencies = [
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-chain-space",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-asset-conversion"
 version = "22.0.0"
 source = "git+https://github.com/dhiway/sdk?branch=release-v1.18.0#b7c7686ec66c9fe6dcfcd89d79f7e3607cd2e193"
@@ -7141,7 +7370,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-std",
 ]
 
 [[package]]
@@ -7388,7 +7616,6 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -7405,7 +7632,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -7420,7 +7646,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std",
 ]
 
 [[package]]
@@ -7432,7 +7657,40 @@ dependencies = [
  "pallet-session",
  "parity-scale-codec",
  "sp-runtime",
- "sp-std",
+]
+
+[[package]]
+name = "pallet-cord-statement"
+version = "0.9.5"
+dependencies = [
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-chain-space",
+ "pallet-schema",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-council-membership"
+version = "0.9.5"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-network-membership",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7448,6 +7706,55 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
+]
+
+[[package]]
+name = "pallet-did"
+version = "0.9.5"
+dependencies = [
+ "cord-identifier",
+ "cord-utilities",
+ "fluent-uri",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "pallet-chain-space",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-did-name"
+version = "0.9.5"
+dependencies = [
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-did-runtime-api"
+version = "0.9.5"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-did",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
 ]
 
 [[package]]
@@ -7482,6 +7789,30 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-entries"
+version = "0.9.5"
+dependencies = [
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "enumflags2",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-namespace",
+ "pallet-registries",
+ "pallet-schema-accounts",
+ "parity-scale-codec",
+ "scale-info",
+ "serde_json",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
  "sp-runtime",
 ]
 
@@ -7680,7 +8011,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -7726,6 +8056,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-namespace"
+version = "0.9.5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-network-membership"
 version = "0.9.7"
 dependencies = [
@@ -7740,8 +8089,27 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "sp-weights",
+]
+
+[[package]]
+name = "pallet-network-score"
+version = "0.9.5"
+dependencies = [
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-chain-space",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7934,6 +8302,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-registries"
+version = "0.9.5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-namespace",
+ "pallet-schema-accounts",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-registry"
 version = "0.9.7"
 dependencies = [
@@ -8005,7 +8395,6 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-std",
 ]
 
 [[package]]
@@ -8041,6 +8430,45 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-weights",
+]
+
+[[package]]
+name = "pallet-schema"
+version = "0.9.5"
+dependencies = [
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-chain-space",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-schema-accounts"
+version = "0.9.5"
+dependencies = [
+ "cord-identifier",
+ "cord-primitives",
+ "cord-utilities",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8241,6 +8669,19 @@ source = "git+https://github.com/dhiway/sdk?branch=release-v1.18.0#b7c7686ec66c9
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
+ "sp-api",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
+name = "pallet-transaction-weight-runtime-api"
+version = "0.9.5"
+dependencies = [
+ "frame-support",
+ "pallet-network-membership",
+ "parity-scale-codec",
+ "scale-info",
  "sp-api",
  "sp-runtime",
  "sp-weights",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,218 +2157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cord-service-test"
-version = "0.9.3-dev"
-dependencies = [
- "array-bytes",
- "async-channel 1.9.0",
- "cord-test-runtime",
- "cord-test-runtime-client",
- "fdlimit",
- "futures",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sc-block-builder",
- "sc-client-api",
- "sc-client-db",
- "sc-consensus",
- "sc-executor",
- "sc-network",
- "sc-network-sync",
- "sc-service",
- "sc-transaction-pool-api",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "sp-storage 19.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
- "sp-tracing 16.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
- "sp-trie",
- "tempfile",
- "tokio",
-]
-
-[[package]]
-name = "cord-test-client"
-version = "0.9.3-dev"
-dependencies = [
- "array-bytes",
- "async-trait",
- "futures",
- "parity-scale-codec",
- "sc-client-api",
- "sc-client-db",
- "sc-consensus",
- "sc-executor",
- "sc-offchain",
- "sc-service",
- "serde",
- "serde_json",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-keyring",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
- "tokio",
-]
-
-[[package]]
-name = "cord-test-runtime"
-version = "0.9.3-dev"
-dependencies = [
- "array-bytes",
- "cord-test-runtime-client",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-rpc-runtime-api",
- "futures",
- "hex-literal",
- "log",
- "pallet-babe",
- "pallet-balances",
- "pallet-timestamp",
- "parity-scale-codec",
- "sc-block-builder",
- "sc-chain-spec",
- "sc-executor",
- "sc-executor-common",
- "sc-service",
- "scale-info",
- "serde",
- "serde_json",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-consensus",
- "sp-consensus-aura",
- "sp-consensus-babe",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/dhiway/sdk?branch=master)",
- "sp-externalities 0.25.0 (git+https://github.com/dhiway/sdk?branch=master)",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-keyring",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-state-machine",
- "sp-tracing 16.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
- "sp-transaction-pool",
- "sp-trie",
- "sp-version",
- "substrate-wasm-builder",
- "trie-db",
-]
-
-[[package]]
-name = "cord-test-runtime-client"
-version = "0.9.3-dev"
-dependencies = [
- "cord-test-client",
- "cord-test-runtime",
- "futures",
- "sc-block-builder",
- "sc-client-api",
- "sc-consensus",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-runtime",
-]
-
-[[package]]
-name = "cord-test-runtime-transaction-pool"
-version = "0.9.3-dev"
-dependencies = [
- "cord-test-runtime-client",
- "futures",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sc-transaction-pool",
- "sc-transaction-pool-api",
- "sp-blockchain",
- "sp-runtime",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cord-test-utils"
-version = "0.9.3-dev"
-dependencies = [
- "assert_cmd",
- "cord-primitives",
- "futures",
- "nix 0.29.0",
- "regex",
- "sc-service",
- "substrate-rpc-client",
- "tokio",
- "trybuild",
-]
-
-[[package]]
-name = "cord-uri"
-version = "0.9.5"
-dependencies = [
- "blake2 0.10.6",
- "bs58",
- "cord-primitives",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "hex",
- "impl-serde",
- "log",
- "parity-scale-codec",
- "primitive-types",
- "scale-info",
- "serde",
- "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/dhiway/sdk?branch=master)",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
- "sp-storage 19.0.0 (git+https://github.com/dhiway/sdk?branch=master)",
-]
-
-[[package]]
-name = "cord-uri-runtime-api"
-version = "0.9.5"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
-]
-
-[[package]]
-name = "cord-utilities"
-version = "0.9.5"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime",
- "sp-weights",
-]
-
-[[package]]
 name = "cord-weave-runtime"
 version = "0.9.7"
 dependencies = [
@@ -7232,25 +7020,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "pallet-asset"
-version = "0.9.3-dev"
-dependencies = [
- "cord-identifier",
- "cord-primitives",
- "cord-utilities",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-chain-space",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-asset-conversion"
 version = "22.0.0"
 source = "git+https://github.com/dhiway/sdk?branch=release-v1.18.0#b7c7686ec66c9fe6dcfcd89d79f7e3607cd2e193"
@@ -7660,40 +7429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-cord-statement"
-version = "0.9.5"
-dependencies = [
- "cord-identifier",
- "cord-primitives",
- "cord-utilities",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-chain-space",
- "pallet-schema",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
-]
-
-[[package]]
-name = "pallet-council-membership"
-version = "0.9.5"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-network-membership",
- "parity-scale-codec",
- "scale-info",
- "sp-io",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-delegated-staking"
 version = "7.0.0"
 source = "git+https://github.com/dhiway/sdk?branch=release-v1.18.0#b7c7686ec66c9fe6dcfcd89d79f7e3607cd2e193"
@@ -7706,55 +7441,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
-]
-
-[[package]]
-name = "pallet-did"
-version = "0.9.5"
-dependencies = [
- "cord-identifier",
- "cord-utilities",
- "fluent-uri",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-balances",
- "pallet-chain-space",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
-]
-
-[[package]]
-name = "pallet-did-name"
-version = "0.9.5"
-dependencies = [
- "cord-utilities",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
-]
-
-[[package]]
-name = "pallet-did-runtime-api"
-version = "0.9.5"
-dependencies = [
- "frame-support",
- "frame-system",
- "pallet-did",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
 ]
 
 [[package]]
@@ -7789,30 +7475,6 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime",
-]
-
-[[package]]
-name = "pallet-entries"
-version = "0.9.5"
-dependencies = [
- "cord-identifier",
- "cord-primitives",
- "cord-utilities",
- "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-namespace",
- "pallet-registries",
- "pallet-schema-accounts",
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-core",
- "sp-io",
- "sp-keystore",
  "sp-runtime",
 ]
 
@@ -8011,6 +7673,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8056,25 +7719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-namespace"
-version = "0.9.5"
-dependencies = [
- "bitflags 1.3.2",
- "cord-identifier",
- "cord-primitives",
- "cord-utilities",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-network-membership"
 version = "0.9.7"
 dependencies = [
@@ -8090,26 +7734,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-weights",
-]
-
-[[package]]
-name = "pallet-network-score"
-version = "0.9.5"
-dependencies = [
- "cord-identifier",
- "cord-primitives",
- "cord-utilities",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-chain-space",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
 ]
 
 [[package]]
@@ -8302,28 +7926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-registries"
-version = "0.9.5"
-dependencies = [
- "bitflags 1.3.2",
- "cord-identifier",
- "cord-primitives",
- "cord-utilities",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-namespace",
- "pallet-schema-accounts",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-registry"
 version = "0.9.7"
 dependencies = [
@@ -8430,45 +8032,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-weights",
-]
-
-[[package]]
-name = "pallet-schema"
-version = "0.9.5"
-dependencies = [
- "cord-identifier",
- "cord-primitives",
- "cord-utilities",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-chain-space",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
-]
-
-[[package]]
-name = "pallet-schema-accounts"
-version = "0.9.5"
-dependencies = [
- "cord-identifier",
- "cord-primitives",
- "cord-utilities",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
 ]
 
 [[package]]
@@ -8669,19 +8232,6 @@ source = "git+https://github.com/dhiway/sdk?branch=release-v1.18.0#b7c7686ec66c9
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
- "sp-weights",
-]
-
-[[package]]
-name = "pallet-transaction-weight-runtime-api"
-version = "0.9.5"
-dependencies = [
- "frame-support",
- "pallet-network-membership",
- "parity-scale-codec",
- "scale-info",
  "sp-api",
  "sp-runtime",
  "sp-weights",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -74,7 +74,6 @@ sp-transaction-storage-proof = { features = [
 	"std",
 ], workspace = true, default-features = true }
 sp-keyring = { workspace = true, default-features = true }
-sp-std = { workspace = true, default-features = true }
 sp-maybe-compressed-blob = { workspace = true, default-features = true }
 sp-mmr-primitives = { workspace = true, default-features = true }
 sp-statement-store = { workspace = true, default-features = true }

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -74,6 +74,7 @@ sp-transaction-storage-proof = { features = [
 	"std",
 ], workspace = true, default-features = true }
 sp-keyring = { workspace = true, default-features = true }
+sp-std = { workspace = true, default-features = true }
 sp-maybe-compressed-blob = { workspace = true, default-features = true }
 sp-mmr-primitives = { workspace = true, default-features = true }
 sp-statement-store = { workspace = true, default-features = true }

--- a/node/cli/src/chain_spec/bootstrap.rs
+++ b/node/cli/src/chain_spec/bootstrap.rs
@@ -38,7 +38,9 @@ use sp_consensus_babe::AuthorityId as BabeId;
 use sp_consensus_beefy::ecdsa_crypto::AuthorityId as BeefyId;
 use sp_core::crypto::UncheckedInto;
 use sp_runtime::Perbill;
-use sp_std::collections::btree_map::BTreeMap;
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
 
 // pub use cord_braid_runtime_constants::currency::UNITS as BRAID_UNITS;
 // pub use cord_loom_runtime_constants::currency::UNITS as LOOM_UNITS;

--- a/node/cli/src/chain_spec/bootstrap.rs
+++ b/node/cli/src/chain_spec/bootstrap.rs
@@ -38,9 +38,7 @@ use sp_consensus_babe::AuthorityId as BabeId;
 use sp_consensus_beefy::ecdsa_crypto::AuthorityId as BeefyId;
 use sp_core::crypto::UncheckedInto;
 use sp_runtime::Perbill;
-extern crate alloc;
-
-use alloc::collections::BTreeMap;
+use sp_std::collections::btree_map::BTreeMap;
 
 // pub use cord_braid_runtime_constants::currency::UNITS as BRAID_UNITS;
 // pub use cord_loom_runtime_constants::currency::UNITS as LOOM_UNITS;

--- a/node/cli/src/command/gen_key.rs
+++ b/node/cli/src/command/gen_key.rs
@@ -23,7 +23,9 @@ use sc_keystore::LocalKeystore;
 use sc_service::config::{BasePath, KeystoreConfig};
 use sp_core::crypto::{AccountId32, KeyTypeId, SecretString};
 use sp_keystore::{Keystore, KeystorePtr};
-use std::sync::Arc;
+
+extern crate alloc;
+use alloc::sync::Arc;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum KeySubcommand {

--- a/node/cli/src/command/gen_key.rs
+++ b/node/cli/src/command/gen_key.rs
@@ -23,9 +23,7 @@ use sc_keystore::LocalKeystore;
 use sc_service::config::{BasePath, KeystoreConfig};
 use sp_core::crypto::{AccountId32, KeyTypeId, SecretString};
 use sp_keystore::{Keystore, KeystorePtr};
-
-extern crate alloc;
-use alloc::sync::Arc;
+use std::sync::Arc;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum KeySubcommand {

--- a/pallets/asset/Cargo.toml
+++ b/pallets/asset/Cargo.toml
@@ -32,7 +32,6 @@ frame-benchmarking = { optional = true, workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
@@ -59,7 +58,6 @@ std = [
 	"sp-runtime/std",
 	"sp-core/std",
 	"sp-io/std",
-	"sp-std/std",
 	"pallet-chain-space/std",
 	"sp-keystore?/std",
 ]

--- a/pallets/asset/src/lib.rs
+++ b/pallets/asset/src/lib.rs
@@ -53,7 +53,6 @@ pub mod pallet {
 		traits::{Hash, Zero},
 		BoundedVec,
 	};
-	use sp_std::{prelude::Clone, str};
 
 	///SS58 Asset Identifier
 	pub type AssetIdOf = Ss58Identifier;

--- a/pallets/asset/src/mock.rs
+++ b/pallets/asset/src/mock.rs
@@ -28,6 +28,9 @@ use sp_runtime::{
 	BuildStorage, MultiSignature,
 };
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 type Signature = MultiSignature;
 type AccountPublic = <Signature as Verify>::Signer;
 pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
@@ -120,7 +123,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/asset/src/tests.rs
+++ b/pallets/asset/src/tests.rs
@@ -6,7 +6,6 @@ use frame_support::{assert_err, assert_ok, BoundedVec};
 use frame_system::RawOrigin;
 use pallet_chain_space::{SpaceCodeOf, SpaceIdOf};
 use sp_runtime::{traits::Hash, AccountId32};
-use sp_std::prelude::*;
 
 /// Generates a space ID from a digest.
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {

--- a/pallets/chain-space/Cargo.toml
+++ b/pallets/chain-space/Cargo.toml
@@ -37,8 +37,6 @@ sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
-
 
 [features]
 default = ['std']
@@ -62,7 +60,6 @@ std = [
 	"sp-io/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/chain-space/src/mock.rs
+++ b/pallets/chain-space/src/mock.rs
@@ -27,6 +27,9 @@ use sp_runtime::{
 	BuildStorage, MultiSignature,
 };
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 type Signature = MultiSignature;
 type AccountPublic = <Signature as Verify>::Signer;
 pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
@@ -116,7 +119,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/chain-space/src/tests.rs
+++ b/pallets/chain-space/src/tests.rs
@@ -5,7 +5,6 @@ use cord_utilities::mock::{mock_origin::DoubleOrigin, SubjectId};
 use frame_support::{assert_err, assert_ok, error::BadOrigin};
 use frame_system::RawOrigin;
 use sp_runtime::{traits::Hash, AccountId32};
-use sp_std::prelude::*;
 
 pub fn generate_space_id<T: Config>(digest: &SpaceCodeOf<T>) -> SpaceIdOf {
 	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Space).unwrap()

--- a/pallets/collection/Cargo.toml
+++ b/pallets/collection/Cargo.toml
@@ -37,7 +37,6 @@ sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
 sp-runtime = { workspace = true }
 
-
 [features]
 default = ['std']
 runtime-benchmarks = [
@@ -59,7 +58,6 @@ std = [
 	"sp-io/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
-	"pallet-identifier/std",
 	"pallet-profile/std",
 ]
 try-runtime = [

--- a/pallets/collection/src/benchmarking.rs
+++ b/pallets/collection/src/benchmarking.rs
@@ -22,7 +22,6 @@ use super::*;
 use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
 use sp_core::H256;
-use sp_std::prelude::*;
 
 benchmarks! {
 	create {

--- a/pallets/collection/src/tests.rs
+++ b/pallets/collection/src/tests.rs
@@ -22,7 +22,6 @@ use crate::mock::*;
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 use sp_core::H256;
-use sp_std::prelude::*;
 
 /// Helper function to extract the collection identifier.
 fn get_collection_id() -> CollectionIdentifierOf {

--- a/pallets/did-name/Cargo.toml
+++ b/pallets/did-name/Cargo.toml
@@ -32,7 +32,6 @@ cord-utilities = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { optional = true, workspace = true }
 
 # Benchmarking dependencies
@@ -56,7 +55,6 @@ std = [
 	"frame-benchmarking?/std",
 	"sp-runtime/std",
 	"sp-core/std",
-	"sp-std/std",
 	"cord-utilities/std",
 	"sp-io?/std",
 	"sp-keystore/std"

--- a/pallets/did-name/src/benchmarking.rs
+++ b/pallets/did-name/src/benchmarking.rs
@@ -26,7 +26,8 @@ use frame_support::{
 };
 use frame_system::RawOrigin;
 use sp_runtime::app_crypto::sr25519;
-use sp_std::{vec, vec::Vec};
+extern crate alloc;
+use alloc::{vec, vec::Vec};
 
 use cord_utilities::traits::GenerateBenchmarkOrigin;
 

--- a/pallets/did-name/src/did_name.rs
+++ b/pallets/did-name/src/did_name.rs
@@ -22,7 +22,11 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use core::ops::Deref;
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{ensure, sp_runtime::SaturatedConversion, traits::Get, BoundedVec};
-use scale_info::{prelude::vec::Vec, TypeInfo};
+use scale_info::TypeInfo;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
 use sp_runtime::{
 	traits::{Debug, PhantomData},
 	RuntimeDebug,

--- a/pallets/did-name/src/did_name.rs
+++ b/pallets/did-name/src/did_name.rs
@@ -17,14 +17,16 @@
 
 // You should have received a copy of the GNU General Public License
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
-
-use sp_std::{fmt::Debug, marker::PhantomData, ops::Deref, vec::Vec};
-
 use crate::{Config, Error};
+use codec::{Decode, Encode, MaxEncodedLen};
+use core::ops::Deref;
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{ensure, sp_runtime::SaturatedConversion, traits::Get, BoundedVec};
-use scale_info::TypeInfo;
-use sp_runtime::RuntimeDebug;
+use scale_info::{prelude::vec::Vec, TypeInfo};
+use sp_runtime::{
+	traits::{Debug, PhantomData},
+	RuntimeDebug,
+};
 
 const NAME_SEPARATOR: u8 = b'@';
 const NETWORK_SUFFIX: &[u8] = b"cord";

--- a/pallets/did-name/src/lib.rs
+++ b/pallets/did-name/src/lib.rs
@@ -46,7 +46,8 @@ pub mod pallet {
 		Blake2_128Concat,
 	};
 	use frame_system::pallet_prelude::*;
-	use sp_std::{fmt::Debug, vec::Vec};
+	use scale_info::prelude::vec::Vec;
+	use sp_runtime::traits::Debug;
 
 	use cord_utilities::traits::CallSources;
 

--- a/pallets/did-name/src/lib.rs
+++ b/pallets/did-name/src/lib.rs
@@ -46,7 +46,10 @@ pub mod pallet {
 		Blake2_128Concat,
 	};
 	use frame_system::pallet_prelude::*;
-	use scale_info::prelude::vec::Vec;
+
+	extern crate alloc;
+	use alloc::vec::Vec;
+
 	use sp_runtime::traits::Debug;
 
 	use cord_utilities::traits::CallSources;

--- a/pallets/did-name/src/mock.rs
+++ b/pallets/did-name/src/mock.rs
@@ -35,6 +35,9 @@ type AccountPublic = <Signature as Verify>::Signer;
 type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
 pub(crate) type Block = frame_system::mocking::MockBlock<Test>;
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 frame_support::construct_runtime!(
 	pub enum Test{
 		System: frame_system,
@@ -98,7 +101,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/did/Cargo.toml
+++ b/pallets/did/Cargo.toml
@@ -38,7 +38,6 @@ frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 # Benchmarking dependencies
 frame-benchmarking = { optional = true, workspace = true }
@@ -70,7 +69,6 @@ std = [
 	"sp-io/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"fluent-uri/std",
 	"frame-benchmarking?/std"
 ]

--- a/pallets/did/src/benchmarking.rs
+++ b/pallets/did/src/benchmarking.rs
@@ -28,7 +28,10 @@ use sp_io::crypto::{
 	ecdsa_generate, ecdsa_sign, ed25519_generate, ed25519_sign, sr25519_generate, sr25519_sign,
 };
 use sp_runtime::{traits::IdentifyAccount, AccountId32, MultiSigner};
-use sp_std::{convert::TryInto, vec::Vec};
+
+extern crate alloc;
+use alloc::vec::Vec;
+use core::convert::TryInto;
 
 use cord_utilities::signature::VerifySignature;
 

--- a/pallets/did/src/did_details.rs
+++ b/pallets/did/src/did_details.rs
@@ -32,14 +32,17 @@ use crate::{
 	utils, AccountIdOf, Config, DidAuthorizedCallOperationOf, DidCreationDetailsOf, KeyIdOf,
 	Payload,
 };
-// use frame_system::pallet_prelude::BlockNumberFor;
+
 use scale_info::TypeInfo;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
 use sp_core::{ecdsa, ed25519, sr25519};
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
 	MultiSignature, SaturatedConversion,
 };
-use sp_std::{convert::TryInto, vec::Vec};
 
 /// Public verification key that a DID can control.
 #[derive(

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -122,7 +122,10 @@ use sp_runtime::{
 	traits::{Dispatchable, Saturating, Zero},
 	SaturatedConversion,
 };
-use sp_std::{boxed::Box, fmt::Debug, prelude::Clone};
+
+extern crate alloc;
+use alloc::boxed::Box;
+use core::{clone::Clone, fmt::Debug};
 
 #[cfg(feature = "runtime-benchmarks")]
 use frame_system::RawOrigin;

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -32,6 +32,9 @@ use sp_runtime::{
 	BuildStorage, MultiSignature, MultiSigner,
 };
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 #[cfg(feature = "runtime-benchmarks")]
 use frame_system::EnsureSigned;
 
@@ -311,7 +314,7 @@ impl DeriveDidCallAuthorizationVerificationKeyRelationship for RuntimeCall {
 	// Always return a System::remark() extrinsic call
 	#[cfg(feature = "runtime-benchmarks")]
 	fn get_call_for_did_call_benchmark() -> Self {
-		RuntimeCall::System(frame_system::Call::remark { remark: sp_std::vec![] })
+		RuntimeCall::System(frame_system::Call::remark { remark: alloc::vec![] })
 	}
 }
 
@@ -344,7 +347,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/did/src/mock_utils.rs
+++ b/pallets/did/src/mock_utils.rs
@@ -20,13 +20,13 @@
 
 use frame_support::storage::bounded_btree_set::BoundedBTreeSet;
 use frame_system::pallet_prelude::BlockNumberFor;
+
 use sp_runtime::{AccountId32, SaturatedConversion};
-use sp_std::{
-	collections::btree_set::BTreeSet,
-	convert::{TryFrom, TryInto},
-	vec,
-	vec::Vec,
-};
+
+extern crate alloc;
+
+use alloc::{collections::BTreeSet, vec, vec::Vec};
+use core::convert::{TryFrom, TryInto};
 
 use crate::{
 	did_details::{

--- a/pallets/did/src/origin.rs
+++ b/pallets/did/src/origin.rs
@@ -22,8 +22,7 @@ use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use cord_utilities::traits::CallSources;
 use frame_support::traits::EnsureOrigin;
 use scale_info::TypeInfo;
-use sp_runtime::RuntimeDebug;
-use sp_std::marker::PhantomData;
+use sp_runtime::{traits::PhantomData, RuntimeDebug};
 
 /// Origin for modules that support DID-based authorization.
 #[derive(

--- a/pallets/did/src/service_endpoints.rs
+++ b/pallets/did/src/service_endpoints.rs
@@ -23,9 +23,9 @@ use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{ensure, traits::Get, BoundedVec};
 use scale_info::TypeInfo;
 use sp_runtime::{traits::SaturatedConversion, RuntimeDebug};
-use sp_std::str;
 #[cfg(any(test, feature = "runtime-benchmarks"))]
-use sp_std::{convert::TryInto, vec::Vec};
+extern crate alloc;
+use alloc::str;
 
 use crate::utils as crate_utils;
 

--- a/pallets/did/src/signature.rs
+++ b/pallets/did/src/signature.rs
@@ -20,9 +20,10 @@
 use cord_utilities::signature::{
 	SignatureVerificationError, SignatureVerificationResult, VerifySignature,
 };
-use frame_support::weights::Weight;
+use frame_support::{pallet_prelude::PhantomData, weights::Weight};
 use sp_runtime::SaturatedConversion;
-use sp_std::{marker::PhantomData, vec::Vec};
+extern crate alloc;
+use alloc::vec::Vec;
 
 use crate::{
 	did_details::{DidSignature, DidVerificationKeyRelationship},

--- a/pallets/did/src/tests.rs
+++ b/pallets/did/src/tests.rs
@@ -24,10 +24,10 @@ use frame_system::pallet_prelude::BlockNumberFor;
 
 use sp_core::{ed25519, Pair};
 use sp_runtime::{traits::BadOrigin, SaturatedConversion};
-use sp_std::{
-	collections::btree_set::BTreeSet,
-	convert::{TryFrom, TryInto},
-};
+extern crate alloc;
+
+use alloc::{collections::BTreeSet, vec, vec::Vec};
+use core::convert::{TryFrom, TryInto};
 
 use crate::{
 	self as did,

--- a/pallets/did/src/try_state.rs
+++ b/pallets/did/src/try_state.rs
@@ -20,7 +20,9 @@
 
 use cord_utilities::test_utils::log_and_return_error_message;
 use frame_support::ensure;
-use scale_info::prelude::format;
+extern crate alloc;
+use alloc::format;
+
 use sp_core::Get;
 use sp_runtime::{SaturatedConversion, TryRuntimeError};
 

--- a/pallets/did/src/utils.rs
+++ b/pallets/did/src/utils.rs
@@ -22,7 +22,9 @@ use codec::Encode;
 use fluent_uri::Uri;
 use scale_info::prelude::format;
 use sp_runtime::traits::Hash;
-use sp_std::vec::Vec;
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 use crate::{did_details::DidPublicKey, AccountIdOf, Config, KeyIdOf};
 // URI base used to test validity of provided service IDs (URI fragments).

--- a/pallets/did/src/utils.rs
+++ b/pallets/did/src/utils.rs
@@ -20,10 +20,10 @@
 
 use codec::Encode;
 use fluent_uri::Uri;
-use scale_info::prelude::format;
+extern crate alloc;
+use alloc::format;
 use sp_runtime::traits::Hash;
 
-extern crate alloc;
 use alloc::vec::Vec;
 
 use crate::{did_details::DidPublicKey, AccountIdOf, Config, KeyIdOf};

--- a/pallets/entries/Cargo.toml
+++ b/pallets/entries/Cargo.toml
@@ -23,7 +23,6 @@ enumflags2 = { workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-io = { workspace = true }
 sp-core = { workspace = true }
 identifier = { workspace = true }
@@ -64,7 +63,6 @@ std = [
 	"sp-io/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"identifier/std",
 	"cord-utilities/std",
 	"pallet-namespace/std",

--- a/pallets/entries/src/lib.rs
+++ b/pallets/entries/src/lib.rs
@@ -59,7 +59,9 @@ use identifier::{
 };
 
 pub use pallet::*;
-use sp_std::{prelude::*, str};
+
+extern crate alloc;
+use alloc::str;
 
 pub use frame_system::WeightInfo;
 pub use types::RegistryEntryDetails;

--- a/pallets/entries/src/mock.rs
+++ b/pallets/entries/src/mock.rs
@@ -22,6 +22,9 @@ use cord_utilities::mock::{mock_origin, SubjectId};
 use frame_support::{derive_impl, parameter_types};
 use pallet_namespace::IsPermissioned;
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 use frame_system::EnsureRoot;
 use sp_runtime::{
 	traits::{IdentifyAccount, IdentityLookup, Verify},
@@ -142,7 +145,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/entries/src/tests.rs
+++ b/pallets/entries/src/tests.rs
@@ -22,7 +22,6 @@ use codec::Encode;
 use frame_support::{assert_err, assert_ok, BoundedVec};
 use serde_json::json;
 use sp_runtime::traits::Hash;
-use sp_std::prelude::*;
 
 use pallet_namespace::{NameSpaceCodeOf, NameSpaceIdOf};
 use pallet_registries::{RegistryBlobOf, RegistryHashOf};

--- a/pallets/entries/src/types.rs
+++ b/pallets/entries/src/types.rs
@@ -23,7 +23,6 @@
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
-use sp_std::prelude::*;
 
 #[derive(
 	Encode,

--- a/pallets/entry/src/lib.rs
+++ b/pallets/entry/src/lib.rs
@@ -40,8 +40,6 @@
 //! * `update_ownership` - Updates the ownership of the Registry Entry.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
-use alloc::vec::Vec;
 mod types;
 
 #[cfg(test)]

--- a/pallets/entry/src/lib.rs
+++ b/pallets/entry/src/lib.rs
@@ -59,6 +59,9 @@ use sp_runtime::traits::Hash;
 
 pub use pallet::*;
 
+extern crate alloc;
+use alloc::{str, vec::Vec};
+
 pub use frame_system::WeightInfo;
 pub use types::RegistryEntryDetails;
 

--- a/pallets/identifier/src/benchmarking.rs
+++ b/pallets/identifier/src/benchmarking.rs
@@ -23,7 +23,6 @@ use crate::pallet;
 use codec::TryFrom;
 use frame_benchmarking::v2::*;
 use frame_support::traits::Get;
-use sp_std::prelude::*;
 
 benchmarks! {
    get_or_add_pallet_index {

--- a/pallets/identifier/src/tests.rs
+++ b/pallets/identifier/src/tests.rs
@@ -21,7 +21,6 @@ use super::*;
 use crate::mock::{new_test_ext, Test};
 use frame_support::{assert_err, assert_ok};
 use sp_core::H256;
-use sp_std::prelude::*;
 
 /// Test that a valid pallet name can be stored and returns a consistent index.
 #[test]

--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -24,7 +24,6 @@ enumflags2 = { workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-io = { workspace = true }
 
 frame-benchmarking = { optional = true, workspace = true }
@@ -47,7 +46,6 @@ std = [
 	"sp-io/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/identity/src/legacy.rs
+++ b/pallets/identity/src/legacy.rs
@@ -26,7 +26,6 @@ use enumflags2::{bitflags, BitFlags};
 use frame_support::{traits::Get, CloneNoBound, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound};
 use scale_info::{build::Variants, Path, Type, TypeInfo};
 use sp_runtime::{BoundedVec, RuntimeDebug};
-use sp_std::prelude::*;
 
 use crate::types::{Data, IdentityInformationProvider};
 

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -87,6 +87,7 @@ pub mod legacy;
 mod tests;
 mod types;
 pub mod weights;
+use scale_info::prelude::{boxed::Box, vec::Vec};
 
 use crate::types::{AuthorityPropertiesOf, Suffix, Username};
 use codec::Encode;
@@ -100,7 +101,7 @@ pub use pallet::*;
 use sp_runtime::traits::{
 	AppendZerosInput, Hash, IdentifyAccount, Saturating, StaticLookup, Verify,
 };
-use sp_std::prelude::*;
+
 pub use types::{
 	Data, IdentityInformationProvider, Judgement, RegistrarIndex, RegistrarInfo, Registration,
 };

--- a/pallets/identity/src/lib.rs
+++ b/pallets/identity/src/lib.rs
@@ -87,7 +87,9 @@ pub mod legacy;
 mod tests;
 mod types;
 pub mod weights;
-use scale_info::prelude::{boxed::Box, vec::Vec};
+extern crate alloc;
+
+use alloc::{boxed::Box, vec::Vec};
 
 use crate::types::{AuthorityPropertiesOf, Suffix, Username};
 use codec::Encode;

--- a/pallets/identity/src/types.rs
+++ b/pallets/identity/src/types.rs
@@ -26,9 +26,10 @@ use frame_support::{
 	traits::{ConstU32, Get},
 	BoundedVec, CloneNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 };
+extern crate alloc;
+use alloc::{vec, vec::Vec};
 use scale_info::{
 	build::{Fields, Variants},
-	prelude::vec,
 	Path, Type, TypeInfo,
 };
 use sp_runtime::{traits::Member, RuntimeDebug};

--- a/pallets/identity/src/types.rs
+++ b/pallets/identity/src/types.rs
@@ -28,10 +28,12 @@ use frame_support::{
 };
 use scale_info::{
 	build::{Fields, Variants},
+	prelude::vec,
 	Path, Type, TypeInfo,
 };
 use sp_runtime::{traits::Member, RuntimeDebug};
-use sp_std::{fmt::Debug, iter::once, prelude::*};
+
+use core::{fmt::Debug, iter::once};
 
 /// An identifier for a single name registrar/identity verification service.
 pub type RegistrarIndex = u32;
@@ -67,7 +69,7 @@ impl Data {
 }
 
 impl Decode for Data {
-	fn decode<I: codec::Input>(input: &mut I) -> sp_std::result::Result<Self, codec::Error> {
+	fn decode<I: codec::Input>(input: &mut I) -> core::result::Result<Self, codec::Error> {
 		let b = input.read_byte()?;
 		Ok(match b {
 			0 => Data::None,
@@ -289,7 +291,7 @@ impl<
 		IdentityInfo: IdentityInformationProvider,
 	> Decode for Registration<AccountId, MaxJudgements, IdentityInfo>
 {
-	fn decode<I: codec::Input>(input: &mut I) -> sp_std::result::Result<Self, codec::Error> {
+	fn decode<I: codec::Input>(input: &mut I) -> core::result::Result<Self, codec::Error> {
 		let (judgements, info) = Decode::decode(&mut AppendZerosInput::new(input))?;
 		Ok(Self { judgements, info })
 	}

--- a/pallets/membership/Cargo.toml
+++ b/pallets/membership/Cargo.toml
@@ -29,7 +29,6 @@ frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [features]
 default = ["std"]
@@ -41,7 +40,6 @@ std = [
 	"scale-info/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"pallet-network-membership/std",
 ]
 runtime-benchmarks = [

--- a/pallets/membership/src/lib.rs
+++ b/pallets/membership/src/lib.rs
@@ -47,7 +47,8 @@ pub mod benchmarking;
 pub mod tests;
 
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
-use scale_info::prelude::vec::Vec;
+extern crate alloc;
+use alloc::{collections::BTreeSet, vec::Vec};
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -126,7 +127,6 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config<I>, I: 'static> BuildGenesisConfig for GenesisConfig<T, I> {
 		fn build(&self) {
-			use scale_info::prelude::collections::BTreeSet;
 			let members_set: BTreeSet<_> = self.members.iter().collect();
 			assert_eq!(
 				members_set.len(),

--- a/pallets/membership/src/lib.rs
+++ b/pallets/membership/src/lib.rs
@@ -31,7 +31,6 @@ use frame_support::{
 	BoundedVec,
 };
 use sp_runtime::traits::{IsMember, StaticLookup, UniqueSaturatedInto};
-use sp_std::prelude::*;
 
 pub mod weights;
 
@@ -48,6 +47,7 @@ pub mod benchmarking;
 pub mod tests;
 
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
+use scale_info::prelude::vec::Vec;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -126,7 +126,7 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config<I>, I: 'static> BuildGenesisConfig for GenesisConfig<T, I> {
 		fn build(&self) {
-			use sp_std::collections::btree_set::BTreeSet;
+			use scale_info::prelude::collections::BTreeSet;
 			let members_set: BTreeSet<_> = self.members.iter().collect();
 			assert_eq!(
 				members_set.len(),

--- a/pallets/meta-tx/Cargo.toml
+++ b/pallets/meta-tx/Cargo.toml
@@ -23,7 +23,6 @@ frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [dev-dependencies]
 pallet-balances = { workspace = true, default-features = true }
@@ -44,7 +43,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/meta-tx/src/lib.rs
+++ b/pallets/meta-tx/src/lib.rs
@@ -64,7 +64,8 @@ pub use pallet::*;
 pub use weights::WeightInfo;
 mod extension;
 pub use extension::MetaTxMarker;
-use scale_info::prelude::boxed::Box;
+extern crate alloc;
+use alloc::boxed::Box;
 
 use core::ops::Add;
 use frame_support::{

--- a/pallets/meta-tx/src/lib.rs
+++ b/pallets/meta-tx/src/lib.rs
@@ -64,6 +64,7 @@ pub use pallet::*;
 pub use weights::WeightInfo;
 mod extension;
 pub use extension::MetaTxMarker;
+use scale_info::prelude::boxed::Box;
 
 use core::ops::Add;
 use frame_support::{
@@ -77,7 +78,6 @@ use sp_runtime::{
 		AsTransactionAuthorizedOrigin, DispatchTransaction, Dispatchable, TransactionExtension,
 	},
 };
-use sp_std::prelude::*;
 
 /// Meta Transaction type.
 ///

--- a/pallets/namespace/Cargo.toml
+++ b/pallets/namespace/Cargo.toml
@@ -37,8 +37,6 @@ sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
-
 
 [features]
 default = ['std']
@@ -61,8 +59,7 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-keystore/std",
-	"sp-runtime/std",
-	"sp-std/std",
+	"sp-runtime/std"
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/namespace/src/mock.rs
+++ b/pallets/namespace/src/mock.rs
@@ -115,7 +115,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(sync::Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/namespace/src/tests.rs
+++ b/pallets/namespace/src/tests.rs
@@ -3,7 +3,6 @@ use crate::mock::*;
 use codec::Encode;
 use frame_support::assert_ok;
 use sp_runtime::traits::Hash;
-use sp_std::prelude::*;
 
 /// Generate a namespace id from a digest.
 pub fn generate_namespace_id<T: Config>(digest: &NameSpaceCodeOf<T>) -> NameSpaceIdOf {

--- a/pallets/network-membership/Cargo.toml
+++ b/pallets/network-membership/Cargo.toml
@@ -25,7 +25,6 @@ network-membership = { workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { optional = true, workspace = true }
 sp-weights = { features = ["serde"], workspace = true }
 frame-benchmarking = { optional = true, workspace = true }
@@ -46,7 +45,6 @@ std = [
 	"frame-benchmarking?/std",
 	"sp-runtime/std",
 	"sp-core/std",
-	"sp-std/std",
 	"serde/std",
 	"frame-support/std",
 	"sp-io/std",

--- a/pallets/network-membership/src/lib.rs
+++ b/pallets/network-membership/src/lib.rs
@@ -38,12 +38,12 @@ use frame_support::{
 	traits::{Get, OriginTrait},
 	DefaultNoBound,
 };
+use scale_info::prelude::collections::BTreeMap;
 use sp_runtime::{
 	impl_tx_ext_default,
-	traits::{DispatchInfoOf, TransactionExtension, Zero},
+	traits::{DispatchInfoOf, PhantomData, TransactionExtension, Zero},
 	transaction_validity::{InvalidTransaction, ValidTransaction},
 };
-use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, prelude::*};
 
 pub use weights::WeightInfo;
 pub mod types;

--- a/pallets/network-membership/src/lib.rs
+++ b/pallets/network-membership/src/lib.rs
@@ -38,7 +38,10 @@ use frame_support::{
 	traits::{Get, OriginTrait},
 	DefaultNoBound,
 };
-use scale_info::prelude::collections::BTreeMap;
+
+extern crate alloc;
+use alloc::collections::BTreeMap;
+
 use sp_runtime::{
 	impl_tx_ext_default,
 	traits::{DispatchInfoOf, PhantomData, TransactionExtension, Zero},

--- a/pallets/network-membership/src/types.rs
+++ b/pallets/network-membership/src/types.rs
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::*;
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::dispatch::DispatchClass;
 use scale_info::TypeInfo;

--- a/pallets/network-score/Cargo.toml
+++ b/pallets/network-score/Cargo.toml
@@ -32,12 +32,10 @@ frame-benchmarking = { optional = true, workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
 pallet-timestamp = { workspace = true }
-
 
 [features]
 default = ['std']
@@ -61,7 +59,6 @@ std = [
 	"sp-runtime/std",
 	"sp-core/std",
 	"sp-io/std",
-	"sp-std/std",
 	"pallet-chain-space/std",
 	"pallet-timestamp/std",
 	"identifier/std",

--- a/pallets/network-score/src/lib.rs
+++ b/pallets/network-score/src/lib.rs
@@ -129,7 +129,9 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 	pub use identifier::{IdentifierCreator, IdentifierTimeline, IdentifierType, Ss58Identifier};
 	use sp_runtime::traits::Hash;
-	use sp_std::{prelude::Clone, str};
+
+	extern crate alloc;
+	use alloc::str;
 
 	/// SS58 Chain Space Identifier
 	pub type SpaceIdOf = Ss58Identifier;

--- a/pallets/network-score/src/mock.rs
+++ b/pallets/network-score/src/mock.rs
@@ -125,7 +125,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(sync::Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/network-score/src/tests.rs
+++ b/pallets/network-score/src/tests.rs
@@ -24,7 +24,6 @@ use frame_support::{assert_err, assert_ok, BoundedVec};
 use frame_system::RawOrigin;
 use pallet_chain_space::SpaceCodeOf;
 use sp_runtime::{traits::Hash, AccountId32};
-use sp_std::prelude::*;
 
 pub fn generate_rating_id<T: Config>(digest: &RatingEntryHashOf<T>) -> RatingEntryIdOf {
 	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Rating).unwrap()

--- a/pallets/node-authorization/Cargo.toml
+++ b/pallets/node-authorization/Cargo.toml
@@ -29,7 +29,6 @@ frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [features]
 default = ["std"]
@@ -44,7 +43,6 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/node-authorization/src/lib.rs
+++ b/pallets/node-authorization/src/lib.rs
@@ -52,9 +52,12 @@ pub mod weights;
 
 pub use crate::{pallet::*, types::*, weights::WeightInfo};
 use cord_primitives::NodeId;
+use scale_info::prelude::{collections::BTreeSet, vec::Vec};
 use sp_core::OpaquePeerId as PeerId;
 use sp_runtime::traits::StaticLookup;
-use sp_std::{collections::btree_set::BTreeSet, iter::FromIterator, prelude::*};
+
+extern crate alloc;
+use alloc::str;
 
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 
@@ -448,7 +451,7 @@ impl<T: Config> Pallet<T> {
 		WellKnownNodes::<T>::put(peer_ids);
 
 		nodes.iter().for_each(|(node_id, who)| {
-			if let Ok(encoded) = sp_std::str::from_utf8(node_id) {
+			if let Ok(encoded) = str::from_utf8(node_id) {
 				if let Ok(node_id_bytes) =
 					frame_support::BoundedVec::try_from(encoded.as_bytes().to_vec())
 				{
@@ -480,7 +483,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn generate_peer_id(node_identity: &NodeId) -> Result<PeerId, Error<T>> {
-		let encoded = sp_std::str::from_utf8(node_identity).map_err(|_| Error::<T>::InvalidUtf8)?;
+		let encoded = str::from_utf8(node_identity).map_err(|_| Error::<T>::InvalidUtf8)?;
 		let decoded = bs58::decode(encoded)
 			.into_vec()
 			.map_err(|_| Error::<T>::InvalidNodeIdentifier)?;

--- a/pallets/node-authorization/src/lib.rs
+++ b/pallets/node-authorization/src/lib.rs
@@ -52,12 +52,13 @@ pub mod weights;
 
 pub use crate::{pallet::*, types::*, weights::WeightInfo};
 use cord_primitives::NodeId;
-use scale_info::prelude::{collections::BTreeSet, vec::Vec};
-use sp_core::OpaquePeerId as PeerId;
-use sp_runtime::traits::StaticLookup;
 
 extern crate alloc;
+use alloc::{collections::BTreeSet, vec::Vec};
+
 use alloc::str;
+use sp_core::OpaquePeerId as PeerId;
+use sp_runtime::traits::StaticLookup;
 
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 

--- a/pallets/node-authorization/src/weights.rs
+++ b/pallets/node-authorization/src/weights.rs
@@ -22,7 +22,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 pub trait WeightInfo {
 	fn add_well_known_node() -> Weight;

--- a/pallets/offences/Cargo.toml
+++ b/pallets/offences/Cargo.toml
@@ -25,7 +25,6 @@ scale-info = { features = ["derive"], workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { workspace = true }
 sp-staking = { workspace = true }
 
@@ -42,7 +41,6 @@ std = [
 	"scale-info/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"sp-core/std",
 	"sp-io/std",
 ]

--- a/pallets/offences/src/lib.rs
+++ b/pallets/offences/src/lib.rs
@@ -37,12 +37,12 @@ mod mock;
 mod tests;
 
 use core::marker::PhantomData;
+use scale_info::prelude::vec::Vec;
 
 use codec::Encode;
 use frame_support::weights::Weight;
 use sp_runtime::traits::Hash;
 use sp_staking::offence::{Kind, Offence, OffenceDetails, OffenceError, ReportOffence};
-use sp_std::prelude::*;
 
 pub use pallet::*;
 

--- a/pallets/offences/src/lib.rs
+++ b/pallets/offences/src/lib.rs
@@ -37,7 +37,8 @@ mod mock;
 mod tests;
 
 use core::marker::PhantomData;
-use scale_info::prelude::vec::Vec;
+extern crate alloc;
+use alloc::vec::Vec;
 
 use codec::Encode;
 use frame_support::weights::Weight;

--- a/pallets/profile/src/lib.rs
+++ b/pallets/profile/src/lib.rs
@@ -30,7 +30,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod types;
+
 extern crate alloc;
+use alloc::{str, string::String};
+
 pub use crate::{pallet::*, types::*};
 use alloc::str;
 use codec::Encode;
@@ -191,8 +194,9 @@ pub mod pallet {
 			ensure!(!Profiles::<T>::contains_key(&profile_id), Error::<T>::ProfileAlreadyExists);
 
 			for (key, _) in &data {
-				let key_str =
-					str::from_utf8(key.as_slice()).map_err(|_| Error::<T>::InvalidKeyPrefix)?;
+				let key_str = str::from_utf8(key.as_slice())
+					.map_err(|_| Error::<T>::InvalidKeyPrefix)
+					.map(String::from)?;
 				ensure!(key_str.starts_with("pub_"), Error::<T>::InvalidKeyPrefix);
 			}
 

--- a/pallets/profile/src/lib.rs
+++ b/pallets/profile/src/lib.rs
@@ -35,7 +35,6 @@ extern crate alloc;
 use alloc::{str, string::String};
 
 pub use crate::{pallet::*, types::*};
-use alloc::str;
 use codec::Encode;
 use frame_support::{
 	ensure, pallet_prelude::DispatchResult, storage::types::StorageMap, BoundedVec,

--- a/pallets/registries/Cargo.toml
+++ b/pallets/registries/Cargo.toml
@@ -40,7 +40,6 @@ sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [features]
 default = ['std']
@@ -65,7 +64,6 @@ std = [
 	"sp-io/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"pallet-namespace/std",
 	"pallet-schema-accounts/std",
 ]

--- a/pallets/registries/src/benchmarking.rs
+++ b/pallets/registries/src/benchmarking.rs
@@ -8,7 +8,6 @@ use frame_system::RawOrigin;
 use identifier::{IdentifierType, Ss58Identifier};
 use pallet_namespace::{NameSpaceCodeOf, NameSpaceIdOf};
 use pallet_schema_accounts::{InputSchemaOf, SchemaHashOf};
-use sp_std::prelude::*;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());

--- a/pallets/registries/src/mock.rs
+++ b/pallets/registries/src/mock.rs
@@ -129,7 +129,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(sync::Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/registries/src/tests.rs
+++ b/pallets/registries/src/tests.rs
@@ -5,7 +5,6 @@ use frame_support::{assert_err, assert_ok};
 use pallet_namespace::{NameSpaceCodeOf, NameSpaceIdOf};
 use pallet_schema_accounts::{InputSchemaOf, SchemaHashOf};
 use sp_runtime::traits::Hash;
-use sp_std::prelude::*;
 
 pub fn generate_registry_id<T: Config>(digest: &RegistryHashOf<T>) -> RegistryIdOf {
 	Ss58Identifier::create_identifier(&(digest).encode()[..], IdentifierType::Registries).unwrap()

--- a/pallets/registry/src/benchmarking.rs
+++ b/pallets/registry/src/benchmarking.rs
@@ -22,7 +22,6 @@ use super::*;
 use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
 use sp_core::H256;
-use sp_std::prelude::*;
 
 benchmarks! {
 	// Benchmark for registry creation.

--- a/pallets/runtime-upgrade/Cargo.toml
+++ b/pallets/runtime-upgrade/Cargo.toml
@@ -21,7 +21,6 @@ scale-info = { features = ["derive"], workspace = true }
 # Substrate dependencies
 frame-system = { workspace = true }
 frame-support = { workspace = true }
-sp-std = { workspace = true }
 
 [features]
 default = ['std']
@@ -29,7 +28,6 @@ std = [
 	'codec/std',
 	'frame-support/std',
 	'frame-system/std',
-	'sp-std/std',
 	'scale-info/std',
 ]
 try-runtime = [

--- a/pallets/runtime-upgrade/src/lib.rs
+++ b/pallets/runtime-upgrade/src/lib.rs
@@ -30,7 +30,8 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
-	use scale_info::prelude::vec::Vec;
+	extern crate alloc;
+	use alloc::vec::Vec;
 
 	#[pallet::pallet]
 	#[pallet::without_storage_info]

--- a/pallets/runtime-upgrade/src/lib.rs
+++ b/pallets/runtime-upgrade/src/lib.rs
@@ -29,7 +29,8 @@ pub use pallet::*;
 pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use sp_std::vec::Vec;
+
+	use scale_info::prelude::vec::Vec;
 
 	#[pallet::pallet]
 	#[pallet::without_storage_info]

--- a/pallets/schema-accounts/Cargo.toml
+++ b/pallets/schema-accounts/Cargo.toml
@@ -33,7 +33,6 @@ frame-benchmarking = { optional = true, workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
@@ -52,7 +51,6 @@ std = [
 	"sp-runtime/std",
 	"sp-core/std",
 	"sp-io/std",
-	"sp-std/std",
 	"log/std",
 	"sp-keystore?/std",
 ]

--- a/pallets/schema-accounts/src/mock.rs
+++ b/pallets/schema-accounts/src/mock.rs
@@ -86,7 +86,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(sync::Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/schema-accounts/src/tests.rs
+++ b/pallets/schema-accounts/src/tests.rs
@@ -22,7 +22,6 @@ use codec::Encode;
 use frame_support::{assert_err, assert_ok, BoundedVec};
 use sp_core::H256;
 use sp_runtime::traits::Hash;
-use sp_std::prelude::*;
 const DEFAULT_SCHEMA_HASH_SEED: u64 = 1u64;
 const ALTERNATIVE_SCHEMA_HASH_SEED: u64 = 2u64;
 

--- a/pallets/schema/Cargo.toml
+++ b/pallets/schema/Cargo.toml
@@ -34,7 +34,6 @@ frame-benchmarking = { optional = true, workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
@@ -53,7 +52,6 @@ std = [
 	"sp-runtime/std",
 	"sp-core/std",
 	"sp-io/std",
-	"sp-std/std",
 	"pallet-chain-space/std",
 	"log/std",
 	"sp-keystore?/std",

--- a/pallets/schema/src/benchmarking.rs
+++ b/pallets/schema/src/benchmarking.rs
@@ -24,7 +24,8 @@ use cord_utilities::traits::GenerateBenchmarkOrigin;
 use frame_benchmarking::{account, benchmarks};
 use frame_support::{sp_runtime::traits::Hash, traits::Get, BoundedVec};
 use frame_system::RawOrigin;
-use scale_info::prelude::vec::Vec;
+extern crate alloc;
+use alloc::vec::Vec;
 
 const SEED: u32 = 0;
 

--- a/pallets/schema/src/benchmarking.rs
+++ b/pallets/schema/src/benchmarking.rs
@@ -24,10 +24,7 @@ use cord_utilities::traits::GenerateBenchmarkOrigin;
 use frame_benchmarking::{account, benchmarks};
 use frame_support::{sp_runtime::traits::Hash, traits::Get, BoundedVec};
 use frame_system::RawOrigin;
-use sp_std::{
-	convert::{TryFrom, TryInto},
-	vec::Vec,
-};
+use scale_info::prelude::vec::Vec;
 
 const SEED: u32 = 0;
 

--- a/pallets/schema/src/mock.rs
+++ b/pallets/schema/src/mock.rs
@@ -115,7 +115,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(sync::Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/pallets/schema/src/tests.rs
+++ b/pallets/schema/src/tests.rs
@@ -24,7 +24,6 @@ use frame_support::{assert_err, assert_noop, assert_ok, BoundedVec};
 use frame_system::RawOrigin;
 use sp_core::H256;
 use sp_runtime::{traits::Hash, AccountId32};
-use sp_std::prelude::*;
 const DEFAULT_SCHEMA_HASH_SEED: u64 = 1u64;
 const ALTERNATIVE_SCHEMA_HASH_SEED: u64 = 2u64;
 

--- a/pallets/session-benchmarking/Cargo.toml
+++ b/pallets/session-benchmarking/Cargo.toml
@@ -22,7 +22,6 @@ frame-benchmarking = { optional = true, workspace = true }
 frame-system = { workspace = true }
 pallet-session = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 
 [features]
 default = ["std"]
@@ -32,7 +31,6 @@ std = [
 	"frame-system/std",
 	"pallet-session/std",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 try-runtime = [
 	"frame-system/try-runtime",

--- a/pallets/session-benchmarking/src/lib.rs
+++ b/pallets/session-benchmarking/src/lib.rs
@@ -19,7 +19,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg(feature = "runtime-benchmarks")]
 use codec::Decode;
-use sp_std::{prelude::*, vec};
+
+use scale_info::prelude::vec::Vec;
 
 use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;

--- a/pallets/session-benchmarking/src/lib.rs
+++ b/pallets/session-benchmarking/src/lib.rs
@@ -20,7 +20,8 @@
 #![cfg(feature = "runtime-benchmarks")]
 use codec::Decode;
 
-use scale_info::prelude::vec::Vec;
+extern crate alloc;
+use alloc::vec::Vec;
 
 use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_system::RawOrigin;

--- a/pallets/statement/Cargo.toml
+++ b/pallets/statement/Cargo.toml
@@ -34,7 +34,6 @@ frame-benchmarking = { optional = true, workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
@@ -61,7 +60,6 @@ std = [
 	"cord-utilities/std",
 	"sp-runtime/std",
 	"sp-io/std",
-	"sp-std/std",
 	"sp-keystore/std",
 	"pallet-chain-space/std",
 	"pallet-schema/std",

--- a/pallets/statement/src/lib.rs
+++ b/pallets/statement/src/lib.rs
@@ -90,12 +90,13 @@ use alloc::str;
 pub mod types;
 pub mod weights;
 pub use crate::{pallet::*, types::*, weights::WeightInfo};
+use alloc::vec::Vec;
 use frame_system::pallet_prelude::BlockNumberFor;
 use identifier::{
 	types::{CallTypeOf, IdentifierTypeOf, Timepoint},
 	EventEntryOf,
 };
-use scale_info::prelude::vec::Vec;
+
 use sp_runtime::SaturatedConversion;
 
 #[frame_support::pallet]

--- a/pallets/statement/src/lib.rs
+++ b/pallets/statement/src/lib.rs
@@ -83,7 +83,10 @@ pub mod tests;
 use cord_primitives::StatusOf;
 use frame_support::{ensure, storage::types::StorageMap};
 use sp_runtime::traits::UniqueSaturatedInto;
-use sp_std::{prelude::Clone, str};
+
+extern crate alloc;
+use alloc::str;
+
 pub mod types;
 pub mod weights;
 pub use crate::{pallet::*, types::*, weights::WeightInfo};
@@ -92,8 +95,8 @@ use identifier::{
 	types::{CallTypeOf, IdentifierTypeOf, Timepoint},
 	EventEntryOf,
 };
+use scale_info::prelude::vec::Vec;
 use sp_runtime::SaturatedConversion;
-use sp_std::{vec, vec::Vec};
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/statement/src/mock.rs
+++ b/pallets/statement/src/mock.rs
@@ -132,7 +132,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(sync::Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/primitives/cord/src/identifier.rs
+++ b/primitives/cord/src/identifier.rs
@@ -56,7 +56,8 @@ pub enum IdentifierError {
 }
 
 /// The Ss58Identifier type is a persistent identifier built from a bounded vector of bytes.
-/// The capacity (here, 52) must be chosen such that the final Base58-encoded value fits the system constraints.
+/// The capacity (here, 52) must be chosen such that the final Base58-encoded value fits the system
+/// constraints.
 #[derive(
 	Clone,
 	Eq,
@@ -316,7 +317,8 @@ mod tests {
 			let enc = Ss58Identifier::compact_encode_to(v, &mut buf);
 
 			match enc {
-				// For values in range 0..=16_383, encoding should succeed and decode should return the same.
+				// For values in range 0..=16_383, encoding should succeed and decode should return
+				// the same.
 				Ok(()) if v <= 16_383 => {
 					let (decoded, len) = Ss58Identifier::compact_decode(&buf)
 						.expect("compact_decode should succeed");

--- a/primitives/corduri/Cargo.toml
+++ b/primitives/corduri/Cargo.toml
@@ -38,7 +38,6 @@ frame-benchmarking = { optional = true, workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
@@ -55,7 +54,6 @@ std = [
 	"frame-system/std",
 	"sp-runtime/std",
 	"sp-io/std",
-	"sp-std/std",
 	"sp-keystore/std",
 	"primitive-types/byteorder",
 	"primitive-types/rustc-hex",

--- a/primitives/corduri/src/benchmarking.rs
+++ b/primitives/corduri/src/benchmarking.rs
@@ -23,7 +23,6 @@ use crate::pallet;
 use codec::TryFrom;
 use frame_benchmarking::v2::*;
 use frame_support::traits::Get;
-use sp_std::prelude::*;
 
 benchmarks! {
 	get_or_add_pallet_index {

--- a/primitives/corduri/src/tests.rs
+++ b/primitives/corduri/src/tests.rs
@@ -22,7 +22,6 @@ use crate::mock::{new_test_ext, Test};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use frame_support::{assert_err, assert_ok};
-use sp_std::prelude::*;
 
 // Helper function to generate a valid 32-byte digest.
 fn valid_digest() -> [u8; 32] {

--- a/primitives/identifier/Cargo.toml
+++ b/primitives/identifier/Cargo.toml
@@ -35,7 +35,6 @@ sp-storage = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { optional = true, workspace = true }
 sp-io = { optional = true, workspace = true }
 sp-keystore = { optional = true, workspace = true }
@@ -49,7 +48,6 @@ std = [
 	"frame-system/std",
 	"sp-runtime/std",
 	"sp-io/std",
-	"sp-std/std",
 	"sp-keystore/std",
 	"primitive-types/byteorder",
 	"primitive-types/rustc-hex",

--- a/primitives/identifier/src/lib.rs
+++ b/primitives/identifier/src/lib.rs
@@ -32,10 +32,9 @@ use alloc::str;
 
 pub mod types;
 pub use crate::types::*;
+use alloc::vec::Vec;
 use frame_support::traits::Get;
 use frame_system::pallet_prelude::BlockNumberFor;
-
-use scale_info::prelude::vec::Vec;
 
 pub use crate::pallet::*;
 

--- a/primitives/identifier/src/lib.rs
+++ b/primitives/identifier/src/lib.rs
@@ -27,14 +27,17 @@ pub use crate::curi::{
 	Ss58Identifier,
 };
 use sp_runtime::BoundedVec;
-use sp_std::{prelude::Clone, str};
+extern crate alloc;
+use alloc::str;
+
 pub mod types;
 pub use crate::types::*;
 use frame_support::traits::Get;
 use frame_system::pallet_prelude::BlockNumberFor;
 
+use scale_info::prelude::vec::Vec;
+
 pub use crate::pallet::*;
-use sp_std::vec;
 
 #[cfg(test)]
 pub mod mock;

--- a/primitives/identifier/src/mock.rs
+++ b/primitives/identifier/src/mock.rs
@@ -51,7 +51,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	#[cfg(feature = "runtime-benchmarks")]
 	let keystore = sp_keystore::testing::MemoryKeystore::new();
 	#[cfg(feature = "runtime-benchmarks")]
-	ext.register_extension(sp_keystore::KeystoreExt(sp_std::sync::Arc::new(keystore)));
+	ext.register_extension(sp_keystore::KeystoreExt(sync::Arc::new(keystore)));
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/runtimes/braid/src/benchmark.rs
+++ b/runtimes/braid/src/benchmark.rs
@@ -20,6 +20,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
+extern crate alloc;
+use alloc::vec::Vec;
 
 #[derive(Clone, Copy, Default, Debug, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub struct DummySignature;

--- a/runtimes/braid/src/benchmark.rs
+++ b/runtimes/braid/src/benchmark.rs
@@ -16,8 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
-extern crate alloc;
-use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 extern crate alloc;

--- a/runtimes/braid/src/weights/frame_benchmarking_baseline.rs
+++ b/runtimes/braid/src/weights/frame_benchmarking_baseline.rs
@@ -21,7 +21,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions for `frame_benchmarking::baseline`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtimes/braid/src/weights/pallet_babe.rs
+++ b/runtimes/braid/src/weights/pallet_babe.rs
@@ -43,6 +43,7 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
+use scale_info::prelude::marker::PhantomData;
 use frame_support::{
     traits::Get,
     weights::{
@@ -50,7 +51,6 @@ use frame_support::{
         Weight,
     },
 };
-use sp_std::marker::PhantomData;
 
 /// Weight functions for `pallet_babe`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtimes/braid/src/weights/pallet_babe.rs
+++ b/runtimes/braid/src/weights/pallet_babe.rs
@@ -43,7 +43,8 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use scale_info::prelude::marker::PhantomData;
+use core::marker::PhantomData;
+
 use frame_support::{
     traits::Get,
     weights::{

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -22,7 +22,6 @@ serde = { features = ["alloc", "derive"], workspace = true }
 sp-runtime = { features = ["serde"], workspace = true }
 sp-staking = { features = ["serde"], workspace = true }
 sp-core = { features = ["serde"], workspace = true }
-sp-std = { workspace = true }
 sp-weights = { workspace = true }
 
 pallet-authorship = { workspace = true }
@@ -68,7 +67,6 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"sp-std/std",
 	"frame-support-test/std",
 	"libsecp256k1/std",
 	"pallet-babe/std",

--- a/runtimes/common/api/assets/Cargo.toml
+++ b/runtimes/common/api/assets/Cargo.toml
@@ -21,7 +21,6 @@ pallet-assets = { workspace = true }
 
 # Substrate
 sp-api = { workspace = true }
-sp-std = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 
@@ -32,7 +31,6 @@ std = [
 	"frame-system/std",
 	"codec/std",
 	"sp-api/std",
-	"sp-std/std",
 	"scale-info/std",
 	"pallet-assets/std",
 ]

--- a/runtimes/common/api/did/Cargo.toml
+++ b/runtimes/common/api/did/Cargo.toml
@@ -21,7 +21,6 @@ pallet-did = { workspace = true }
 
 # Substrate
 sp-api = { workspace = true }
-sp-std = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 
@@ -32,7 +31,6 @@ std = [
 	"frame-system/std",
 	"codec/std",
 	"sp-api/std",
-	"sp-std/std",
 	"scale-info/std",
 	"pallet-did/std",
 ]

--- a/runtimes/common/api/did/src/did_details.rs
+++ b/runtimes/common/api/did/src/did_details.rs
@@ -21,10 +21,10 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_did::{did_details::DidPublicKeyDetails, AccountIdOf, KeyIdOf};
-use scale_info::{
-	prelude::collections::{BTreeMap, BTreeSet},
-	TypeInfo,
-};
+
+extern crate alloc;
+use alloc::collections::{BTreeMap, BTreeSet};
+use scale_info::TypeInfo;
 
 #[derive(Encode, Decode, TypeInfo, Clone, Debug, Eq, PartialEq, MaxEncodedLen)]
 pub struct DidDetails<Key: Ord, BlockNumber: MaxEncodedLen, AccountId> {

--- a/runtimes/common/api/did/src/did_details.rs
+++ b/runtimes/common/api/did/src/did_details.rs
@@ -21,8 +21,10 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_did::{did_details::DidPublicKeyDetails, AccountIdOf, KeyIdOf};
-use scale_info::TypeInfo;
-use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
+use scale_info::{
+	prelude::collections::{BTreeMap, BTreeSet},
+	TypeInfo,
+};
 
 #[derive(Encode, Decode, TypeInfo, Clone, Debug, Eq, PartialEq, MaxEncodedLen)]
 pub struct DidDetails<Key: Ord, BlockNumber: MaxEncodedLen, AccountId> {

--- a/runtimes/common/api/did/src/lib.rs
+++ b/runtimes/common/api/did/src/lib.rs
@@ -21,8 +21,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, Decode, Encode, MaxEncodedLen};
-use scale_info::TypeInfo;
-use sp_std::vec::Vec;
+use scale_info::{prelude::vec::Vec, TypeInfo};
 
 mod did_details;
 mod service_endpoint;

--- a/runtimes/common/api/did/src/lib.rs
+++ b/runtimes/common/api/did/src/lib.rs
@@ -21,7 +21,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, Decode, Encode, MaxEncodedLen};
-use scale_info::{prelude::vec::Vec, TypeInfo};
+use scale_info::TypeInfo;
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 mod did_details;
 mod service_endpoint;

--- a/runtimes/common/api/did/src/service_endpoint.rs
+++ b/runtimes/common/api/did/src/service_endpoint.rs
@@ -19,7 +19,10 @@
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
 use codec::{Decode, Encode};
-use scale_info::{prelude::vec::Vec, TypeInfo};
+use scale_info::TypeInfo;
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 #[derive(Encode, Decode, TypeInfo, Eq, PartialEq)]
 pub struct ServiceEndpoint<Id, Type, Url> {

--- a/runtimes/common/api/did/src/service_endpoint.rs
+++ b/runtimes/common/api/did/src/service_endpoint.rs
@@ -19,8 +19,7 @@
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
 use codec::{Decode, Encode};
-use scale_info::TypeInfo;
-use sp_std::vec::Vec;
+use scale_info::{prelude::vec::Vec, TypeInfo};
 
 #[derive(Encode, Decode, TypeInfo, Eq, PartialEq)]
 pub struct ServiceEndpoint<Id, Type, Url> {

--- a/runtimes/common/api/weight/Cargo.toml
+++ b/runtimes/common/api/weight/Cargo.toml
@@ -19,7 +19,6 @@ codec = { features = ["derive"], workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 frame-support = { workspace = true }
 sp-api = { workspace = true }
-sp-std = { workspace = true }
 sp-runtime = { workspace = true }
 sp-weights = { workspace = true }
 pallet-network-membership = { workspace = true }
@@ -30,7 +29,6 @@ std = [
 	"codec/std",
 	"scale-info/std",
 	"frame-support/std",
-	"sp-std/std",
 	"sp-api/std",
 	"sp-runtime/std",
 	"sp-weights/std",

--- a/runtimes/common/authorities/Cargo.toml
+++ b/runtimes/common/authorities/Cargo.toml
@@ -25,7 +25,6 @@ log = { workspace = true }
 frame-system = { workspace = true }
 frame-support = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-core = { workspace = true }
 sp-staking = { workspace = true }
 pallet-session = { features = ["historical"], workspace = true }
@@ -46,7 +45,6 @@ std = [
 	'frame-system/std',
 	'frame-support/std',
 	'sp-runtime/std',
-	'sp-std/std',
 	'sp-core/std',
 	'sp-staking/std',
 	"sp-state-machine/std",

--- a/runtimes/common/authorities/src/lib.rs
+++ b/runtimes/common/authorities/src/lib.rs
@@ -24,8 +24,8 @@ pub mod impls;
 
 use frame_support::{dispatch::DispatchResult, ensure, pallet_prelude::*, traits::EnsureOrigin};
 pub use pallet::*;
+use scale_info::prelude::{vec, vec::Vec};
 use sp_staking::SessionIndex;
-use sp_std::{vec, vec::Vec};
 
 #[cfg(test)]
 pub mod mock;
@@ -379,7 +379,7 @@ impl<T: Config> pallet_session::historical::SessionManager<T::ValidatorId, T::Fu
 	}
 	fn new_session_genesis(
 		new_index: SessionIndex,
-	) -> Option<sp_std::vec::Vec<(T::ValidatorId, T::FullIdentification)>> {
+	) -> Option<vec::Vec<(T::ValidatorId, T::FullIdentification)>> {
 		<Self as pallet_session::SessionManager<_>>::new_session_genesis(new_index).map(
 			|validators_ids| {
 				validators_ids.into_iter().filter_map(add_full_identification::<T>).collect()

--- a/runtimes/common/authorities/src/lib.rs
+++ b/runtimes/common/authorities/src/lib.rs
@@ -24,7 +24,10 @@ pub mod impls;
 
 use frame_support::{dispatch::DispatchResult, ensure, pallet_prelude::*, traits::EnsureOrigin};
 pub use pallet::*;
-use scale_info::prelude::{vec, vec::Vec};
+
+extern crate alloc;
+use alloc::{vec, vec::Vec};
+
 use sp_staking::SessionIndex;
 
 #[cfg(test)]

--- a/runtimes/common/authorities/src/mock.rs
+++ b/runtimes/common/authorities/src/mock.rs
@@ -20,7 +20,9 @@ use super::*;
 use crate::{self as cord_authority_membership};
 use frame_support::{derive_impl, parameter_types};
 use sp_state_machine::BasicExternalities;
-use std::collections::BTreeMap;
+
+extern crate alloc;
+use alloc::collections::BTreeMap;
 
 use frame_system::{pallet_prelude::BlockNumberFor, EnsureRoot};
 use pallet_offences::{traits::OnOffenceHandler, SlashStrategy};

--- a/runtimes/common/src/lib.rs
+++ b/runtimes/common/src/lib.rs
@@ -22,8 +22,7 @@
 
 pub mod elections;
 
-extern crate alloc;
-use scale_info::prelude::marker;
+use core::marker;
 
 use cord_primitives::{AccountId, Balance, BlockNumber};
 use frame_support::{

--- a/runtimes/common/src/lib.rs
+++ b/runtimes/common/src/lib.rs
@@ -23,6 +23,7 @@
 pub mod elections;
 
 extern crate alloc;
+use scale_info::prelude::marker;
 
 use cord_primitives::{AccountId, Balance, BlockNumber};
 use frame_support::{
@@ -154,7 +155,7 @@ where
 	}
 }
 
-pub struct SendFeesToTreasury<R>(sp_std::marker::PhantomData<R>);
+pub struct SendFeesToTreasury<R>(marker::PhantomData<R>);
 
 impl<R> OnUnbalanced<CreditOf<R>> for SendFeesToTreasury<R>
 where

--- a/runtimes/loom/src/benchmark.rs
+++ b/runtimes/loom/src/benchmark.rs
@@ -20,6 +20,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
+extern crate alloc;
+use alloc::vec::Vec;
 
 #[derive(Clone, Copy, Default, Debug, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub struct DummySignature;

--- a/runtimes/loom/src/benchmark.rs
+++ b/runtimes/loom/src/benchmark.rs
@@ -20,8 +20,6 @@ extern crate alloc;
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
-extern crate alloc;
-use alloc::vec::Vec;
 
 #[derive(Clone, Copy, Default, Debug, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub struct DummySignature;

--- a/runtimes/loom/src/genesis_config_presets.rs
+++ b/runtimes/loom/src/genesis_config_presets.rs
@@ -26,7 +26,6 @@ use alloc::{vec, vec::Vec};
 use cord_loom_runtime_constants::currency::UNITS;
 pub use cord_primitives::{AccountId, Balance, NodeId, Signature};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
-use scale_info::prelude::collections::BTreeMap;
 use sp_consensus_babe::AuthorityId as BabeId;
 use sp_consensus_beefy::ecdsa_crypto::AuthorityId as BeefyId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;

--- a/runtimes/loom/src/genesis_config_presets.rs
+++ b/runtimes/loom/src/genesis_config_presets.rs
@@ -26,6 +26,7 @@ use alloc::{vec, vec::Vec};
 use cord_loom_runtime_constants::currency::UNITS;
 pub use cord_primitives::{AccountId, Balance, NodeId, Signature};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
+use scale_info::prelude::collections::BTreeMap;
 use sp_consensus_babe::AuthorityId as BabeId;
 use sp_consensus_beefy::ecdsa_crypto::AuthorityId as BeefyId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;

--- a/runtimes/loom/src/lib.rs
+++ b/runtimes/loom/src/lib.rs
@@ -21,6 +21,8 @@
 #![recursion_limit = "1024"]
 
 extern crate alloc;
+use alloc::vec::Vec;
+use scale_info::prelude::vec;
 use alloc::{string::String, vec, vec::Vec};
 use codec::Encode;
 

--- a/runtimes/loom/src/lib.rs
+++ b/runtimes/loom/src/lib.rs
@@ -21,8 +21,6 @@
 #![recursion_limit = "1024"]
 
 extern crate alloc;
-use alloc::vec::Vec;
-use scale_info::prelude::vec;
 use alloc::{string::String, vec, vec::Vec};
 use codec::Encode;
 

--- a/runtimes/loom/src/weights/frame_benchmarking_baseline.rs
+++ b/runtimes/loom/src/weights/frame_benchmarking_baseline.rs
@@ -21,7 +21,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions for `frame_benchmarking::baseline`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtimes/loom/src/weights/pallet_babe.rs
+++ b/runtimes/loom/src/weights/pallet_babe.rs
@@ -50,7 +50,7 @@ use frame_support::{
         Weight,
     },
 };
-use scale_info::prelude::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions for `pallet_babe`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtimes/loom/src/weights/pallet_babe.rs
+++ b/runtimes/loom/src/weights/pallet_babe.rs
@@ -50,7 +50,7 @@ use frame_support::{
         Weight,
     },
 };
-use sp_std::marker::PhantomData;
+use scale_info::prelude::marker::PhantomData;
 
 /// Weight functions for `pallet_babe`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtimes/loom/src/weights/pallet_elections_phragmen.rs
+++ b/runtimes/loom/src/weights/pallet_elections_phragmen.rs
@@ -21,7 +21,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions for `pallet_elections_phragmen`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtimes/loom/src/weights/pallet_proxy.rs
+++ b/runtimes/loom/src/weights/pallet_proxy.rs
@@ -21,7 +21,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions for `pallet_proxy`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtimes/weave/src/benchmark.rs
+++ b/runtimes/weave/src/benchmark.rs
@@ -20,6 +20,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
+extern crate alloc;
+use alloc::vec::Vec;
 
 #[derive(Clone, Copy, Default, Debug, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub struct DummySignature;

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -32,7 +32,6 @@ use frame_election_provider_support::{
 	bounds::ElectionBoundsBuilder, generate_solution_type, onchain, BalancingConfig,
 	SequentialPhragmen,
 };
-use scale_info::prelude::{vec, vec::Vec};
 
 use frame_support::{
 	derive_impl,
@@ -683,8 +682,8 @@ impl Get<Option<BalancingConfig>> for OffchainRandomBalancing {
 			max => {
 				let seed = sp_io::offchain::random_seed();
 				let random = <u32>::decode(&mut TrailingZeroInput::new(&seed))
-					.expect("input is padded with zeroes; qed")
-					% max.saturating_add(1);
+					.expect("input is padded with zeroes; qed") %
+					max.saturating_add(1);
 				random as usize
 			},
 		};

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -32,6 +32,8 @@ use frame_election_provider_support::{
 	bounds::ElectionBoundsBuilder, generate_solution_type, onchain, BalancingConfig,
 	SequentialPhragmen,
 };
+use scale_info::prelude::{vec, vec::Vec};
+
 use frame_support::{
 	derive_impl,
 	genesis_builder_helper::{build_state, get_preset},

--- a/runtimes/weave/src/weights/pallet_babe.rs
+++ b/runtimes/weave/src/weights/pallet_babe.rs
@@ -50,7 +50,7 @@ use frame_support::{
         Weight,
     },
 };
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions for `pallet_babe`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/runtimes/weave/src/weights/pallet_proxy.rs
+++ b/runtimes/weave/src/weights/pallet_proxy.rs
@@ -21,7 +21,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Weight functions for `pallet_proxy`.
 pub struct WeightInfo<T>(PhantomData<T>);

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -27,7 +27,6 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-sp-std = { workspace = true }
 sp-weights = { workspace = true }
 
 [features]
@@ -46,7 +45,6 @@ std = [
 	"serde",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
 	"sp-weights/std",
 	"log/std",
 	"serde?/std"

--- a/utilities/src/mock.rs
+++ b/utilities/src/mock.rs
@@ -31,7 +31,7 @@ use sp_runtime::AccountId32;
 #[frame_support::pallet]
 #[allow(dead_code)]
 pub mod mock_origin {
-	use scale_info::prelude::marker::PhantomData;
+	use core::marker::PhantomData;
 
 	use codec::{Decode, Encode, MaxEncodedLen};
 	use frame_support::{traits::EnsureOrigin, Parameter};

--- a/utilities/src/mock.rs
+++ b/utilities/src/mock.rs
@@ -31,7 +31,7 @@ use sp_runtime::AccountId32;
 #[frame_support::pallet]
 #[allow(dead_code)]
 pub mod mock_origin {
-	use sp_std::marker::PhantomData;
+	use scale_info::prelude::marker::PhantomData;
 
 	use codec::{Decode, Encode, MaxEncodedLen};
 	use frame_support::{traits::EnsureOrigin, Parameter};

--- a/utilities/src/signature.rs
+++ b/utilities/src/signature.rs
@@ -23,7 +23,7 @@ use scale_info::TypeInfo;
 use sp_weights::Weight;
 
 #[cfg(any(test, feature = "mock", feature = "runtime-benchmarks"))]
-use scale_info::prelude::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// The Result of the signature verification.
 pub type SignatureVerificationResult = Result<(), SignatureVerificationError>;

--- a/utilities/src/signature.rs
+++ b/utilities/src/signature.rs
@@ -23,7 +23,7 @@ use scale_info::TypeInfo;
 use sp_weights::Weight;
 
 #[cfg(any(test, feature = "mock", feature = "runtime-benchmarks"))]
-use sp_std::marker::PhantomData;
+use scale_info::prelude::marker::PhantomData;
 
 /// The Result of the signature verification.
 pub type SignatureVerificationResult = Result<(), SignatureVerificationError>;

--- a/utilities/src/test_utils.rs
+++ b/utilities/src/test_utils.rs
@@ -18,7 +18,9 @@
 // You should have received a copy of the GNU General Public License
 // along with CORD. If not, see <https://www.gnu.org/licenses/>.
 
-use scale_info::prelude::string::String;
+extern crate alloc;
+use alloc::string::String;
+
 use sp_runtime::TryRuntimeError;
 
 /// Logs the error message and returns "Sanity test error"


### PR DESCRIPTION
Use no-std compatible packages as we run in a WASM environment.