### PR TITLE
entry, weave: Add runtime api for verifying digest 

### DIFF
--- a/origin/container/coretime/src/genesis_config_presets.rs
+++ b/origin/container/coretime/src/genesis_config_presets.rs
@@ -94,9 +94,8 @@ pub fn preset_names() -> Vec<PresetId> {
 pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	let patch = match id.as_ref() {
 		sp_genesis_builder::DEV_RUNTIME_PRESET => coretime_origin_development_genesis(2005.into()),
-		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET => {
-			coretime_origin_local_testnet_genesis(2005.into())
-		},
+		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET =>
+			coretime_origin_local_testnet_genesis(2005.into()),
 		_ => return None,
 	};
 	Some(

--- a/origin/container/coretime/src/lib.rs
+++ b/origin/container/coretime/src/lib.rs
@@ -539,39 +539,39 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			),
 			ProxyType::CancelProxy => matches!(
 				c,
-				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
-					| RuntimeCall::Utility { .. }
-					| RuntimeCall::Multisig { .. }
+				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
+					RuntimeCall::Utility { .. } |
+					RuntimeCall::Multisig { .. }
 			),
 			ProxyType::Broker => {
 				matches!(
 					c,
-					RuntimeCall::Broker { .. }
-						| RuntimeCall::Utility { .. }
-						| RuntimeCall::Multisig { .. }
+					RuntimeCall::Broker { .. } |
+						RuntimeCall::Utility { .. } |
+						RuntimeCall::Multisig { .. }
 				)
 			},
 			ProxyType::CoretimeRenewer => {
 				matches!(
 					c,
-					RuntimeCall::Broker(pallet_broker::Call::renew { .. })
-						| RuntimeCall::Utility { .. }
-						| RuntimeCall::Multisig { .. }
+					RuntimeCall::Broker(pallet_broker::Call::renew { .. }) |
+						RuntimeCall::Utility { .. } |
+						RuntimeCall::Multisig { .. }
 				)
 			},
 			ProxyType::OnDemandPurchaser => {
 				matches!(
 					c,
-					RuntimeCall::Broker(pallet_broker::Call::purchase_credit { .. })
-						| RuntimeCall::Utility { .. }
-						| RuntimeCall::Multisig { .. }
+					RuntimeCall::Broker(pallet_broker::Call::purchase_credit { .. }) |
+						RuntimeCall::Utility { .. } |
+						RuntimeCall::Multisig { .. }
 				)
 			},
 			ProxyType::Collator => matches!(
 				c,
-				RuntimeCall::CollatorSelection { .. }
-					| RuntimeCall::Utility { .. }
-					| RuntimeCall::Multisig { .. }
+				RuntimeCall::CollatorSelection { .. } |
+					RuntimeCall::Utility { .. } |
+					RuntimeCall::Multisig { .. }
 			),
 		}
 	}

--- a/origin/container/coretime/src/weights/xcm/mod.rs
+++ b/origin/container/coretime/src/weights/xcm/mod.rs
@@ -43,14 +43,12 @@ impl WeighAssets for AssetFilter {
 					WildFungibility::Fungible => weight,
 					// Magic number 2 has to do with the fact that we could have up to 2 times
 					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible => {
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64)
-					},
+					WildFungibility::NonFungible =>
+						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
 				},
 				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min((*count as u64).max(1))),
-				AllOfCounted { count, .. } => {
-					weight.saturating_mul(MAX_ASSETS.min((*count as u64).max(1)))
-				},
+				AllOfCounted { count, .. } =>
+					weight.saturating_mul(MAX_ASSETS.min((*count as u64).max(1))),
 			},
 		}
 	}

--- a/origin/container/entity/src/genesis_config_presets.rs
+++ b/origin/container/entity/src/genesis_config_presets.rs
@@ -94,9 +94,8 @@ pub fn preset_names() -> Vec<PresetId> {
 pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	let patch = match id.as_ref() {
 		sp_genesis_builder::DEV_RUNTIME_PRESET => entity_origin_development_genesis(2004.into()),
-		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET => {
-			entity_origin_local_testnet_genesis(2004.into())
-		},
+		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET =>
+			entity_origin_local_testnet_genesis(2004.into()),
 		_ => return None,
 	};
 	Some(

--- a/origin/container/entity/src/lib.rs
+++ b/origin/container/entity/src/lib.rs
@@ -494,23 +494,23 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			),
 			ProxyType::CancelProxy => matches!(
 				c,
-				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
-					| RuntimeCall::Utility { .. }
-					| RuntimeCall::Multisig { .. }
+				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
+					RuntimeCall::Utility { .. } |
+					RuntimeCall::Multisig { .. }
 			),
 			ProxyType::Entity => {
 				matches!(
 					c,
-					RuntimeCall::Entity { .. }
-						| RuntimeCall::Utility { .. }
-						| RuntimeCall::Multisig { .. }
+					RuntimeCall::Entity { .. } |
+						RuntimeCall::Utility { .. } |
+						RuntimeCall::Multisig { .. }
 				)
 			},
 			ProxyType::Collator => matches!(
 				c,
-				RuntimeCall::CollatorSelection { .. }
-					| RuntimeCall::Utility { .. }
-					| RuntimeCall::Multisig { .. }
+				RuntimeCall::CollatorSelection { .. } |
+					RuntimeCall::Utility { .. } |
+					RuntimeCall::Multisig { .. }
 			),
 		}
 	}

--- a/origin/container/src/chain_spec/mod.rs
+++ b/origin/container/src/chain_spec/mod.rs
@@ -36,29 +36,23 @@ impl LoadSpec for ChainSpecLoader {
 			// "origin-coretime" | "coretime" => Box::new(GenericChainSpec::from_json_bytes(
 			// 	&include_bytes!("../../chain-specs/tbd.json")[..],
 			// )?),
-			"origin-coretime-dev" | "coretime-dev" => {
-				Box::new(coretime::coretime_origin_staging_development_config())
-			},
-			"origin-coretime-local" | "coretime-local" => {
-				Box::new(coretime::coretime_origin_staging_local_config())
-			},
-			"origin-coretime-genesis" | "coretime-genesis" => {
-				Box::new(coretime::coretime_origin_genesis_config())
-			},
+			"origin-coretime-dev" | "coretime-dev" =>
+				Box::new(coretime::coretime_origin_staging_development_config()),
+			"origin-coretime-local" | "coretime-local" =>
+				Box::new(coretime::coretime_origin_staging_local_config()),
+			"origin-coretime-genesis" | "coretime-genesis" =>
+				Box::new(coretime::coretime_origin_genesis_config()),
 
 			// // -- Entity
 			// "origin-entity" | "entity" => Box::new(GenericChainSpec::from_json_bytes(
 			// 	&include_bytes!("../../chain-specs/tbd.json")[..],
 			// )?),
-			"origin-entity-dev" | "entity-dev" => {
-				Box::new(entity::entity_origin_staging_development_config())
-			},
-			"origin-entity-local" | "entity-local" => {
-				Box::new(entity::entity_origin_staging_local_config())
-			},
-			"origin-entity-genesis" | "entity-genesis" => {
-				Box::new(entity::origin_entity_genesis_config())
-			},
+			"origin-entity-dev" | "entity-dev" =>
+				Box::new(entity::entity_origin_staging_development_config()),
+			"origin-entity-local" | "entity-local" =>
+				Box::new(entity::entity_origin_staging_local_config()),
+			"origin-entity-genesis" | "entity-genesis" =>
+				Box::new(entity::origin_entity_genesis_config()),
 
 			// -- Fallback (generic chainspec)
 			"" => {
@@ -110,12 +104,11 @@ impl RuntimeResolverT for RuntimeResolver {
 	fn runtime(&self, chain_spec: &dyn ChainSpec) -> sc_cli::Result<Runtime> {
 		let legacy_runtime = LegacyRuntime::from_id(chain_spec.id());
 		Ok(match legacy_runtime {
-			LegacyRuntime::Asset
-			| LegacyRuntime::Coretime
-			| LegacyRuntime::Entity
-			| LegacyRuntime::Omni => {
-				Runtime::Omni(BlockNumber::U32, Consensus::Aura(AuraConsensusId::Sr25519))
-			},
+			LegacyRuntime::Asset |
+			LegacyRuntime::Coretime |
+			LegacyRuntime::Entity |
+			LegacyRuntime::Omni =>
+				Runtime::Omni(BlockNumber::U32, Consensus::Aura(AuraConsensusId::Sr25519)),
 		})
 	}
 }

--- a/origin/relay/cli/src/command.rs
+++ b/origin/relay/cli/src/command.rs
@@ -78,15 +78,12 @@ impl SubstrateCli for Cli {
 			// "cord-relay" | "cord-origin-relay" => Box::new(GenericChainSpec::from_json_bytes(
 			// 	&include_bytes!("../../chain-specs/tbd.json")[..],
 			// )?),
-			//
 			#[cfg(feature = "origin-native")]
-			"relay-dev" | "origin-relay-dev" => {
-				Box::new(chain_spec::cord_origin_relay_development_config()?)
-			},
+			"relay-dev" | "origin-relay-dev" =>
+				Box::new(chain_spec::cord_origin_relay_development_config()?),
 			#[cfg(feature = "origin-native")]
-			"relay-local" | "origin-relay-local" => {
-				Box::new(chain_spec::cord_origin_relay_local_testnet_config()?)
-			},
+			"relay-local" | "origin-relay-local" =>
+				Box::new(chain_spec::cord_origin_relay_local_testnet_config()?),
 			path => {
 				let path = std::path::PathBuf::from(path);
 

--- a/origin/relay/runtime/constants/src/lib.rs
+++ b/origin/relay/runtime/constants/src/lib.rs
@@ -93,7 +93,8 @@ pub mod fee {
 	impl WeightToFeePolynomial for WeightToFee {
 		type Balance = Balance;
 		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-			// in Polkadot, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 MILLI:
+			// in Polkadot, extrinsic base weight (smallest non-zero weight) is mapped to 1/10
+			// MILLI:
 			let p = super::currency::MILLI;
 			let q = 10 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
 			smallvec![WeightToFeeCoefficient {

--- a/origin/relay/runtime/src/genesis_config_presets.rs
+++ b/origin/relay/runtime/src/genesis_config_presets.rs
@@ -239,9 +239,8 @@ pub fn preset_names() -> Vec<PresetId> {
 pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	let patch = match id.as_ref() {
 		sp_genesis_builder::DEV_RUNTIME_PRESET => cord_origin_relay_development_config_genesis(),
-		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET => {
-			cord_origin_relay_local_testnet_genesis()
-		},
+		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET =>
+			cord_origin_relay_local_testnet_genesis(),
 		_ => return None,
 	};
 	Some(

--- a/origin/relay/runtime/src/lib.rs
+++ b/origin/relay/runtime/src/lib.rs
@@ -1078,23 +1078,23 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType<ProxyType> {
 			),
 			ProxyType::Governance => matches!(
 				c,
-				RuntimeCall::Treasury(..)
-					| RuntimeCall::Bounties(..)
-					| RuntimeCall::Utility(..)
-					| RuntimeCall::ChildBounties(..)
-					| RuntimeCall::ConvictionVoting(..)
-					| RuntimeCall::Referenda(..)
-					| RuntimeCall::Whitelist(..)
+				RuntimeCall::Treasury(..) |
+					RuntimeCall::Bounties(..) |
+					RuntimeCall::Utility(..) |
+					RuntimeCall::ChildBounties(..) |
+					RuntimeCall::ConvictionVoting(..) |
+					RuntimeCall::Referenda(..) |
+					RuntimeCall::Whitelist(..)
 			),
 			ProxyType::Staking => {
 				matches!(
 					c,
-					RuntimeCall::Staking(..)
-						| RuntimeCall::Session(..)
-						| RuntimeCall::Utility(..)
-						| RuntimeCall::FastUnstake(..)
-						| RuntimeCall::VoterList(..)
-						| RuntimeCall::NominationPools(..)
+					RuntimeCall::Staking(..) |
+						RuntimeCall::Session(..) |
+						RuntimeCall::Utility(..) |
+						RuntimeCall::FastUnstake(..) |
+						RuntimeCall::VoterList(..) |
+						RuntimeCall::NominationPools(..)
 				)
 			},
 			ProxyType::NominationPools => {
@@ -1106,12 +1106,12 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType<ProxyType> {
 			ProxyType::Auction => matches!(c, RuntimeCall::Registrar(..) | RuntimeCall::Slots(..)),
 			ProxyType::ParaRegistration => matches!(
 				c,
-				RuntimeCall::Registrar(paras_registrar::Call::reserve { .. })
-					| RuntimeCall::Registrar(paras_registrar::Call::register { .. })
-					| RuntimeCall::Utility(pallet_utility::Call::batch { .. })
-					| RuntimeCall::Utility(pallet_utility::Call::batch_all { .. })
-					| RuntimeCall::Utility(pallet_utility::Call::force_batch { .. })
-					| RuntimeCall::Proxy(pallet_proxy::Call::remove_proxy { .. })
+				RuntimeCall::Registrar(paras_registrar::Call::reserve { .. }) |
+					RuntimeCall::Registrar(paras_registrar::Call::register { .. }) |
+					RuntimeCall::Utility(pallet_utility::Call::batch { .. }) |
+					RuntimeCall::Utility(pallet_utility::Call::batch_all { .. }) |
+					RuntimeCall::Utility(pallet_utility::Call::force_batch { .. }) |
+					RuntimeCall::Proxy(pallet_proxy::Call::remove_proxy { .. })
 			),
 		}
 	}
@@ -2767,8 +2767,8 @@ mod test_fees {
 		};
 
 		let mut active = target_voters;
-		while weight_with(active).all_lte(OffchainSolutionWeightLimit::get())
-			|| active == target_voters
+		while weight_with(active).all_lte(OffchainSolutionWeightLimit::get()) ||
+			active == target_voters
 		{
 			active += 1;
 		}
@@ -2883,8 +2883,8 @@ mod multiplier_tests {
 	#[test]
 	fn multiplier_can_grow_from_zero() {
 		let minimum_multiplier = MinimumMultiplier::get();
-		let target = TargetBlockFullness::get()
-			* BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
+		let target = TargetBlockFullness::get() *
+			BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
 		// if the min is too small, then this will not change, and we are doomed forever.
 		// the weight is 1/100th bigger than target.
 		run_with_system_weight(target.saturating_mul(101) / 100, || {

--- a/pallets/entity/src/benchmarking.rs
+++ b/pallets/entity/src/benchmarking.rs
@@ -19,8 +19,7 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
-use crate::Event as EntityEvent;
-use crate::Pallet as EntityPallet;
+use crate::{Event as EntityEvent, Pallet as EntityPallet};
 use alloc::vec::Vec;
 use cord_primitives::doket::Element;
 use frame_benchmarking::{v2::*, BenchmarkError};

--- a/pallets/entity/src/lib.rs
+++ b/pallets/entity/src/lib.rs
@@ -437,8 +437,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// “Rotate” (update) an existing attribute: record the old value in history, bump the version,
-		/// then overwrite. Fails if the key is missing or invalid.
+		/// “Rotate” (update) an existing attribute: record the old value in history, bump the
+		/// version, then overwrite. Fails if the key is missing or invalid.
 		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::rotate_attribute( key.len() as u32 + val.as_ref().len() as u32))]
 		pub fn rotate_attribute(
@@ -633,7 +633,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Add an entity doken name under the constant suffix ".myn.social", always stored lowercase.
+		/// Add an entity doken name under the constant suffix ".myn.social", always stored
+		/// lowercase.
 		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::set_id_name(prefix.len() as u32))]
 		pub fn set_id_name(origin: OriginFor<T>, mut prefix: Vec<u8>) -> DispatchResult {

--- a/pallets/entity/src/tests.rs
+++ b/pallets/entity/src/tests.rs
@@ -18,10 +18,7 @@
 
 #![cfg(test)]
 use super::*;
-use crate::entity::EntityInfo;
-use crate::mock::*;
-use crate::pallet::Pallet as EntityPallet;
-use crate::Error;
+use crate::{entity::EntityInfo, mock::*, pallet::Pallet as EntityPallet, Error};
 use cord_primitives::doket::{Attribute, Element};
 use frame_support::{assert_noop, assert_ok};
 use pallet_doken::Doken;

--- a/pallets/entry/Cargo.toml
+++ b/pallets/entry/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 targets = ['x86_64-unknown-linux-gnu']
 
 [dev-dependencies]
-sp-core = { features = ["std"], workspace = true }
 sp-keystore = { features = ["std"], workspace = true }
 
 [dependencies]

--- a/pallets/entry/src/lib.rs
+++ b/pallets/entry/src/lib.rs
@@ -66,6 +66,7 @@ pub use types::RegistryEntryDetails;
 pub use cord_primitives::StatusOf;
 use pallet_profile::ProfileIdOf;
 use pallet_registry::{Permissions, RegistryIdentifierOf};
+// use alloc::string::String;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -601,6 +602,16 @@ pub mod pallet {
 	}
 }
 
+// pub trait Ss58Encoding {
+//     fn to_ss58check(&self) -> String;
+// }
+
+// impl Ss58Encoding for Ss58Identifier {
+//     fn to_ss58check(&self) -> String {
+//         sp_core::crypto::Ss58Codec::to_ss58check(&self.0) // Assuming `self.0` contains the raw bytes
+//     }
+// }
+
 impl<T: Config> Pallet<T> {
 	/// Records an activity using a provided event message.
 	pub fn record_activity(
@@ -615,4 +626,21 @@ impl<T: Config> Pallet<T> {
 			.map_err(|_| Error::<T>::StateUpdateFailed)?;
 		Ok(())
 	}
+
+	pub fn verify_digest(
+        digest: T::Hash,
+        registry_id: Option<RegistryIdOf>,
+    ) -> Result<Option<RegistryEntryIdOf>, Error<T>> {
+        let mut registry_entry_identifier: Option<RegistryEntryIdOf> = None;
+
+        if let Some(registry_id) = registry_id {
+            registry_entry_identifier = <HashToIdentifier<T>>::get(&digest, registry_id);
+       } else {
+			for (_registry_id, entry_id) in <HashToIdentifier<T>>::iter_prefix(&digest) {
+				registry_entry_identifier = Some(entry_id);
+			}
+		}
+
+       	Ok(registry_entry_identifier)
+    }
 }

--- a/pallets/entry/src/lib.rs
+++ b/pallets/entry/src/lib.rs
@@ -602,16 +602,6 @@ pub mod pallet {
 	}
 }
 
-// pub trait Ss58Encoding {
-//     fn to_ss58check(&self) -> String;
-// }
-
-// impl Ss58Encoding for Ss58Identifier {
-//     fn to_ss58check(&self) -> String {
-//         sp_core::crypto::Ss58Codec::to_ss58check(&self.0) // Assuming `self.0` contains the raw bytes
-//     }
-// }
-
 impl<T: Config> Pallet<T> {
 	/// Records an activity using a provided event message.
 	pub fn record_activity(
@@ -627,20 +617,19 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	// Verify the existence of digest in Registry Entry.
 	pub fn verify_digest(
-        digest: T::Hash,
-        registry_id: Option<RegistryIdOf>,
-    ) -> Result<Option<RegistryEntryIdOf>, Error<T>> {
-        let mut registry_entry_identifier: Option<RegistryEntryIdOf> = None;
+		digest: T::Hash,
+		registry_id: Option<RegistryIdOf>,
+	) -> Result<Option<RegistryEntryIdOf>, Error<T>> {
+		let registry_entry_id = if let Some(reg_id) = registry_id {
+			HashToIdentifier::<T>::get(&digest, reg_id)
+		} else {
+			HashToIdentifier::<T>::iter_prefix(&digest)
+				.next()
+				.map(|(_reg_id, entry_id)| entry_id)
+		};
 
-        if let Some(registry_id) = registry_id {
-            registry_entry_identifier = <HashToIdentifier<T>>::get(&digest, registry_id);
-       } else {
-			for (_registry_id, entry_id) in <HashToIdentifier<T>>::iter_prefix(&digest) {
-				registry_entry_identifier = Some(entry_id);
-			}
-		}
-
-       	Ok(registry_entry_identifier)
-    }
+		Ok(registry_entry_id)
+	}
 }

--- a/pallets/remote-proxy/src/lib.rs
+++ b/pallets/remote-proxy/src/lib.rs
@@ -474,20 +474,16 @@ pub mod pallet {
 				match c.is_sub_type() {
 					// Proxy call cannot add or remove a proxy with more permissions than it already
 					// has.
-					Some(pallet_proxy::Call::add_proxy { ref proxy_type, .. })
-					| Some(pallet_proxy::Call::remove_proxy { ref proxy_type, .. })
+					Some(pallet_proxy::Call::add_proxy { ref proxy_type, .. }) |
+					Some(pallet_proxy::Call::remove_proxy { ref proxy_type, .. })
 						if !def.proxy_type.is_superset(proxy_type) =>
-					{
-						false
-					},
+						false,
 					// Proxy call cannot remove all proxies or kill pure proxies unless it has full
 					// permissions.
-					Some(pallet_proxy::Call::remove_proxies { .. })
-					| Some(pallet_proxy::Call::kill_pure { .. })
+					Some(pallet_proxy::Call::remove_proxies { .. }) |
+					Some(pallet_proxy::Call::kill_pure { .. })
 						if def.proxy_type != T::ProxyType::default() =>
-					{
-						false
-					},
+						false,
 					_ => def.proxy_type.filter(c),
 				}
 			});

--- a/primitives/cord/src/element.rs
+++ b/primitives/cord/src/element.rs
@@ -29,7 +29,8 @@ use scale_info::TypeInfo;
 
 /// The `Elum` enum supports the following variants:
 /// - None: Indicates that no data is provided.
-/// - Raw: Contains data stored directly as a bounded vector; the capacity is specified by `MAX_CAP`.
+/// - Raw: Contains data stored directly as a bounded vector; the capacity is specified by
+///   `MAX_CAP`.
 /// - Digest: A fixed 32-byte digest (e.g., computed using BlakeTwo256).
 /// - Doken: An embedded Ss58Identifier.
 /// - CID: A fixed 64-byte content identifier.

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -33,7 +33,6 @@ use frame_election_provider_support::{
 	SequentialPhragmen,
 };
 
-use pallet_entry::{RegistryIdOf, RegistryEntryIdOf};
 mod registry_entry_api;
 
 use frame_support::{
@@ -685,8 +684,8 @@ impl Get<Option<BalancingConfig>> for OffchainRandomBalancing {
 			max => {
 				let seed = sp_io::offchain::random_seed();
 				let random = <u32>::decode(&mut TrailingZeroInput::new(&seed))
-					.expect("input is padded with zeroes; qed")
-					% max.saturating_add(1);
+					.expect("input is padded with zeroes; qed") %
+					max.saturating_add(1);
 				random as usize
 			},
 		};
@@ -2537,9 +2536,9 @@ impl_runtime_apis! {
 			vec![]
 		}
 	}
-	
-	impl crate::registry_entry_api::RegistryEntryApi<Block, Hash, RegistryIdOf> for Runtime {
-		fn verify_digest(digest: Hash, registry_id: Option<RegistryIdOf>) -> Option<RegistryEntryIdOf> {
+
+	impl crate::registry_entry_api::RegistryEntryApi<Block, Hash, Ss58Identifier> for Runtime {
+		fn verify_digest(digest: Hash, registry_id: Option<Ss58Identifier>) -> Option<Ss58Identifier> {
 			pallet_entry::Pallet::<Runtime>::verify_digest(digest, registry_id).ok().flatten()
 		}
 	}

--- a/runtimes/weave/src/lib.rs
+++ b/runtimes/weave/src/lib.rs
@@ -33,6 +33,9 @@ use frame_election_provider_support::{
 	SequentialPhragmen,
 };
 
+use pallet_entry::{RegistryIdOf, RegistryEntryIdOf};
+mod registry_entry_api;
+
 use frame_support::{
 	derive_impl,
 	genesis_builder_helper::{build_state, get_preset},
@@ -2532,6 +2535,12 @@ impl_runtime_apis! {
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
 			vec![]
+		}
+	}
+	
+	impl crate::registry_entry_api::RegistryEntryApi<Block, Hash, RegistryIdOf> for Runtime {
+		fn verify_digest(digest: Hash, registry_id: Option<RegistryIdOf>) -> Option<RegistryEntryIdOf> {
+			pallet_entry::Pallet::<Runtime>::verify_digest(digest, registry_id).ok().flatten()
 		}
 	}
 }

--- a/runtimes/weave/src/registry_entry_api.rs
+++ b/runtimes/weave/src/registry_entry_api.rs
@@ -20,17 +20,15 @@
 
 //! Runtime API definition for Registry Entry
 
+use crate::{Decode, Encode};
 use sp_api::decl_runtime_apis;
-use pallet_entry::RegistryEntryIdOf;
-use crate::{Encode, Decode};
 
 decl_runtime_apis! {
-    pub trait RegistryEntryApi<Hash, RegistryIdOf> 
-    where
-        Hash: Encode + Decode,
-        RegistryIdOf: Encode + Decode,
-    {
-        fn verify_digest(digest: Hash, registry_id: Option<RegistryIdOf>) -> Option<RegistryEntryIdOf>;
-    }
+	pub trait RegistryEntryApi<Hash, Ss58Identifier>
+	where
+		Hash: Encode + Decode,
+		Ss58Identifier: Encode + Decode,
+	{
+		fn verify_digest(digest: Hash, registry_id: Option<Ss58Identifier>) -> Option<Ss58Identifier>;
+	}
 }
-

--- a/runtimes/weave/src/registry_entry_api.rs
+++ b/runtimes/weave/src/registry_entry_api.rs
@@ -1,0 +1,36 @@
+// This file is part of CORD – https://cord.network
+
+// Copyright (C) 2019-2023 BOTLabs GmbH.
+// Copyright (C) Dhiway Networks Pvt. Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Adapted to meet the requirements of the CORD project.
+
+// CORD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// CORD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with CORD. If not, see <https://www.gnu.org/licenses/>.
+
+//! Runtime API definition for Registry Entry
+
+use sp_api::decl_runtime_apis;
+use pallet_entry::RegistryEntryIdOf;
+use crate::{Encode, Decode};
+
+decl_runtime_apis! {
+    pub trait RegistryEntryApi<Hash, RegistryIdOf> 
+    where
+        Hash: Encode + Decode,
+        RegistryIdOf: Encode + Decode,
+    {
+        fn verify_digest(digest: Hash, registry_id: Option<RegistryIdOf>) -> Option<RegistryEntryIdOf>;
+    }
+}
+


### PR DESCRIPTION
- Verify if the digests exits, if yes return the registry-entry-id. It shall be in `hex`. Verifiers are needed to convert to `base58`.
- If the `registry-id` is not given, it iterates through all registry-id, else just a O(1) operation.